### PR TITLE
Use a generic example path in the PRD config sample

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -346,7 +346,7 @@ taps:
   - name: my-local-skills
     kind: path
     registered: false
-    path: /Users/steve/code/my-skills
+    path: /Users/alice/code/my-skills
 
 # Agents the user has force-disabled. Any agent not listed here is auto-detected.
 disabled_agents: []


### PR DESCRIPTION
The PRD's example `config.yaml` snippet used `/Users/steve/` as a placeholder path for a path-kind tap. Swap it for `/Users/alice/` so the public repo doesn't carry a personal username in docs.

No code or behavior change — pure docs.