### PR TITLE
Point the default core tap at with-logic/crew-skills

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -318,7 +318,7 @@ taps:
   - name: core
     kind: git
     registered: true
-    url: https://github.com/crew-sh/core.git
+    url: https://github.com/with-logic/crew-skills.git
   - name: acme
     kind: git
     registered: true
@@ -499,7 +499,7 @@ Written into every crew-installed skill directory. JSON, UTF-8, trailing newline
   "adapters": ["codex", "gemini-cli"],
   "tap_name": "core",
   "tap_kind": "git",
-  "tap_url": "https://github.com/crew-sh/core.git",
+  "tap_url": "https://github.com/with-logic/crew-skills.git",
   "tap_subpath": "",
   "path": "python-testing",
   "ref": "main",

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -12,7 +12,7 @@ import type { Config } from "../core/types.ts";
 export const DEFAULT_TAP_NAME = "core";
 
 /** URL of the default tap. Kept here so §19 item 1 has one place to update. */
-export const DEFAULT_TAP_URL = "https://github.com/crew-sh/core.git";
+export const DEFAULT_TAP_URL = "https://github.com/with-logic/crew-skills.git";
 
 /** The default autoupdate interval (4 hours in seconds) per §10.2. */
 export const DEFAULT_AUTOUPDATE_INTERVAL_SECONDS = 14400;


### PR DESCRIPTION
The `core` tap URL has been a placeholder (`crew-sh/core`, which nobody owns) since the original draft. Now that `with-logic/crew-skills` exists, wire the default to there.

## Changes

- `src/config/defaults.ts`: `DEFAULT_TAP_URL` → `https://github.com/with-logic/crew-skills.git`
- `PRD.md`: two example snippets updated to match

No behavior change for anyone already running crew — the `core` tap URL is only read on first-run config creation. Existing installs keep whatever URL they've got written in `~/.crew/config.yaml`.