### PR TITLE
Release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+## [0.3.1] — 2026-04-20
+
+### Added
+- **17 agent adapters** — crew now installs skills into every major agent coder on agentskills.io: Amp, AutoHand, Claude Code, Codex, Command Code, Cursor, Factory, Gemini CLI, GitHub Copilot, Goose, Junie, Kiro, Mistral Vibe, Nanobot, OpenCode, Pi, and Roo Code.
+- **`crew agents` command** (replaces `crew targets`) — lists detected agent coders with human-readable status; `crew agents enable <name>` / `crew agents disable <name>` force or suppress individual agents.
+- **`--agent <name>` flag** on `crew install` / `crew uninstall` — scope an operation to one specific agent.
+- **Subpath taps** — point a tap at a subdirectory of a monorepo: `crew tap add @org/repo//skills`. Skills are referenced the same way regardless.
+- **`crew tap update [<name>]`** — refresh tap clones without touching installed skills.
+- **`crew tap add` is now idempotent** — re-adding the same URL exits 0. Duplicate-name conflicts show a copy-pasteable remedy.
+- **`crew tap add` is now transactional** — a failed clone leaves no config entry; retry from a clean slate.
+- **Whole-tap installs** — `crew install <tap-name>` installs every skill in the tap and opts you into tracking future additions on `crew update`.
+- **Dependency closure on targeted update** — `crew update <name>` now pulls in every skill that `<name>` transitively requires, so dep-tree roots stay coherent.
+- **Scoped fetches on targeted update** — `crew update <name>` only refreshes the taps backing named entries; unrelated taps are left untouched.
+- **Autoupdate logging** — when autoupdate is running on a schedule, each run appends a timestamped exit-status line to `~/.crew/logs/autoupdate.log`. `crew autoupdate status` surfaces last-run time and exit code.
+- **Autoupdate pinned to `CREW_HOME`** — scheduled runs now always use the same crew home directory that `crew autoupdate enable` was called from.
+- **`crew cache clean` freed-space summary** — reports bytes reclaimed and orphan count; prints a friendly "nothing to clean" when the cache was already empty.
+- **Login Items attribution** — the background autoupdate agent now appears as "Crew Skill Autoupdate" in macOS System Settings → Login Items instead of Bun's code-signing identity.
+- **Machine-readable `--json` help** — `crew help --json` and `crew help <command> --json` emit structured JSON for tooling.
+- **`@owner/repo` shorthand** — an alias for `gh:owner/repo` in install references.
+- **`crew tap <ref>` shorthand** for `crew tap add`.
+- **`source_gone` soft outcome** — when a skill is deleted upstream, `crew update` records it and exits 0 rather than failing; the local install is preserved until you explicitly remove it.
+
+### Changed
+- **`crew targets` → `crew agents`** everywhere: command name, flag names (`--target` → `--agent`), config keys (`forced_targets` / `disabled_targets` → `forced_agents` / `disabled_agents`), and error codes (`no_targets` → `no_agents`).
+- **Taps replace bundles** — every installed skill now belongs to exactly one tap. Multi-skill installs create an auto-tap implicitly; auto-taps are garbage-collected when their last skill is uninstalled. Registered taps (added via `crew tap add`) stick around even when empty. `crew tap add <same-url>` promotes an auto-tap to registered without re-cloning.
+- **Shared install path for compatible tools** — Cursor, Command Code, Gemini CLI, Goose, OpenCode, Pi, and GitHub Copilot all read `~/.agents/skills/`; crew writes one physical copy there and reports per-agent outcomes. Codex moved from `~/.codex/skills/` (which Codex never actually read) to `~/.agents/skills/`.
+- **`crew update` tracks tap vs. individual installs** — only whole-tap installs opt into auto-expansion of new upstream skills on update. Installing a single skill (`crew install <tap>/<skill>`) no longer silently grows into the entire tap on the next update.
+- **Read-only commands no longer hit the network** — `crew search`, bare-name `crew install`, and qualified `<tap>/<skill>` install use cached clones; fetches happen only in `crew update`, `crew tap update`, `crew tap add`, and `crew install <git-url>`.
+- **Polished output across every command** — structured headers, checkmarks, aligned columns, human time-ago timestamps, and plain-English status words replace raw code tokens throughout `crew install`, `crew uninstall`, `crew update`, `crew list`, `crew info`, `crew search`, `crew tap`, `crew agents`, `crew autoupdate`, `crew cache`, and `crew doctor`.
+- **`crew doctor` output grouped by area** — findings are bucketed into Agents / State / Autoupdate / Config / Storage with translated human phrases; repeated findings collapse into a count with a short sample and "…and N more".
+- **`crew list` project-scope annotations** — skills installed in specific projects show `└ in <path>` sub-rows; "all agents" collapses the common case.
+- **`crew info` multi-location block** — shows every location a skill is installed in, distinguishing user scope from project paths.
+- **`crew update` project-scope tags** — per-skill rows for project installs include a dim `(in <path>)` tag so repeated names across projects stay distinguishable.
+- **Invalid subcommand args are errors** — `crew tap knasdjnadkj` now exits with a clear error message; bare `crew tap` still shows the help page.
+- **Humanized help docs** — every help page rewritten to lead with outcomes and user-facing vocabulary ("your collections", "agent coders") rather than internal implementation terms.
+- **`crew autoupdate status` interval rendering** — "every 4 hours", "every 30 minutes", "every day" instead of raw seconds.
+- **Default `core` tap URL** updated to `https://github.com/with-logic/crew-skills.git` (only affects first-run config creation; existing installs are unaffected).
+
+### Fixed
+- **`crew tap add` collision prompt uses `<tap-name>` placeholder** instead of `<your-name>`, matching CLI vocabulary.
+- **Autoupdate launchd agent labeled correctly** in macOS Login Items (was showing Bun's signer identity).
+- **`crew update` no longer spuriously expands single-skill installs** into the whole tap on the next run.
+- **Transitive dependency edges preserved across shared-dep installs** — installing a skill that shares a dep with an already-installed skill no longer drops the existing `required_by` edge, preventing incorrect prune behavior on later uninstalls.
+
+All notable changes to crew are documented in this file. The format
+is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and crew adheres to [Semantic Versioning](https://semver.org/).
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crew",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A package manager for Agent Skills",
   "type": "module",
   "module": "src/index.ts",

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -5,5 +5,5 @@
  * without touching anything else. The value written to the `installed_by`
  * marker field and printed by `crew version` is derived from here.
  */
-export const CREW_VERSION = "0.3.0";
+export const CREW_VERSION = "0.3.1";
 export const CREW_INSTALLED_BY = `crew/${CREW_VERSION}`;


### PR DESCRIPTION
## Summary

- **17 agent adapters** — crew now installs skills into every major agent coder on agentskills.io (Amp, AutoHand, Claude Code, Codex, Command Code, Cursor, Factory, Gemini CLI, GitHub Copilot, Goose, Junie, Kiro, Mistral Vibe, Nanobot, OpenCode, Pi, Roo Code). Several share the `~/.agents/skills/` path, so one install serves all compatible tools with a single file on disk.
- **`crew targets` → `crew agents`** — the command, flags (`--target` → `--agent`), and config keys are renamed to match how users actually refer to these tools.
- **Taps replace bundles** — every installed skill belongs to one tap. Multi-skill installs create auto-taps implicitly; `crew tap add` against the same URL promotes an auto-tap to registered without re-cloning. Whole-tap installs track future upstream additions; single-skill installs don't silently grow.
- **New tap features** — subpath taps for monorepos (`crew tap add @org/repo//skills`), `crew tap update` to refresh clones independently, idempotent `tap add`, transactional `tap add` (failed clone leaves no config entry).
- **Smarter `crew update`** — targeted updates walk the full dependency closure; fetch scope is limited to backing taps only; `source_gone` is a soft outcome rather than an error.
- **Autoupdate improvements** — scheduled runs are pinned to the correct `CREW_HOME`; each run logs a timestamped exit-status line visible in `crew autoupdate status`; the Login Items entry now reads "Crew Skill Autoupdate" instead of Bun's signer name.
- **Polished output everywhere** — structured headers, checkmarks, aligned columns, human time-ago timestamps, and plain-English status words across every command. `crew doctor` groups findings by area and collapses repeated findings. `crew cache clean` reports bytes freed.
- **Human-friendly help** — every help page rewritten to lead with outcomes and user vocabulary; invalid subcommand args now produce clear errors instead of silent help pages.
- **Default `core` tap** now points at `https://github.com/with-logic/crew-skills.git` (first-run only; existing installs unaffected).

## Added

- 14 new agent adapters (Amp, AutoHand, Command Code, Cursor, Factory, GitHub Copilot, Goose, Junie, Kiro, Mistral Vibe, Nanobot, OpenCode, Pi, Roo Code) joining Claude Code, Codex, and Gemini CLI
- `crew agents` command with `enable` / `disable` subcommands and `--agent <name>` flag on install/uninstall
- Subpath tap support for monorepos: `crew tap add @org/repo//skills`
- `crew tap update [<name>]` — refresh tap clones without touching installed skills
- Whole-tap installs: `crew install <tap-name>` installs every skill and tracks future additions
- Dependency closure on `crew update <name>` — transitive deps come along automatically
- Autoupdate run log (`~/.crew/logs/autoupdate.log`) with last-run timestamp and exit status in `crew autoupdate status`
- `source_gone` soft outcome when a skill is deleted upstream
- `@owner/repo` shorthand (alias for `gh:owner/repo`)
- Machine-readable `--json` output for `crew help`

## Changed

- `crew targets` renamed to `crew agents`; `--target` → `--agent`; config keys `forced_targets`/`disabled_targets` → `forced_agents`/`disabled_agents`
- Bundles replaced by taps — every install now belongs to exactly one tap; auto-taps are GC'd when their last skill is removed
- Shared `~/.agents/skills/` path for Cursor, Command Code, Gemini CLI, Goose, OpenCode, Pi, GitHub Copilot — one file on disk, per-agent reporting
- Codex install path corrected from `~/.codex/skills/` to `~/.agents/skills/` (which Codex actually reads)
- Read-only commands (`crew search`, bare installs) no longer fetch from the network — use cached clones
- `crew update` fetch scope limited to backing taps when targeting specific skills
- `crew tap add` is now idempotent (same URL → exit 0) and transactional (failed clone → no config entry)
- Output polished across every command: structured headers, symbols, aligned columns, time-ago, plain-English status words
- `crew doctor` output grouped by area (Agents / State / Autoupdate / Config / Storage) with collapsed repeated findings
- Help docs rewritten to lead with user outcomes and plain language throughout
- Invalid subcommand args now exit with a clear error; bare commands show help
- Default `core` tap URL updated to `https://github.com/with-logic/crew-skills.git`

## Fixed

- Autoupdate background agent now appears as "Crew Skill Autoupdate" in macOS Login Items
- Scheduled autoupdate runs honor the `CREW_HOME` set at enable time instead of defaulting to `~/.crew`
- Single-skill installs no longer expand into the whole tap on `crew update`
- Shared-dep `required_by` edges are preserved when a new install overlaps an existing dep, preventing incorrect prune on later uninstall
- `crew tap add` collision error message uses `<tap-name>` placeholder matching CLI vocabulary

🤖 Generated with [Claude Code](https://claude.com/claude-code)