### PR TITLE
Add landing site scaffold under site/

### DIFF
--- a/.github/workflows/site-ci.yml
+++ b/.github/workflows/site-ci.yml
@@ -1,0 +1,39 @@
+name: Site CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "site/**"
+      - ".github/workflows/site-ci.yml"
+  push:
+    branches: [main]
+    paths:
+      - "site/**"
+      - ".github/workflows/site-ci.yml"
+
+# Cancel in-progress runs on the same ref when a new push arrives.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: site
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Typecheck
+        run: bun run typecheck
+      - name: Lint
+        run: bun run lint
+      - name: Build
+        run: bun run build

--- a/biome.json
+++ b/biome.json
@@ -2,7 +2,7 @@
   "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
   "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
   "files": {
-    "includes": ["**", "!**/node_modules", "!**/dist", "!**/coverage", "!bun.lock"]
+    "includes": ["**", "!**/node_modules", "!**/dist", "!**/coverage", "!bun.lock", "!site"]
   },
   "formatter": {
     "enabled": true,

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+.next/
+out/
+.vercel/
+*.tsbuildinfo
+next-env.d.ts
+.env*.local
+.DS_Store

--- a/site/app/globals.css
+++ b/site/app/globals.css
@@ -1,0 +1,42 @@
+@import "../styles/tokens.css";
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: var(--bg);
+  color: var(--ink);
+  font-family: var(--font-sans);
+  font-size: 16px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  font-feature-settings: "ss01", "cv11";
+}
+
+a {
+  color: var(--ink);
+  text-decoration: underline;
+  text-decoration-color: var(--line-2);
+  text-underline-offset: 3px;
+}
+
+a:hover {
+  text-decoration-color: var(--accent);
+}
+
+hr {
+  border: 0;
+  border-top: 1px solid var(--line);
+  margin: 0;
+}
+
+code {
+  font-family: var(--font-mono);
+}

--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -1,0 +1,46 @@
+import type { Metadata } from "next";
+import { Inter, JetBrains_Mono } from "next/font/google";
+import type { ReactNode } from "react";
+import "./globals.css";
+
+const inter = Inter({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  variable: "--font-sans",
+  display: "swap",
+});
+
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  variable: "--font-mono",
+  display: "swap",
+});
+
+export const metadata: Metadata = {
+  metadataBase: new URL("https://crew.logic.inc"),
+  title: "crew — a package manager for agent skills",
+  description:
+    "Find great skills. Install them with one command into every coding agent on your machine. Publish your own as easily as pushing to GitHub.",
+  openGraph: {
+    title: "crew — a package manager for agent skills",
+    description:
+      "Find great skills. Install them with one command into every coding agent on your machine.",
+    type: "website",
+    url: "https://crew.logic.inc",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "crew — a package manager for agent skills",
+    description:
+      "Find great skills. Install them with one command into every coding agent on your machine.",
+  },
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en" className={`${inter.variable} ${jetbrainsMono.variable}`}>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -1,0 +1,43 @@
+import { AgentsStrip } from "../components/sections/AgentsStrip";
+import { BottomCTA } from "../components/sections/BottomCTA";
+import { Commands } from "../components/sections/Commands";
+import { Demo } from "../components/sections/Demo";
+import { Faq } from "../components/sections/Faq";
+import { Footer } from "../components/sections/Footer";
+import { Hero } from "../components/sections/Hero";
+import { HowItWorks } from "../components/sections/HowItWorks";
+import { Install } from "../components/sections/Install";
+import { Nav } from "../components/sections/Nav";
+import { Problem } from "../components/sections/Problem";
+import { Safety } from "../components/sections/Safety";
+import { SkillMdExample } from "../components/sections/SkillMdExample";
+import { SkillRefs } from "../components/sections/SkillRefs";
+import { Taps } from "../components/sections/Taps";
+import { Teams } from "../components/sections/Teams";
+import { ValueProp } from "../components/sections/ValueProp";
+
+export default function Page() {
+  return (
+    <>
+      <Nav />
+      <main>
+        <Hero />
+        <AgentsStrip />
+        <ValueProp />
+        <Install />
+        <Problem />
+        <HowItWorks />
+        <SkillRefs />
+        <Demo />
+        <Commands />
+        <Taps />
+        <Teams />
+        <Safety />
+        <SkillMdExample />
+        <Faq />
+        <BottomCTA />
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/site/biome.json
+++ b/site/biome.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
-  "root": false,
   "extends": ["../biome.json"],
   "files": {
     "includes": ["**/*.{ts,tsx,js,jsx,json,mjs}", "!.next", "!out", "!node_modules"]

--- a/site/biome.json
+++ b/site/biome.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
+  "root": false,
+  "extends": ["../biome.json"],
+  "files": {
+    "includes": ["**/*.{ts,tsx,js,jsx,json,mjs}", "!.next", "!out", "!node_modules"]
+  },
+  "linter": {
+    "rules": {
+      "style": {
+        "useFilenamingConvention": {
+          "level": "error",
+          "options": {
+            "strictCase": false,
+            "requireAscii": true,
+            "filenameCases": ["camelCase", "PascalCase", "kebab-case"]
+          }
+        }
+      },
+      "correctness": {
+        "noUndeclaredDependencies": {
+          "level": "error",
+          "options": { "devDependencies": true }
+        },
+        "useImportExtensions": "off"
+      }
+    }
+  },
+  "overrides": [
+    {
+      "includes": [
+        "app/**/page.tsx",
+        "app/**/layout.tsx",
+        "app/**/not-found.tsx",
+        "app/**/error.tsx",
+        "app/**/loading.tsx",
+        "app/**/template.tsx",
+        "app/**/default.tsx",
+        "next.config.*",
+        "types/**/*.d.ts"
+      ],
+      "linter": {
+        "rules": {
+          "style": {
+            "noDefaultExport": "off"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/site/bun.lock
+++ b/site/bun.lock
@@ -1,0 +1,154 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "crew-site",
+      "dependencies": {
+        "next": "^15.0.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "2.4.12",
+        "@types/node": "^22.0.0",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "typescript": "^5.6.0",
+      },
+    },
+  },
+  "packages": {
+    "@biomejs/biome": ["@biomejs/biome@2.4.12", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.12", "@biomejs/cli-darwin-x64": "2.4.12", "@biomejs/cli-linux-arm64": "2.4.12", "@biomejs/cli-linux-arm64-musl": "2.4.12", "@biomejs/cli-linux-x64": "2.4.12", "@biomejs/cli-linux-x64-musl": "2.4.12", "@biomejs/cli-win32-arm64": "2.4.12", "@biomejs/cli-win32-x64": "2.4.12" }, "bin": { "biome": "bin/biome" } }, "sha512-Rro7adQl3NLq/zJCIL98eElXKI8eEiBtoeu5TbXF/U3qbjuSc7Jb5rjUbeHHcquDWeSf3HnGP7XI5qGrlRk/pA=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BnMU4Pc3ciEVteVpZ0BK33MLr7X57F5w1dwDLDn+/iy/yTrA4Q/N2yftidFtsA4vrDh0FMXDpacNV/Tl3fbmng=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-x9uJ0bI1rJsWICp3VH8w/5PnAVD3A7SqzDpbrfoUQX1QyWrK5jSU4fRLo/wSgGeplCivbxBRKmt5Xq4/nWvq8A=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-tOwuCuZZtKi1jVzbk/5nXmIsziOB6yqN8c9r9QM0EJYPU6DpQWf11uBOSCfFKKM4H3d9ZoarvlgMfbcuD051Pw=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-FhfpkAAlKL6kwvcVap0Hgp4AhZmtd3YImg0kK1jd7C/aSoh4SfsB2f++yG1rU0lr8Y5MCFJrcSkmssiL9Xnnig=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.12", "", { "os": "linux", "cpu": "x64" }, "sha512-8pFeAnLU9QdW9jCIslB/v82bI0lhBmz2ZAKc8pVMFPO0t0wAHsoEkrUQUbMkIorTRIjbqyNZHA3lEXavsPWYSw=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.12", "", { "os": "linux", "cpu": "x64" }, "sha512-dwTIgZrGutzhkQCuvHynCkyW6hJxUuyZqKKO0YNfaS2GUoRO+tOvxXZqZB6SkWAOdfZTzwaw8IEdUnIkHKHoew=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-B0DLnx0vA9ya/3v7XyCaP+/lCpnbWbMOfUFFve+xb5OxyYvdHaS55YsSddr228Y+JAFk58agCuZTsqNiw2a6ig=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.12", "", { "os": "win32", "cpu": "x64" }, "sha512-yMckRzTyZ83hkk8iDFWswqSdU8tvZxspJKnYNh7JZr/zhZNOlzH13k4ecboU6MurKExCe2HUkH75pGI/O2JwGA=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+
+    "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
+    "@next/env": ["@next/env@15.5.15", "", {}, "sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg=="],
+
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.5.15", "", { "os": "darwin", "cpu": "arm64" }, "sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw=="],
+
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.5.15", "", { "os": "darwin", "cpu": "x64" }, "sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ=="],
+
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.5.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w=="],
+
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.5.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg=="],
+
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.5.15", "", { "os": "linux", "cpu": "x64" }, "sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg=="],
+
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.5.15", "", { "os": "linux", "cpu": "x64" }, "sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ=="],
+
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.5.15", "", { "os": "win32", "cpu": "arm64" }, "sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A=="],
+
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.5.15", "", { "os": "win32", "cpu": "x64" }, "sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA=="],
+
+    "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
+
+    "@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
+
+    "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
+
+    "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "caniuse-lite": ["caniuse-lite@1.0.30001788", "", {}, "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ=="],
+
+    "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
+
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "next": ["next@15.5.15", "", { "dependencies": { "@next/env": "15.5.15", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.5.15", "@next/swc-darwin-x64": "15.5.15", "@next/swc-linux-arm64-gnu": "15.5.15", "@next/swc-linux-arm64-musl": "15.5.15", "@next/swc-linux-x64-gnu": "15.5.15", "@next/swc-linux-x64-musl": "15.5.15", "@next/swc-win32-arm64-msvc": "15.5.15", "@next/swc-win32-x64-msvc": "15.5.15", "sharp": "^0.34.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
+
+    "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
+
+    "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
+
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "styled-jsx": ["styled-jsx@5.1.6", "", { "dependencies": { "client-only": "0.0.1" }, "peerDependencies": { "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0" } }, "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+  }
+}

--- a/site/components/primitives/Brand.module.css
+++ b/site/components/primitives/Brand.module.css
@@ -1,0 +1,9 @@
+.brand {
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: 15px;
+  letter-spacing: -0.01em;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}

--- a/site/components/primitives/Brand.tsx
+++ b/site/components/primitives/Brand.tsx
@@ -1,0 +1,15 @@
+import styles from "./Brand.module.css";
+import { BrandMark } from "./BrandMark";
+
+interface BrandProps {
+  readonly as?: "div" | "span";
+}
+
+/** Brand mark + wordmark combo, as rendered in the nav and footer. */
+export function Brand({ as: Tag = "div" }: BrandProps) {
+  return (
+    <Tag className={styles.brand}>
+      <BrandMark /> crew
+    </Tag>
+  );
+}

--- a/site/components/primitives/BrandMark.module.css
+++ b/site/components/primitives/BrandMark.module.css
@@ -1,0 +1,16 @@
+.mark {
+  width: 16px;
+  height: 16px;
+  background: var(--accent);
+  display: inline-block;
+  border-radius: 2px;
+  transform: rotate(45deg);
+  position: relative;
+}
+
+.mark::after {
+  content: "";
+  position: absolute;
+  inset: 4px;
+  background: var(--bg);
+}

--- a/site/components/primitives/BrandMark.tsx
+++ b/site/components/primitives/BrandMark.tsx
@@ -1,0 +1,9 @@
+import styles from "./BrandMark.module.css";
+
+/**
+ * The diamond-in-diamond brand mark. Placeholder shape for the real
+ * logo — swap the CSS geometry when the SVG lands.
+ */
+export function BrandMark() {
+  return <span className={styles.mark} aria-hidden="true" />;
+}

--- a/site/components/primitives/Button.module.css
+++ b/site/components/primitives/Button.module.css
@@ -1,0 +1,28 @@
+.btn {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  padding: 10px 16px;
+  border-radius: 5px;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--ink);
+  background: var(--ink);
+  color: var(--bg);
+}
+
+.btn:hover {
+  background: #000;
+}
+
+.ghost {
+  background: transparent;
+  color: var(--ink);
+  border-color: var(--line-2);
+}
+
+.ghost:hover {
+  background: transparent;
+  border-color: var(--ink);
+}

--- a/site/components/primitives/Button.tsx
+++ b/site/components/primitives/Button.tsx
@@ -1,0 +1,19 @@
+import type { AnchorHTMLAttributes, ReactNode } from "react";
+import styles from "./Button.module.css";
+
+interface ButtonProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
+  readonly children: ReactNode;
+  readonly variant?: "solid" | "ghost";
+}
+
+/** Monospace CTA button. Rendered as an anchor. */
+export function Button({ children, variant = "solid", className, ...rest }: ButtonProps) {
+  const classes = [styles.btn, variant === "ghost" && styles.ghost, className]
+    .filter(Boolean)
+    .join(" ");
+  return (
+    <a className={classes} {...rest}>
+      {children}
+    </a>
+  );
+}

--- a/site/components/primitives/Chip.module.css
+++ b/site/components/primitives/Chip.module.css
@@ -1,0 +1,19 @@
+.chip {
+  font-family: var(--font-mono);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 10px;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: #fff;
+  color: var(--ink);
+  font-size: 13px;
+}
+
+.dot {
+  width: 6px;
+  height: 6px;
+  background: var(--accent);
+  border-radius: 50%;
+}

--- a/site/components/primitives/Chip.tsx
+++ b/site/components/primitives/Chip.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from "react";
+import styles from "./Chip.module.css";
+
+interface ChipProps {
+  readonly children: ReactNode;
+  /** Small circular dot before the label (common "status chip" pattern). */
+  readonly dot?: boolean;
+}
+
+/** Small rounded-rectangle label, used in the agents strip and elsewhere. */
+export function Chip({ children, dot = false }: ChipProps) {
+  return (
+    <span className={`${styles.chip} ${dot ? styles.withDot : ""}`}>
+      {dot ? <span className={styles.dot} /> : null}
+      {children}
+    </span>
+  );
+}

--- a/site/components/primitives/CodeBlock.module.css
+++ b/site/components/primitives/CodeBlock.module.css
@@ -1,0 +1,58 @@
+.code {
+  font-family: var(--font-mono);
+  font-size: 13.5px;
+  line-height: 1.65;
+  background: var(--term-bg);
+  color: var(--term-ink);
+  border-radius: 8px;
+  padding: 20px 22px;
+  overflow-x: auto;
+  white-space: pre;
+  border: 1px solid #000;
+  margin: 0;
+}
+
+.light {
+  background: #fff;
+  color: var(--ink);
+  border: 1px solid var(--line);
+}
+
+.cmt {
+  color: var(--term-mute);
+}
+.light .cmt {
+  color: var(--mute);
+}
+
+.p {
+  color: var(--term-prompt);
+}
+.light .p {
+  color: var(--mute);
+}
+
+.ok {
+  color: var(--term-ok);
+}
+.light .ok {
+  color: oklch(0.5 0.12 150);
+}
+
+.warn {
+  color: var(--term-warn);
+}
+
+.acc {
+  color: var(--term-accent);
+}
+.light .acc {
+  color: var(--accent-ink);
+}
+
+.key {
+  color: var(--term-key);
+}
+.light .key {
+  color: oklch(0.5 0.12 250);
+}

--- a/site/components/primitives/CodeBlock.tsx
+++ b/site/components/primitives/CodeBlock.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from "react";
+import styles from "./CodeBlock.module.css";
+
+interface CodeBlockProps {
+  readonly children: ReactNode;
+  /** Dark terminal palette (default) or light paper palette. */
+  readonly variant?: "dark" | "light";
+}
+
+/** A monospace code block with light or dark palette. */
+export function CodeBlock({ children, variant = "dark" }: CodeBlockProps) {
+  const cls = variant === "light" ? `${styles.code} ${styles.light}` : styles.code;
+  return <pre className={cls}>{children}</pre>;
+}
+
+/** Syntax-highlight helpers for use inside <CodeBlock>. */
+export const Cmt = ({ children }: { children: ReactNode }) => (
+  <span className={styles.cmt}>{children}</span>
+);
+export const Prompt = ({ children = "$" }: { children?: ReactNode }) => (
+  <span className={styles.p}>{children}</span>
+);
+export const Ok = ({ children }: { children: ReactNode }) => (
+  <span className={styles.ok}>{children}</span>
+);
+export const Warn = ({ children }: { children: ReactNode }) => (
+  <span className={styles.warn}>{children}</span>
+);
+export const Acc = ({ children }: { children: ReactNode }) => (
+  <span className={styles.acc}>{children}</span>
+);
+export const Key = ({ children }: { children: ReactNode }) => (
+  <span className={styles.key}>{children}</span>
+);

--- a/site/components/primitives/Container.module.css
+++ b/site/components/primitives/Container.module.css
@@ -1,0 +1,5 @@
+.wrap {
+  max-width: var(--wrap-max);
+  margin: 0 auto;
+  padding: 0 var(--wrap-pad);
+}

--- a/site/components/primitives/Container.tsx
+++ b/site/components/primitives/Container.tsx
@@ -1,0 +1,16 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import styles from "./Container.module.css";
+
+interface ContainerProps extends HTMLAttributes<HTMLDivElement> {
+  readonly children: ReactNode;
+}
+
+/** Horizontally-constrained content wrapper. */
+export function Container({ children, className, ...rest }: ContainerProps) {
+  const composed = className ? `${styles.wrap} ${className}` : styles.wrap;
+  return (
+    <div className={composed} {...rest}>
+      {children}
+    </div>
+  );
+}

--- a/site/components/primitives/Eyebrow.module.css
+++ b/site/components/primitives/Eyebrow.module.css
@@ -1,0 +1,23 @@
+.eyebrow {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--mute);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 0 0 32px 0;
+}
+
+.eyebrow::before {
+  content: "";
+  width: 24px;
+  height: 1px;
+  background: var(--mute);
+  display: inline-block;
+}
+
+.centered {
+  justify-content: center;
+}

--- a/site/components/primitives/Eyebrow.tsx
+++ b/site/components/primitives/Eyebrow.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react";
+import styles from "./Eyebrow.module.css";
+
+interface EyebrowProps {
+  readonly children: ReactNode;
+  /** Center the eyebrow within its container. */
+  readonly centered?: boolean;
+}
+
+/** Monospace label with a leading dash. "PROMPT_LIKE LABEL". */
+export function Eyebrow({ children, centered = false }: EyebrowProps) {
+  return <p className={`${styles.eyebrow} ${centered ? styles.centered : ""}`}>{children}</p>;
+}

--- a/site/components/primitives/Mono.tsx
+++ b/site/components/primitives/Mono.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from "react";
+
+/** Inline monospace text. Thin semantic wrapper over `<code>`. */
+export function Mono({ children }: { readonly children: ReactNode }) {
+  return <code>{children}</code>;
+}

--- a/site/components/primitives/Pill.module.css
+++ b/site/components/primitives/Pill.module.css
@@ -1,0 +1,18 @@
+.pill {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  padding: 6px 12px;
+  border: 1px solid var(--line-2);
+  border-radius: 999px;
+  background: #fff;
+  color: var(--ink-2);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.accent {
+  background: color-mix(in oklab, var(--accent) 14%, transparent);
+  border-color: color-mix(in oklab, var(--accent) 30%, transparent);
+  color: var(--accent-ink);
+}

--- a/site/components/primitives/Pill.tsx
+++ b/site/components/primitives/Pill.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react";
+import styles from "./Pill.module.css";
+
+interface PillProps {
+  readonly children: ReactNode;
+  /** Tinted accent background with a colored border. */
+  readonly accent?: boolean;
+}
+
+/** Rounded monospace pill. Used for kickers, chips, small labels. */
+export function Pill({ children, accent = false }: PillProps) {
+  return <span className={`${styles.pill} ${accent ? styles.accent : ""}`}>{children}</span>;
+}

--- a/site/components/primitives/Section.module.css
+++ b/site/components/primitives/Section.module.css
@@ -1,0 +1,15 @@
+.section {
+  padding: 96px 0;
+}
+
+.tight {
+  padding: 64px 0;
+}
+
+.ruleTop {
+  border-top: 1px solid var(--line);
+}
+
+.ruleBottom {
+  border-bottom: 1px solid var(--line);
+}

--- a/site/components/primitives/Section.tsx
+++ b/site/components/primitives/Section.tsx
@@ -1,0 +1,34 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import styles from "./Section.module.css";
+
+interface SectionProps extends HTMLAttributes<HTMLElement> {
+  readonly children: ReactNode;
+  readonly tight?: boolean;
+  readonly ruleTop?: boolean;
+  readonly ruleBottom?: boolean;
+}
+
+/** A top-level page section with consistent vertical padding. */
+export function Section({
+  children,
+  tight = false,
+  ruleTop = false,
+  ruleBottom = false,
+  className,
+  ...rest
+}: SectionProps) {
+  const classes = [
+    styles.section,
+    tight && styles.tight,
+    ruleTop && styles.ruleTop,
+    ruleBottom && styles.ruleBottom,
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return (
+    <section className={classes} {...rest}>
+      {children}
+    </section>
+  );
+}

--- a/site/components/primitives/SectionHead.module.css
+++ b/site/components/primitives/SectionHead.module.css
@@ -1,0 +1,43 @@
+.head {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  gap: 48px;
+  margin-bottom: 56px;
+  align-items: start;
+}
+
+.num {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--mute);
+}
+
+.num strong {
+  color: var(--ink);
+  font-weight: 500;
+}
+
+.title {
+  font-family: var(--font-sans);
+  font-weight: 600;
+  font-size: 40px;
+  line-height: 1.05;
+  letter-spacing: -0.025em;
+  margin: 0 0 16px;
+  max-width: 620px;
+  text-wrap: balance;
+}
+
+.description {
+  font-size: 17px;
+  color: var(--ink-2);
+  margin: 0;
+  max-width: 620px;
+}
+
+@media (max-width: 860px) {
+  .head {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+}

--- a/site/components/primitives/SectionHead.tsx
+++ b/site/components/primitives/SectionHead.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from "react";
+import styles from "./SectionHead.module.css";
+
+interface SectionHeadProps {
+  readonly number: string;
+  readonly label: string;
+  readonly title: ReactNode;
+  readonly description: ReactNode;
+}
+
+/**
+ * Two-column section head used at the top of most page sections:
+ * a "§ NN  <label>" number block on the left, a heading + lede on the right.
+ */
+export function SectionHead({ number, label, title, description }: SectionHeadProps) {
+  return (
+    <div className={styles.head}>
+      <div className={styles.num}>
+        § {number}&nbsp;&nbsp;<strong>{label}</strong>
+      </div>
+      <div>
+        <h2 className={styles.title}>{title}</h2>
+        <p className={styles.description}>{description}</p>
+      </div>
+    </div>
+  );
+}

--- a/site/components/primitives/Terminal.module.css
+++ b/site/components/primitives/Terminal.module.css
@@ -1,0 +1,49 @@
+.card {
+  background: #fff;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow:
+    0 1px 0 rgba(0, 0, 0, 0.02),
+    0 12px 40px -24px rgba(23, 22, 26, 0.25);
+}
+
+.head {
+  display: flex;
+  align-items: center;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--line);
+  background: var(--paper);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--mute);
+}
+
+.dots {
+  display: flex;
+  gap: 6px;
+  margin-right: 12px;
+}
+
+.dots i {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  display: inline-block;
+  background: #d8d2c4;
+}
+
+.title {
+  flex: 1;
+}
+
+.action {
+  margin-left: auto;
+}
+
+.body {
+  padding: 20px;
+  font-family: var(--font-mono);
+  font-size: 14px;
+  line-height: 1.7;
+}

--- a/site/components/primitives/Terminal.tsx
+++ b/site/components/primitives/Terminal.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from "react";
+import styles from "./Terminal.module.css";
+
+interface TerminalProps {
+  readonly children: ReactNode;
+  /** Optional title shown in the terminal chrome (e.g. `~/work · zsh`). */
+  readonly title?: string;
+  /** Optional right-side element — a copy button, a label, etc. */
+  readonly action?: ReactNode;
+}
+
+/**
+ * A stylized terminal window: traffic-light dots, a title, and
+ * monospace body content. Use <Prompt>, <Output>, etc. for lines.
+ */
+export function Terminal({ children, title, action }: TerminalProps) {
+  return (
+    <div className={styles.card}>
+      <div className={styles.head}>
+        <div className={styles.dots}>
+          <i />
+          <i />
+          <i />
+        </div>
+        {title ? <span className={styles.title}>{title}</span> : null}
+        {action ? <div className={styles.action}>{action}</div> : null}
+      </div>
+      <div className={styles.body}>{children}</div>
+    </div>
+  );
+}

--- a/site/components/primitives/TerminalLine.module.css
+++ b/site/components/primitives/TerminalLine.module.css
@@ -1,0 +1,25 @@
+.line {
+  display: flex;
+  gap: 12px;
+}
+
+.prompt {
+  color: var(--mute);
+  user-select: none;
+}
+
+.content {
+  color: var(--ink-2);
+}
+
+.ok {
+  color: var(--ok);
+}
+
+.warn {
+  color: var(--warn);
+}
+
+.muted {
+  color: var(--mute);
+}

--- a/site/components/primitives/TerminalLine.tsx
+++ b/site/components/primitives/TerminalLine.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from "react";
+import styles from "./TerminalLine.module.css";
+
+interface TerminalLineProps {
+  readonly children: ReactNode;
+  /** Prompt shown in the gutter. Defaults to `$ `. Pass "" for a continuation line. */
+  readonly prompt?: string;
+  /** A status marker at the start of the content: ✓, ✗, etc. */
+  readonly status?: "ok" | "warn" | "muted";
+}
+
+/** A single line inside a <Terminal>. */
+export function TerminalLine({ children, prompt = "$", status }: TerminalLineProps) {
+  const statusClass = status ? styles[status] : undefined;
+  return (
+    <div className={styles.line}>
+      <span className={styles.prompt}>{prompt || <>&nbsp;</>}</span>
+      {status ? (
+        <span className={statusClass}>{status === "ok" ? "✓" : status === "warn" ? "✗" : "·"}</span>
+      ) : null}
+      <span className={styles.content}>{children}</span>
+    </div>
+  );
+}

--- a/site/components/sections/AgentsStrip.module.css
+++ b/site/components/sections/AgentsStrip.module.css
@@ -1,0 +1,27 @@
+.strip {
+  display: flex;
+  align-items: center;
+  gap: 32px;
+  padding: 22px 0;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--mute);
+  flex-wrap: wrap;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.label {
+  color: var(--ink-2);
+  text-transform: uppercase;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+}
+
+.trail {
+  color: var(--mute);
+}
+
+.trail a {
+  color: var(--ink-2);
+}

--- a/site/components/sections/AgentsStrip.tsx
+++ b/site/components/sections/AgentsStrip.tsx
@@ -1,0 +1,24 @@
+import { Chip } from "../primitives/Chip";
+import { Container } from "../primitives/Container";
+import styles from "./AgentsStrip.module.css";
+
+const FEATURED_AGENTS = ["claude-code", "codex", "cursor", "gemini-cli", "goose"] as const;
+
+export function AgentsStrip() {
+  return (
+    <Container>
+      <div className={styles.strip}>
+        <span className={styles.label}>Installs into</span>
+        {FEATURED_AGENTS.map((name) => (
+          <Chip key={name} dot>
+            {name}
+          </Chip>
+        ))}
+        <span className={styles.trail}>
+          &mdash; and every agent whose skill layout follows the{" "}
+          <a href="https://agentskills.io/specification">Agent Skills spec</a>.
+        </span>
+      </div>
+    </Container>
+  );
+}

--- a/site/components/sections/BottomCTA.module.css
+++ b/site/components/sections/BottomCTA.module.css
@@ -1,0 +1,19 @@
+.wrap {
+  text-align: center;
+  padding: 48px 0;
+}
+
+.title {
+  font-size: 48px;
+  font-weight: 600;
+  letter-spacing: -0.03em;
+  margin: 0 0 24px;
+  line-height: 1.05;
+}
+
+.ctaRow {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  flex-wrap: wrap;
+}

--- a/site/components/sections/BottomCTA.tsx
+++ b/site/components/sections/BottomCTA.tsx
@@ -1,0 +1,24 @@
+import { Button } from "../primitives/Button";
+import { Container } from "../primitives/Container";
+import { Eyebrow } from "../primitives/Eyebrow";
+import { Section } from "../primitives/Section";
+import styles from "./BottomCTA.module.css";
+
+export function BottomCTA() {
+  return (
+    <Section tight ruleTop>
+      <Container>
+        <div className={styles.wrap}>
+          <Eyebrow centered>Teach every agent on your machine</Eyebrow>
+          <h2 className={styles.title}>$ crew install &lt;skill&gt;</h2>
+          <div className={styles.ctaRow}>
+            <Button href="#install">Install crew</Button>
+            <Button href="#commands" variant="ghost">
+              Read the reference
+            </Button>
+          </div>
+        </div>
+      </Container>
+    </Section>
+  );
+}

--- a/site/components/sections/Commands.module.css
+++ b/site/components/sections/Commands.module.css
@@ -1,0 +1,90 @@
+.groups {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: 48px;
+}
+
+.nav {
+  position: sticky;
+  top: 80px;
+  align-self: start;
+}
+
+.nav ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.nav a {
+  color: var(--mute);
+  text-decoration: none;
+  display: flex;
+  justify-content: space-between;
+}
+
+.nav a:hover {
+  color: var(--ink);
+}
+
+.n {
+  color: var(--line-2);
+}
+
+.group {
+  margin-bottom: 48px;
+}
+
+.groupTitle {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--mute);
+  margin: 0 0 14px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--line);
+}
+
+.row {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  gap: 32px;
+  padding: 14px 0;
+  border-bottom: 1px dashed var(--line);
+}
+
+.row:last-child {
+  border-bottom: 0;
+}
+
+.sig {
+  font-family: var(--font-mono);
+  font-size: 13.5px;
+  color: var(--ink);
+  white-space: nowrap;
+}
+
+.flag {
+  color: var(--accent-ink);
+}
+
+.desc {
+  color: var(--ink-2);
+  font-size: 14.5px;
+}
+
+@media (max-width: 860px) {
+  .groups {
+    grid-template-columns: 1fr;
+  }
+  .row {
+    grid-template-columns: 1fr;
+    gap: 6px;
+  }
+}

--- a/site/components/sections/Commands.tsx
+++ b/site/components/sections/Commands.tsx
@@ -1,0 +1,220 @@
+import type { ReactNode } from "react";
+import { Container } from "../primitives/Container";
+import { Section } from "../primitives/Section";
+import { SectionHead } from "../primitives/SectionHead";
+import styles from "./Commands.module.css";
+
+interface Command {
+  /** Stable identifier. Used as the React key and, eventually, a deep-link anchor. */
+  readonly name: string;
+  readonly signature: ReactNode;
+  readonly description: ReactNode;
+}
+
+interface Group {
+  readonly id: string;
+  readonly label: string;
+  readonly commands: readonly Command[];
+}
+
+const GROUPS: readonly Group[] = [
+  {
+    id: "cmd-managing",
+    label: "Managing skills",
+    commands: [
+      {
+        name: "install",
+        signature: <>crew install &lt;ref&gt;…</>,
+        description: "Install one or more skills into every detected agent.",
+      },
+      {
+        name: "uninstall",
+        signature: <>crew uninstall &lt;name&gt;…</>,
+        description: "Remove installed skills from every agent they were installed into.",
+      },
+      {
+        name: "update",
+        signature: <>crew update [&lt;name&gt;…]</>,
+        description: (
+          <>
+            Update all installed skills, or only those named. Pinned SHAs are skipped unless{" "}
+            <span className={styles.flag}>--force</span>.
+          </>
+        ),
+      },
+      {
+        name: "list",
+        signature: <>crew list</>,
+        description: "List installed skills, grouped by scope, with sources and resolved SHAs.",
+      },
+      {
+        name: "info",
+        signature: <>crew info &lt;ref-or-name&gt;</>,
+        description: "Show details for an installed skill or one available in a tap.",
+      },
+    ],
+  },
+  {
+    id: "cmd-discovery",
+    label: "Discovery",
+    commands: [
+      {
+        name: "search",
+        signature: <>crew search &lt;query&gt;</>,
+        description: "Case-insensitive substring match across every configured tap.",
+      },
+      {
+        name: "tap-add",
+        signature: <>crew tap add &lt;git-url&gt; [name]</>,
+        description: (
+          <>
+            Clone a registry into <code>~/.crew/taps/</code>. Name defaults to the repo name.
+          </>
+        ),
+      },
+      {
+        name: "tap-remove",
+        signature: <>crew tap remove &lt;name&gt;</>,
+        description: "Delete a local tap clone and drop it from config.",
+      },
+      {
+        name: "tap-list",
+        signature: <>crew tap list</>,
+        description: "Print each tap's name, URL, and last-fetched timestamp.",
+      },
+    ],
+  },
+  {
+    id: "cmd-agents",
+    label: "Agents & automation",
+    commands: [
+      {
+        name: "agents",
+        signature: <>crew agents</>,
+        description: "List detected agents and whether they're enabled, disabled, or forced.",
+      },
+      {
+        name: "agents-enable",
+        signature: <>crew agents enable &lt;name&gt;</>,
+        description: "Force-enable an agent even if auto-detection misses it.",
+      },
+      {
+        name: "agents-disable",
+        signature: <>crew agents disable &lt;name&gt;</>,
+        description: "Skip this agent on all install and update operations.",
+      },
+      {
+        name: "autoupdate-enable",
+        signature: (
+          <>
+            crew autoupdate enable <span className={styles.flag}>[--interval]</span>
+          </>
+        ),
+        description: (
+          <>
+            Install a launchd user agent that runs <code>crew update --quiet</code> on an interval
+            (default 4h).
+          </>
+        ),
+      },
+      {
+        name: "autoupdate-status",
+        signature: <>crew autoupdate status</>,
+        description: "Whether active, last run, next run, configured interval.",
+      },
+    ],
+  },
+  {
+    id: "cmd-housekeeping",
+    label: "Housekeeping",
+    commands: [
+      {
+        name: "doctor",
+        signature: (
+          <>
+            crew doctor <span className={styles.flag}>[--verify] [--repair]</span>
+          </>
+        ),
+        description: (
+          <>
+            Check integrity between state, markers, and agent directories.{" "}
+            <span className={styles.flag}>--repair</span> fixes recoverable drift without ever
+            touching customized files.
+          </>
+        ),
+      },
+      {
+        name: "cache-clean",
+        signature: <>crew cache clean</>,
+        description: "Remove ephemeral caches and unreferenced store entries.",
+      },
+    ],
+  },
+  {
+    id: "cmd-meta",
+    label: "Meta",
+    commands: [
+      {
+        name: "help",
+        signature: <>crew help [&lt;command&gt;]</>,
+        description: "Overview or per-command help, with realistic examples.",
+      },
+      {
+        name: "version",
+        signature: <>crew version</>,
+        description: "Print the version string and exit.",
+      },
+    ],
+  },
+];
+
+export function Commands() {
+  return (
+    <Section id="commands" ruleTop>
+      <Container>
+        <SectionHead
+          number="06"
+          label="Command reference"
+          title="Everything the CLI can do."
+          description={
+            <>
+              Every command accepts <code>--scope</code>, <code>--agent</code>,{" "}
+              <code>--dry-run</code>, <code>--json</code>, <code>--quiet</code>,{" "}
+              <code>--verbose</code>, <code>--yes</code>, and <code>--force</code> where they apply.
+              Run <code>crew help &lt;command&gt;</code> for examples.
+            </>
+          }
+        />
+
+        <div className={styles.groups}>
+          <nav className={styles.nav}>
+            <ul>
+              {GROUPS.map((g) => (
+                <li key={g.id}>
+                  <a href={`#${g.id}`}>
+                    <span>{g.label}</span>
+                    <span className={styles.n}>{String(g.commands.length).padStart(2, "0")}</span>
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </nav>
+
+          <div>
+            {GROUPS.map((g) => (
+              <div key={g.id} id={g.id} className={styles.group}>
+                <h3 className={styles.groupTitle}>{g.label}</h3>
+                {g.commands.map((c) => (
+                  <div key={c.name} className={styles.row}>
+                    <div className={styles.sig}>{c.signature}</div>
+                    <div className={styles.desc}>{c.description}</div>
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        </div>
+      </Container>
+    </Section>
+  );
+}

--- a/site/components/sections/Demo.tsx
+++ b/site/components/sections/Demo.tsx
@@ -1,0 +1,70 @@
+import { Acc, Cmt, CodeBlock, Key, Ok, Prompt, Warn } from "../primitives/CodeBlock";
+import { Container } from "../primitives/Container";
+import { Section } from "../primitives/Section";
+import { SectionHead } from "../primitives/SectionHead";
+
+export function Demo() {
+  return (
+    <Section id="demo" ruleTop>
+      <Container>
+        <SectionHead
+          number="05"
+          label="A day with crew"
+          title="What using it actually feels like."
+          description="Six commands that cover roughly 90% of what you'll ever type."
+        />
+
+        <CodeBlock>
+          <Cmt># Find a skill across every tap you've added.</Cmt>
+          {"\n"}
+          <Prompt /> crew search <Acc>engineer</Acc>
+          {
+            "\ncore/founding-engineer    Ship like a founding engineer: bias to action, small PRs, obvious code."
+          }
+          {
+            "\ncore/staff-engineer       Design docs, RFC etiquette, cross-team technical leadership."
+          }
+          {"\nacme/platform-engineer    Team conventions for infra work and on-call handoffs."}
+          {"\n\n"}
+          <Cmt># Install one — it lands in every agent on your machine.</Cmt>
+          {"\n"}
+          <Prompt /> crew install <Acc>founding-engineer</Acc>
+          {"\n"}
+          <Ok>✓</Ok> claude-code · codex · cursor · gemini-cli · goose
+          {"\n\n"}
+          <Cmt># Install straight from a repo, pinned to a tag, at a subpath.</Cmt>
+          {"\n"}
+          <Prompt /> crew install <Acc>{"@acme/skills@v1.2.0//engineers/founding"}</Acc>
+          {"\n\n"}
+          <Cmt># See what's installed, grouped by scope.</Cmt>
+          {"\n"}
+          <Prompt /> crew list
+          {"\n"}
+          <Warn>user</Warn>
+          {"\n  founding-engineer     core           a1b2c3d   5 agents"}
+          {"\n  code-review           core           d4e5f6a   5 agents"}
+          {"\n  platform-engineer     acme/v1.2.0    9c8b7a6   5 agents"}
+          {"\n"}
+          <Warn>project</Warn> <Cmt>(/Users/you/work/api)</Cmt>
+          {"\n  api-review-checklist  ./skills/review    —     5 agents"}
+          {"\n\n"}
+          <Cmt># Pull the latest versions of everything.</Cmt>
+          {"\n"}
+          <Prompt /> crew update
+          {"\n"}
+          <Ok>✓</Ok> founding-engineer a1b2c3d → e8f9a01 (5 agents)
+          {"\n"}
+          <Ok>✓</Ok> code-review up to date
+          {"\n"}
+          <Ok>✓</Ok> platform-engineer pinned @ v1.2.0, skipped
+          {"\n\n"}
+          <Cmt># Run it in the background every 4 hours.</Cmt>
+          {"\n"}
+          <Prompt /> crew autoupdate enable
+          {"\n"}
+          <Ok>✓</Ok> launchd agent <Key>sh.crew.autoupdate</Key> loaded (interval: 4h)
+        </CodeBlock>
+      </Container>
+    </Section>
+  );
+}

--- a/site/components/sections/Faq.module.css
+++ b/site/components/sections/Faq.module.css
@@ -1,0 +1,66 @@
+.list {
+  max-width: 820px;
+}
+
+.list details {
+  border-bottom: 1px solid var(--line);
+  padding: 20px 0;
+}
+
+/* All inline code inside a FAQ entry picks up the same pill styling
+   — whether it appears in the question or the answer. */
+.list details code {
+  font-family: var(--font-mono);
+  font-size: 0.88em;
+  background: var(--paper);
+  padding: 1px 6px;
+  border-radius: 3px;
+}
+
+.list details summary {
+  cursor: pointer;
+  list-style: none;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 24px;
+  font-weight: 500;
+  font-size: 18px;
+  letter-spacing: -0.01em;
+}
+
+.list details summary > span:first-child {
+  flex: 1;
+}
+
+.list details summary code {
+  font-size: 0.85em;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.list details summary::-webkit-details-marker {
+  display: none;
+}
+
+.list details summary::after {
+  content: "+";
+  font-family: var(--font-mono);
+  color: var(--mute);
+  font-size: 20px;
+  transition: transform 0.15s;
+}
+
+.list details[open] summary::after {
+  content: "−";
+}
+
+.ans {
+  margin-top: 12px;
+  color: var(--ink-2);
+  max-width: 720px;
+}
+
+.ans p {
+  margin: 0 0 10px;
+}

--- a/site/components/sections/Faq.tsx
+++ b/site/components/sections/Faq.tsx
@@ -1,0 +1,123 @@
+import type { ReactNode } from "react";
+import { Container } from "../primitives/Container";
+import { Section } from "../primitives/Section";
+import { SectionHead } from "../primitives/SectionHead";
+import styles from "./Faq.module.css";
+
+interface QA {
+  readonly id: string;
+  readonly q: ReactNode;
+  readonly a: ReactNode;
+  readonly defaultOpen?: boolean;
+}
+
+const QAS: readonly QA[] = [
+  {
+    id: "symlinks",
+    defaultOpen: true,
+    q: "Why copies instead of symlinks?",
+    a: "Symlinks break the moment two agents resolve a skill differently, or a user pins one agent to an older ref. Copies are dumb, predictable, and safe: each agent's directory is self-sufficient. The marginal disk cost is negligible — skills are markdown.",
+  },
+  {
+    id: "edits",
+    q: "What happens if I edit an installed skill?",
+    a: (
+      <>
+        Crew records a content hash in the <code>.crew.json</code> marker at install time. On the
+        next <code>crew install</code> or <code>crew update</code>, it recomputes the hash. If it
+        differs, crew refuses to overwrite your changes and reports <code>customized</code>. You
+        pass <code>--force</code> to override, or copy your edits into a new skill and install that
+        instead.
+      </>
+    ),
+  },
+  {
+    id: "new-agent",
+    q: "How do I add support for a new agent?",
+    a: (
+      <>
+        Write an adapter — six methods: <code>detect</code>, <code>user_path</code>,{" "}
+        <code>project_path</code>, <code>install</code>, <code>uninstall</code>,{" "}
+        <code>list_installed</code>. Register it. The install pipeline is tool-agnostic; adapters
+        just know where the files go.
+      </>
+    ),
+  },
+  {
+    id: "registry",
+    q: "Is there a hosted registry?",
+    a: (
+      <>
+        No. The default tap <code>core</code> is a plain git repo. Anyone can host a tap — your
+        team, your company, yourself. Crew never phones home.
+      </>
+    ),
+  },
+  {
+    id: "update-skip",
+    q: (
+      <>
+        How does <code>crew update</code> know when to skip a skill?
+      </>
+    ),
+    a: (
+      <>
+        Skills pinned to an exact SHA are skipped unless <code>--force</code>. Skills pinned to a
+        tag are re-resolved: if the tag moved and <code>--force</code> is given, the new commit is
+        installed. Everything else (branches, default branches, bare tap references) updates to
+        whatever the ref resolves to now.
+      </>
+    ),
+  },
+  {
+    id: "platforms",
+    q: "What about Linux? Windows?",
+    a: "Future work. The v1 spec is macOS-only because launchd is the autoupdate mechanism and each agent adapter encodes platform-specific paths. Nothing in the core design is Mac-specific; it's a scope decision, not a technical one.",
+  },
+  {
+    id: "cross-tap-dep",
+    q: "Can a skill depend on another skill in a different tap?",
+    a: "Yes. Dependency references are full skill references — any form the CLI accepts. You can depend on a bare name (resolved across taps), a qualified tap name, a git URL with a ref, or a subpath inside a monorepo.",
+  },
+  {
+    id: "project-git",
+    q: (
+      <>
+        Does <code>project</code> scope interact with git?
+      </>
+    ),
+    a: (
+      <>
+        Not automatically. <code>--scope project</code> writes into the agent's project-local skills
+        directory relative to your current working directory. Whether you commit that directory is
+        up to you. Many teams do; it means cloning a repo gives you its skills, no{" "}
+        <code>crew install</code> required.
+      </>
+    ),
+  },
+];
+
+export function Faq() {
+  return (
+    <Section id="faq" ruleTop>
+      <Container>
+        <SectionHead
+          number="11"
+          label="FAQ"
+          title="Things people ask before they install it."
+          description=""
+        />
+        <div className={styles.list}>
+          {QAS.map((qa) => (
+            <details key={qa.id} open={qa.defaultOpen}>
+              <summary>
+                <span>{qa.q}</span>
+              </summary>
+              <div className={styles.ans}>{typeof qa.a === "string" ? <p>{qa.a}</p> : qa.a}</div>
+            </details>
+          ))}
+        </div>
+      </Container>
+    </Section>
+  );
+}

--- a/site/components/sections/Footer.module.css
+++ b/site/components/sections/Footer.module.css
@@ -1,0 +1,65 @@
+.footer {
+  padding: 64px 0 48px;
+  border-top: 1px solid var(--line);
+  background: var(--paper);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr 1fr 1fr;
+  gap: 48px;
+  margin-bottom: 48px;
+}
+
+.lede {
+  color: var(--ink-2);
+  font-size: 14px;
+  margin: 12px 0 0;
+  max-width: 340px;
+}
+
+.h5 {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--mute);
+  margin: 0 0 16px;
+  font-weight: 500;
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 14px;
+}
+
+.list a {
+  color: var(--ink-2);
+  text-decoration: none;
+}
+
+.list a:hover {
+  color: var(--ink);
+}
+
+.bot {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--mute);
+  padding-top: 32px;
+  border-top: 1px solid var(--line);
+}
+
+@media (max-width: 860px) {
+  .grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}

--- a/site/components/sections/Footer.tsx
+++ b/site/components/sections/Footer.tsx
@@ -1,0 +1,72 @@
+import { Brand } from "../primitives/Brand";
+import { Container } from "../primitives/Container";
+import styles from "./Footer.module.css";
+
+const COLUMNS: readonly {
+  readonly title: string;
+  readonly links: readonly { readonly href: string; readonly label: string }[];
+}[] = [
+  {
+    title: "Product",
+    links: [
+      { href: "#how", label: "How it works" },
+      { href: "#commands", label: "Commands" },
+      { href: "#safety", label: "Safety" },
+      { href: "#install", label: "Install" },
+    ],
+  },
+  {
+    title: "Resources",
+    links: [
+      { href: "https://agentskills.io/specification", label: "Agent Skills spec" },
+      { href: "#skill-md", label: "SKILL.md anatomy" },
+      { href: "#faq", label: "FAQ" },
+    ],
+  },
+  {
+    title: "Project",
+    links: [
+      { href: "https://github.com/with-logic/crew", label: "GitHub" },
+      { href: "https://github.com/with-logic/crew-skills", label: "Default tap (core)" },
+      {
+        href: "https://github.com/with-logic/crew/blob/main/CHANGELOG.md",
+        label: "Changelog",
+      },
+      { href: "https://github.com/with-logic/crew/blob/main/LICENSE", label: "License · MIT" },
+    ],
+  },
+];
+
+export function Footer() {
+  return (
+    <footer className={styles.footer}>
+      <Container>
+        <div className={styles.grid}>
+          <div>
+            <Brand />
+            <p className={styles.lede}>
+              A package manager for agent skills. Install once, everywhere. Ship skills like
+              packages. macOS-first, open source.
+            </p>
+          </div>
+          {COLUMNS.map((c) => (
+            <div key={c.title}>
+              <h5 className={styles.h5}>{c.title}</h5>
+              <ul className={styles.list}>
+                {c.links.map((l) => (
+                  <li key={l.href}>
+                    <a href={l.href}>{l.label}</a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+        <div className={styles.bot}>
+          <span>crew · v0.3.1 · macOS (arm64, x86_64)</span>
+          <span>$ crew help</span>
+        </div>
+      </Container>
+    </footer>
+  );
+}

--- a/site/components/sections/Hero.module.css
+++ b/site/components/sections/Hero.module.css
@@ -1,0 +1,158 @@
+.hero {
+  padding: 56px 0 88px;
+  position: relative;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1.15fr 1fr;
+  gap: 64px;
+  align-items: start;
+}
+
+.kicker {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+  margin: 0 0 28px;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 14px 7px 12px;
+  background: color-mix(in oklab, var(--accent) 14%, transparent);
+  border: 1px solid color-mix(in oklab, var(--accent) 30%, transparent);
+  border-radius: 999px;
+  white-space: nowrap;
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.sq {
+  width: 8px;
+  height: 8px;
+  background: var(--accent);
+  border-radius: 2px;
+  display: inline-block;
+}
+
+.sep {
+  color: var(--mute);
+  opacity: 0.5;
+  margin: 0 2px;
+}
+
+.os {
+  color: var(--accent-ink);
+  font-weight: 600;
+}
+
+.title {
+  font-family: var(--font-sans);
+  font-weight: 600;
+  font-size: 76px;
+  line-height: 1;
+  letter-spacing: -0.038em;
+  margin: 0 0 28px;
+  text-wrap: balance;
+}
+
+.accent {
+  color: var(--accent-ink);
+}
+
+.lede {
+  font-size: 20px;
+  color: var(--ink-2);
+  max-width: 540px;
+  margin: 0 0 40px;
+  line-height: 1.5;
+}
+
+.ctaRow {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.meta {
+  display: flex;
+  gap: 18px;
+  flex-wrap: wrap;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--mute);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-top: 36px;
+}
+
+.meta span {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--ok);
+  display: inline-block;
+}
+
+/* Terminal body styling */
+.line {
+  display: flex;
+  gap: 12px;
+}
+
+.prompt {
+  color: var(--mute);
+  user-select: none;
+}
+
+.cmd {
+  color: var(--ink);
+}
+
+.out {
+  color: var(--ink-2);
+}
+
+.ok {
+  color: var(--ok);
+}
+
+.dim {
+  color: var(--mute);
+}
+
+.acc {
+  color: var(--accent-ink);
+}
+
+.caret {
+  display: inline-block;
+  width: 8px;
+  height: 15px;
+  background: var(--ink);
+  animation: blink 1.05s steps(2) infinite;
+  align-self: center;
+}
+
+@keyframes blink {
+  50% {
+    opacity: 0;
+  }
+}
+
+@media (max-width: 860px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+  .title {
+    font-size: 48px;
+  }
+}

--- a/site/components/sections/Hero.tsx
+++ b/site/components/sections/Hero.tsx
@@ -1,0 +1,99 @@
+import { Button } from "../primitives/Button";
+import { Container } from "../primitives/Container";
+import { Terminal } from "../primitives/Terminal";
+import styles from "./Hero.module.css";
+
+export function Hero() {
+  return (
+    <section className={styles.hero}>
+      <Container>
+        <div className={styles.grid}>
+          <div>
+            <p className={styles.kicker}>
+              <span className={styles.sq} />
+              open source
+              <span className={styles.sep}>/</span>
+              <span className={styles.os}>MIT</span>
+            </p>
+            <h1 className={styles.title}>
+              Crew is a package manager <span className={styles.accent}>for agent skills</span>.
+            </h1>
+            <p className={styles.lede}>
+              Find great skills. Install them with one command into every coding agent on your
+              machine. Publish your own as easily as pushing to GitHub.
+            </p>
+            <div className={styles.ctaRow}>
+              <Button href="#install">Install crew →</Button>
+              <Button href="#how" variant="ghost">
+                How it works
+              </Button>
+              <Button href="#commands" variant="ghost">
+                Command reference
+              </Button>
+            </div>
+            <div className={styles.meta}>
+              <span>
+                <span className={styles.dot} />
+                Open source · MIT
+              </span>
+              <span>macOS · Apple Silicon &amp; Intel</span>
+              <span>Single binary</span>
+              <span>Zero config</span>
+            </div>
+          </div>
+          <HeroTerminal />
+        </div>
+      </Container>
+    </section>
+  );
+}
+
+function HeroTerminal() {
+  return (
+    <Terminal title="~/work · zsh">
+      <div className={styles.line}>
+        <span className={styles.prompt}>$</span>
+        <span className={styles.cmd}>crew install founding-engineer</span>
+      </div>
+      <div className={styles.line}>
+        <span className={styles.prompt}>&nbsp;</span>
+        <span className={styles.dim}>
+          resolving <span className={styles.acc}>founding-engineer</span> from tap{" "}
+          <span className={styles.acc}>core</span>…
+        </span>
+      </div>
+      <div className={styles.line}>
+        <span className={styles.prompt}>&nbsp;</span>
+        <span className={styles.dim}>
+          fetched <span className={styles.acc}>core</span> @{" "}
+          <span className={styles.acc}>a1b2c3d</span> · validated SKILL.md
+        </span>
+      </div>
+      <div className={styles.line}>
+        <span className={styles.prompt}>&nbsp;</span>
+        <span className={styles.ok}>✓</span>
+        <span className={styles.out}>claude-code &nbsp;→ ~/.claude/skills/founding-engineer</span>
+      </div>
+      <div className={styles.line}>
+        <span className={styles.prompt}>&nbsp;</span>
+        <span className={styles.ok}>✓</span>
+        <span className={styles.out}>
+          codex &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;→ ~/.agents/skills/founding-engineer
+        </span>
+      </div>
+      <div className={styles.line}>
+        <span className={styles.prompt}>&nbsp;</span>
+        <span className={styles.ok}>✓</span>
+        <span className={styles.out}>gemini-cli &nbsp;→ ~/.agents/skills/founding-engineer</span>
+      </div>
+      <div className={styles.line}>
+        <span className={styles.prompt}>&nbsp;</span>
+        <span className={styles.dim}>installed in 3 agents · 0 skipped · 0 failed</span>
+      </div>
+      <div className={styles.line}>
+        <span className={styles.prompt}>$</span>
+        <span className={styles.caret} />
+      </div>
+    </Terminal>
+  );
+}

--- a/site/components/sections/HowItWorks.module.css
+++ b/site/components/sections/HowItWorks.module.css
@@ -1,0 +1,112 @@
+.pipeline {
+  display: grid;
+  grid-template-columns: 1.1fr 1fr;
+  gap: 48px;
+  align-items: stretch;
+}
+
+.steps {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  border-top: 1px solid var(--line);
+}
+
+.step {
+  display: grid;
+  grid-template-columns: 56px 1fr;
+  gap: 20px;
+  padding: 24px 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.n {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--mute);
+  padding-top: 2px;
+}
+
+.title {
+  font-size: 17px;
+  margin: 0 0 6px;
+  letter-spacing: -0.01em;
+}
+
+.body {
+  margin: 0;
+  color: var(--ink-2);
+  font-size: 15px;
+}
+
+.diagram {
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 28px;
+  position: sticky;
+  top: 80px;
+  align-self: start;
+}
+
+.dTitle {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--mute);
+  margin-bottom: 20px;
+}
+
+.dRow {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 0;
+  border-bottom: 1px dashed var(--line-2);
+  font-family: var(--font-mono);
+  font-size: 13px;
+}
+
+.dRow:last-of-type {
+  border-bottom: 0;
+}
+
+.dName {
+  color: var(--ink);
+  font-weight: 600;
+  width: 110px;
+}
+
+.dPath {
+  color: var(--mute);
+  font-size: 12px;
+  flex: 1;
+}
+
+.dStatus {
+  color: var(--ok);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.dNote {
+  margin-top: 22px;
+  padding-top: 18px;
+  border-top: 1px solid var(--line);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--mute);
+  line-height: 1.6;
+}
+
+.dEmph {
+  color: var(--ink);
+}
+
+@media (max-width: 860px) {
+  .pipeline {
+    grid-template-columns: 1fr;
+  }
+}

--- a/site/components/sections/HowItWorks.tsx
+++ b/site/components/sections/HowItWorks.tsx
@@ -1,0 +1,121 @@
+import { Container } from "../primitives/Container";
+import { Section } from "../primitives/Section";
+import { SectionHead } from "../primitives/SectionHead";
+import styles from "./HowItWorks.module.css";
+
+const STEPS: readonly {
+  readonly n: string;
+  readonly title: string;
+  readonly body: React.ReactNode;
+}[] = [
+  {
+    n: "01",
+    title: "Find great skills.",
+    body: (
+      <>
+        Search across the default <code>core</code> collection and anything else you've added.
+        Browse what your teammates, favorite engineers, and the broader community are publishing.
+      </>
+    ),
+  },
+  {
+    n: "02",
+    title: "Tap into more sources.",
+    body: (
+      <>
+        A <em>tap</em> is any git repo full of skills. Add your team's repo, a community collection,
+        your own private one — <code>crew tap add</code> once, and every skill inside is searchable
+        and installable.
+      </>
+    ),
+  },
+  {
+    n: "03",
+    title: "Install into every agent.",
+    body: (
+      <>
+        One <code>crew install</code> copies the skill into Claude Code, Codex, Cursor, Gemini CLI,
+        GitHub Copilot, Goose, and every other agent on your machine. Grab one skill, or a whole
+        collection at once.
+      </>
+    ),
+  },
+  {
+    n: "04",
+    title: "Dependencies, handled.",
+    body: (
+      <>
+        Skills can depend on other skills. Crew walks the graph and installs everything they need. A
+        single "team baseline" meta-skill can pull in a dozen others in one command.
+      </>
+    ),
+  },
+  {
+    n: "05",
+    title: "Stay current automatically.",
+    body: (
+      <>
+        <code>crew update</code> pulls the latest versions of everything. Flip on autoupdate and a
+        background job keeps every agent fresh in the background.
+      </>
+    ),
+  },
+];
+
+const DIAGRAM_ROWS: readonly {
+  readonly name: string;
+  readonly path: string;
+  readonly status: string;
+}[] = [
+  { name: "claude-code", path: "~/.claude/skills/", status: "detected" },
+  { name: "codex", path: "~/.agents/skills/", status: "detected" },
+  { name: "cursor", path: "~/.agents/skills/", status: "detected" },
+  { name: "gemini-cli", path: "~/.agents/skills/", status: "detected" },
+];
+
+export function HowItWorks() {
+  return (
+    <Section id="how" ruleTop>
+      <Container>
+        <SectionHead
+          number="03"
+          label="How it works"
+          title="Find, install, update. Repeat."
+          description="Four everyday motions. No manifest to learn, no plugins to configure — commands that do what they say, across every agent you use."
+        />
+
+        <div className={styles.pipeline}>
+          <div className={styles.steps}>
+            {STEPS.map((s) => (
+              <div key={s.n} className={styles.step}>
+                <div className={styles.n}>{s.n}</div>
+                <div>
+                  <h4 className={styles.title}>{s.title}</h4>
+                  <p className={styles.body}>{s.body}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <aside className={styles.diagram}>
+            <div className={styles.dTitle}>Agent adapters · showing 4 of 17</div>
+            {DIAGRAM_ROWS.map((r) => (
+              <div key={r.name} className={styles.dRow}>
+                <span className={styles.dName}>{r.name}</span>
+                <span className={styles.dPath}>{r.path}</span>
+                <span className={styles.dStatus}>{r.status}</span>
+              </div>
+            ))}
+            <div className={styles.dNote}>
+              Each adapter knows its tool's skill directory at both{" "}
+              <span className={styles.dEmph}>user</span> and{" "}
+              <span className={styles.dEmph}>project</span> scope. Multiple agents that share the
+              same convention (Codex, Cursor, Gemini, Goose, and others read{" "}
+              <code>~/.agents/skills/</code>) share a single install copy — one write, every agent.
+            </div>
+          </aside>
+        </div>
+      </Container>
+    </Section>
+  );
+}

--- a/site/components/sections/Install.module.css
+++ b/site/components/sections/Install.module.css
@@ -1,0 +1,40 @@
+.grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+}
+
+.requirements {
+  margin-top: 32px;
+  padding: 20px 24px;
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  font-size: 14.5px;
+  color: var(--ink-2);
+  display: flex;
+  gap: 20px;
+  align-items: flex-start;
+}
+
+.reqBadge {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--mute);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 3px 7px;
+  border: 1px solid var(--line-2);
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.reqStrong {
+  color: var(--ink);
+}
+
+@media (max-width: 860px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/site/components/sections/Install.tsx
+++ b/site/components/sections/Install.tsx
@@ -1,0 +1,59 @@
+import { Acc, CodeBlock } from "../primitives/CodeBlock";
+import { Container } from "../primitives/Container";
+import { Eyebrow } from "../primitives/Eyebrow";
+import { Section } from "../primitives/Section";
+import { SectionHead } from "../primitives/SectionHead";
+import styles from "./Install.module.css";
+
+export function Install() {
+  return (
+    <Section id="install" ruleTop>
+      <Container>
+        <SectionHead
+          number="02"
+          label="Installation"
+          title="Installation."
+          description={
+            <>
+              A single macOS binary. Drops nothing on your system outside of <code>~/.crew/</code>{" "}
+              and whichever agent skills directories you install into. Uninstall with{" "}
+              <code>rm -rf ~/.crew &amp;&amp; rm /usr/local/bin/crew</code>.
+            </>
+          }
+        />
+
+        <div className={styles.grid}>
+          <div>
+            <Eyebrow>Homebrew</Eyebrow>
+            <CodeBlock>
+              {"$ brew install "}
+              <Acc>with-logic/tap/crew</Acc>
+              {"\n$ crew version\ncrew "}
+              <Acc>0.3.1</Acc>
+              {" (darwin-arm64)"}
+            </CodeBlock>
+          </div>
+          <div>
+            <Eyebrow>Curl</Eyebrow>
+            <CodeBlock>
+              {"$ curl -fsSL "}
+              <Acc>https://crew.logic.inc/install.sh</Acc>
+              {" | sh\n$ crew version\ncrew "}
+              <Acc>0.3.1</Acc>
+              {" (darwin-arm64)"}
+            </CodeBlock>
+          </div>
+        </div>
+
+        <div className={styles.requirements}>
+          <span className={styles.reqBadge}>req</span>
+          <div>
+            <strong className={styles.reqStrong}>Requires:</strong> macOS 13+ (Ventura or later),{" "}
+            <code>git</code> on <code>PATH</code>, and <code>launchctl</code> (present on every
+            macOS). Linux and Windows support is tracked but not shipping in v1.
+          </div>
+        </div>
+      </Container>
+    </Section>
+  );
+}

--- a/site/components/sections/Nav.module.css
+++ b/site/components/sections/Nav.module.css
@@ -1,0 +1,101 @@
+.nav {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  background: color-mix(in oklab, var(--bg) 92%, transparent);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--line);
+}
+
+.inner {
+  display: flex;
+  align-items: center;
+  gap: 32px;
+  height: var(--nav-h);
+  padding: 0 var(--wrap-pad);
+  max-width: var(--wrap-max);
+  margin: 0 auto;
+}
+
+.version {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--mute);
+  padding: 3px 7px;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+}
+
+.links {
+  display: flex;
+  gap: 24px;
+  font-size: 14px;
+  color: var(--ink-2);
+  margin-left: 12px;
+}
+
+.links a {
+  text-decoration: none;
+  color: var(--ink-2);
+  white-space: nowrap;
+}
+
+.links a:hover {
+  color: var(--ink);
+}
+
+.spacer {
+  flex: 1;
+}
+
+.osPill {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  padding: 5px 10px 5px 8px;
+  border: 1px solid var(--line-2);
+  border-radius: 999px;
+  color: var(--ink-2);
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: #fff;
+}
+
+.osPill:hover {
+  border-color: var(--ink);
+  color: var(--ink);
+}
+
+.gh {
+  color: var(--ink);
+}
+
+.cta {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  padding: 6px 12px;
+  border: 1px solid var(--line-2);
+  border-radius: 4px;
+  text-decoration: none;
+  background: #fff;
+  color: var(--ink);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.cta:hover {
+  border-color: var(--ink);
+}
+
+.ctaArrow {
+  color: var(--mute);
+}
+
+@media (max-width: 860px) {
+  .links,
+  .osPill {
+    display: none;
+  }
+}

--- a/site/components/sections/Nav.tsx
+++ b/site/components/sections/Nav.tsx
@@ -1,0 +1,55 @@
+import { Brand } from "../primitives/Brand";
+import styles from "./Nav.module.css";
+
+const LINKS: readonly { readonly href: string; readonly label: string }[] = [
+  { href: "#how", label: "How it works" },
+  { href: "#refs", label: "Skill refs" },
+  { href: "#commands", label: "Commands" },
+  { href: "#taps", label: "Taps" },
+  { href: "#faq", label: "FAQ" },
+];
+
+export function Nav() {
+  return (
+    <nav className={styles.nav}>
+      <div className={styles.inner}>
+        <Brand />
+        <span className={styles.version}>v0.3.1</span>
+        <div className={styles.links}>
+          {LINKS.map((l) => (
+            <a key={l.href} href={l.href}>
+              {l.label}
+            </a>
+          ))}
+        </div>
+        <div className={styles.spacer} />
+        <a
+          className={styles.osPill}
+          href="https://github.com/with-logic/crew"
+          aria-label="GitHub repository"
+        >
+          <GitHubMark />
+          github.com/with-logic/crew
+        </a>
+        <a className={styles.cta} href="#install">
+          $ crew install <span className={styles.ctaArrow}>↗</span>
+        </a>
+      </div>
+    </nav>
+  );
+}
+
+function GitHubMark() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      aria-hidden="true"
+      className={styles.gh}
+    >
+      <path d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.42 7.42 0 0 1 4 0c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8a8 8 0 0 0-8-8z" />
+    </svg>
+  );
+}

--- a/site/components/sections/Problem.module.css
+++ b/site/components/sections/Problem.module.css
@@ -1,0 +1,38 @@
+.grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0;
+  border-top: 1px solid var(--line);
+  border-left: 1px solid var(--line);
+}
+
+.cell {
+  padding: 32px;
+  border-right: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.num {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--mute);
+  margin-bottom: 20px;
+}
+
+.title {
+  font-size: 19px;
+  margin: 0 0 10px;
+  letter-spacing: -0.01em;
+}
+
+.body {
+  color: var(--ink-2);
+  font-size: 15px;
+  margin: 0;
+}
+
+@media (max-width: 860px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/site/components/sections/Problem.tsx
+++ b/site/components/sections/Problem.tsx
@@ -1,0 +1,71 @@
+import { Container } from "../primitives/Container";
+import { Section } from "../primitives/Section";
+import { SectionHead } from "../primitives/SectionHead";
+import styles from "./Problem.module.css";
+
+const CELLS: readonly {
+  readonly num: string;
+  readonly subtitle: string;
+  readonly title: string;
+  readonly body: React.ReactNode;
+}[] = [
+  {
+    num: "01",
+    subtitle: "share with peers",
+    title: "Publish a skill.",
+    body: (
+      <>
+        Any git repo with a <code>SKILL.md</code> at the root is installable. Push to GitHub, send
+        the link — <code>crew install @you/skill</code> and your friend has it.
+      </>
+    ),
+  },
+  {
+    num: "02",
+    subtitle: "share with your team",
+    title: "Your skills repo is your registry.",
+    body: (
+      <>
+        Point crew at a shared repo — a <em>tap</em> — and everyone on the team pulls the same
+        skills, reviewed in PRs, versioned in git. Onboarding is one command.
+      </>
+    ),
+  },
+  {
+    num: "03",
+    subtitle: "share with the industry",
+    title: "Discover what actually works.",
+    body: (
+      <>
+        Browse the default <code>core</code> tap and community taps for battle-tested skills —
+        review conventions, language idioms, framework playbooks. Fork, tweak, publish your own.
+      </>
+    ),
+  },
+];
+
+export function Problem() {
+  return (
+    <Section id="why">
+      <Container>
+        <SectionHead
+          number="01"
+          label="Why crew"
+          title="Great skills exist. You should have them all."
+          description="Right now, the best prompts and agent playbooks either sit on one person's machine or get copy-pasted through gists and Slack messages that nobody keeps current. Crew gives them a format, a home, and a way to travel. Anyone can publish. Anyone can install."
+        />
+        <div className={styles.grid}>
+          {CELLS.map((c) => (
+            <div key={c.num} className={styles.cell}>
+              <div className={styles.num}>
+                {c.num} / {c.subtitle}
+              </div>
+              <h3 className={styles.title}>{c.title}</h3>
+              <p className={styles.body}>{c.body}</p>
+            </div>
+          ))}
+        </div>
+      </Container>
+    </Section>
+  );
+}

--- a/site/components/sections/Safety.module.css
+++ b/site/components/sections/Safety.module.css
@@ -1,0 +1,42 @@
+.grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0;
+  border-top: 1px solid var(--line);
+  border-left: 1px solid var(--line);
+}
+
+.item {
+  padding: 28px;
+  border-right: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.sym {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  padding: 3px 7px;
+  border: 1px solid var(--line-2);
+  border-radius: 3px;
+  color: var(--ink);
+  margin-bottom: 16px;
+  display: inline-block;
+}
+
+.title {
+  margin: 0 0 8px;
+  font-size: 16px;
+  letter-spacing: -0.01em;
+}
+
+.body {
+  margin: 0;
+  font-size: 14px;
+  color: var(--ink-2);
+}
+
+@media (max-width: 860px) {
+  .grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}

--- a/site/components/sections/Safety.tsx
+++ b/site/components/sections/Safety.tsx
@@ -1,0 +1,106 @@
+import type { ReactNode } from "react";
+import { Container } from "../primitives/Container";
+import { Section } from "../primitives/Section";
+import { SectionHead } from "../primitives/SectionHead";
+import styles from "./Safety.module.css";
+
+const ITEMS: readonly {
+  readonly sym: string;
+  readonly title: string;
+  readonly body: ReactNode;
+}[] = [
+  {
+    sym: "fs",
+    title: "No symlinks, ever.",
+    body: (
+      <>
+        Every install is a file copy. Upgrades atomically rename into place. You can{" "}
+        <code>rm -rf</code> a skill with no side effects.
+      </>
+    ),
+  },
+  {
+    sym: "exec",
+    title: "Never executes anything.",
+    body: "No post-install hooks, no build steps, no user-supplied scripts run by crew. It copies files. Agents are what run them.",
+  },
+  {
+    sym: "marker",
+    title: "Tracks what it wrote.",
+    body: (
+      <>
+        Every installed skill gets a <code>.crew.json</code> marker with its source, ref, SHA, and
+        content hash. Removing a skill removes only what crew created.
+      </>
+    ),
+  },
+  {
+    sym: "diff",
+    title: "Detects your edits.",
+    body: (
+      <>
+        On re-install, crew re-hashes the destination. If you've customized a managed skill, the
+        install is refused — unless you pass <code>--force</code>.
+      </>
+    ),
+  },
+  {
+    sym: "lock",
+    title: "Concurrency-safe.",
+    body: (
+      <>
+        Every write takes an advisory lock on <code>state.json.lock</code>. The background
+        autoupdater and your interactive shell can't stomp on each other.
+      </>
+    ),
+  },
+  {
+    sym: "sha",
+    title: "Reproducible versions.",
+    body: "Tags and branches resolve to full 40-char commit SHAs at install time. The SHA — not the tag — is what's recorded.",
+  },
+  {
+    sym: "scope",
+    title: "Owns only ~/.crew/.",
+    body: (
+      <>
+        Crew writes to its own directory and to each agent's skills directory. It won't touch your
+        global <code>AGENTS.md</code>, settings JSON, or anything else.
+      </>
+    ),
+  },
+  {
+    sym: "doctor",
+    title: "Auditable.",
+    body: (
+      <>
+        <code>crew doctor</code> reconciles state, markers, and agent directories.{" "}
+        <code>--repair</code> fixes drift without ever touching files you edited.
+      </>
+    ),
+  },
+];
+
+export function Safety() {
+  return (
+    <Section id="safety" ruleTop>
+      <Container>
+        <SectionHead
+          number="09"
+          label="Safety model"
+          title="Crew is a file copier."
+          description="Crew is a file copier. It doesn't execute your skills, your taps, or anything they pull in. It leaves a paper trail you can audit, and it refuses to overwrite anything it didn't install itself."
+        />
+        <div className={styles.grid}>
+          {ITEMS.map((i) => (
+            <div key={i.sym} className={styles.item}>
+              <span className={styles.sym}>{i.sym}</span>
+              <h4 className={styles.title}>{i.title}</h4>
+              <p className={styles.body}>{i.body}</p>
+            </div>
+          ))}
+        </div>
+      </Container>
+    </Section>
+  );
+}

--- a/site/components/sections/SkillMdExample.module.css
+++ b/site/components/sections/SkillMdExample.module.css
@@ -1,0 +1,18 @@
+.callouts {
+  margin-top: 32px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+}
+
+.cText {
+  margin: 0;
+  color: var(--ink-2);
+  font-size: 14.5px;
+}
+
+@media (max-width: 860px) {
+  .callouts {
+    grid-template-columns: 1fr;
+  }
+}

--- a/site/components/sections/SkillMdExample.tsx
+++ b/site/components/sections/SkillMdExample.tsx
@@ -1,0 +1,76 @@
+import { Cmt, CodeBlock, Key } from "../primitives/CodeBlock";
+import { Container } from "../primitives/Container";
+import { Eyebrow } from "../primitives/Eyebrow";
+import { Section } from "../primitives/Section";
+import { SectionHead } from "../primitives/SectionHead";
+import styles from "./SkillMdExample.module.css";
+
+export function SkillMdExample() {
+  return (
+    <Section id="skill-md" ruleTop>
+      <Container>
+        <SectionHead
+          number="10"
+          label="Anatomy of a skill"
+          title={
+            <>
+              No proprietary manifest. Just <code>SKILL.md</code>.
+            </>
+          }
+          description={
+            <>
+              Crew reads the{" "}
+              <a href="https://agentskills.io/specification">Agent Skills specification</a>{" "}
+              directly. Crew-specific metadata lives under <code>metadata.crew</code> so the skill
+              stays fully spec-compliant — readable by any agent, not just the ones crew installs
+              into.
+            </>
+          }
+        />
+
+        <CodeBlock variant="light">
+          {"---\n"}
+          <Key>name</Key>: founding-engineer
+          {"\n"}
+          <Key>description</Key>: Ship like a founding engineer. Use when scoping, writing, or
+          reviewing code at an early-stage company.
+          {"\n"}
+          <Key>license</Key>: MIT
+          {"\n"}
+          <Key>metadata</Key>:{"\n  "}
+          <Key>crew</Key>:{"\n    "}
+          <Key>homepage</Key>: https://github.com/jane/founding-engineer
+          {"\n    "}
+          <Key>dependencies</Key>:{"\n      - code-review\n      - @acme/skills//code-review@v1.0"}
+          {"\n---\n\n"}
+          <Cmt># Founding engineer mode</Cmt>
+          {"\n\nBias to action. The second-best solution shipped this week beats the"}
+          {"\nperfect one shipped next month. Prefer small, obvious PRs over clever"}
+          {"\nones. Delete code aggressively. Write the boring version first.\n\n"}
+          <Cmt># ...the rest of the skill body is whatever the agent needs to read.</Cmt>
+        </CodeBlock>
+
+        <div className={styles.callouts}>
+          <div>
+            <Eyebrow>homepage</Eyebrow>
+            <p className={styles.cText}>
+              Shown by <code>crew info</code> so people can find your docs.
+            </p>
+          </div>
+          <div>
+            <Eyebrow>dependencies</Eyebrow>
+            <p className={styles.cText}>
+              Other skills to pull in — by name, git URL, or path. Walked transitively.
+            </p>
+          </div>
+          <div>
+            <Eyebrow>versions</Eyebrow>
+            <p className={styles.cText}>
+              Every install pins to a git commit SHA. Pin to a tag with <code>@v1.0</code>.
+            </p>
+          </div>
+        </div>
+      </Container>
+    </Section>
+  );
+}

--- a/site/components/sections/SkillRefs.module.css
+++ b/site/components/sections/SkillRefs.module.css
@@ -1,0 +1,61 @@
+.grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+}
+
+.card {
+  background: #fff;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.kind {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--mute);
+  margin: 0;
+  font-weight: 600;
+}
+
+.title {
+  font-size: 20px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+
+.desc {
+  color: var(--ink-2);
+  font-size: 14.5px;
+  margin: 0;
+}
+
+.examples {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--ink);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.examples li::before {
+  content: "$ ";
+  color: var(--mute);
+}
+
+@media (max-width: 860px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/site/components/sections/SkillRefs.tsx
+++ b/site/components/sections/SkillRefs.tsx
@@ -1,0 +1,89 @@
+import { Container } from "../primitives/Container";
+import { Section } from "../primitives/Section";
+import { SectionHead } from "../primitives/SectionHead";
+import styles from "./SkillRefs.module.css";
+
+const CARDS: readonly {
+  readonly kind: string;
+  readonly title: string;
+  readonly desc: React.ReactNode;
+  readonly examples: readonly string[];
+}[] = [
+  {
+    kind: "Local path",
+    title: "./my-skill",
+    desc: (
+      <>
+        A directory on your machine. Detected by leading <code>./</code>, <code>../</code>,{" "}
+        <code>/</code>, or <code>~</code>. Tilde expands, relatives resolve against <code>cwd</code>
+        .
+      </>
+    ),
+    examples: ["crew install ./founding-engineer", "crew install ~/code/team-skills/code-review"],
+  },
+  {
+    kind: "Git source",
+    title: "@owner/repo",
+    desc: (
+      <>
+        Any reachable git URL. No tap setup required. <code>@owner/repo</code> is GitHub shorthand;
+        full <code>https://</code> and <code>git@</code> URLs work for anywhere else. Append{" "}
+        <code>@ref</code> to pin, <code>{"//subpath"}</code> to scope.
+      </>
+    ),
+    examples: [
+      "crew install @acme/skills",
+      "crew install @acme/skills@v1.2.0",
+      "crew install @acme/skills//engineers/founding",
+    ],
+  },
+  {
+    kind: "Tap source",
+    title: "founding-engineer",
+    desc: (
+      <>
+        A skill inside a configured tap. Bare names search every tap; qualify with{" "}
+        <code>tap/name</code> to be explicit. Pin with <code>@v1.0</code>.
+      </>
+    ),
+    examples: [
+      "crew install founding-engineer",
+      "crew install core/founding-engineer",
+      "crew install acme/code-review@v1.0",
+    ],
+  },
+];
+
+export function SkillRefs() {
+  return (
+    <Section id="refs" ruleTop>
+      <Container>
+        <SectionHead
+          number="04"
+          label="Skill references"
+          title="Three ways to point at a skill."
+          description={
+            <>
+              A reference is anything you can hand to <code>crew install</code> — and anything
+              another skill can list as a dependency. The grammar is small on purpose.
+            </>
+          }
+        />
+        <div className={styles.grid}>
+          {CARDS.map((c) => (
+            <div key={c.kind} className={styles.card}>
+              <h4 className={styles.kind}>{c.kind}</h4>
+              <p className={styles.title}>{c.title}</p>
+              <p className={styles.desc}>{c.desc}</p>
+              <ul className={styles.examples}>
+                {c.examples.map((e) => (
+                  <li key={e}>{e}</li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </Container>
+    </Section>
+  );
+}

--- a/site/components/sections/Taps.module.css
+++ b/site/components/sections/Taps.module.css
@@ -1,0 +1,17 @@
+.grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+}
+
+.note {
+  color: var(--ink-2);
+  margin-top: 20px;
+  font-size: 15px;
+}
+
+@media (max-width: 860px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/site/components/sections/Taps.tsx
+++ b/site/components/sections/Taps.tsx
@@ -1,0 +1,77 @@
+import { Acc, Cmt, CodeBlock, Key, Ok, Prompt } from "../primitives/CodeBlock";
+import { Container } from "../primitives/Container";
+import { Eyebrow } from "../primitives/Eyebrow";
+import { Section } from "../primitives/Section";
+import { SectionHead } from "../primitives/SectionHead";
+import styles from "./Taps.module.css";
+
+export function Taps() {
+  return (
+    <Section id="taps" ruleTop>
+      <Container>
+        <SectionHead
+          number="07"
+          label="Taps"
+          title="A tap is just a git repo full of skills."
+          description={
+            <>
+              No hosted registry, no server, no account. Your team's skills repo <em>is</em> the
+              package index. Fork it, branch it, review it in pull requests, and{" "}
+              <code>crew update</code> pulls it like any other.
+            </>
+          }
+        />
+
+        <div className={styles.grid}>
+          <div>
+            <Eyebrow>Repository shape</Eyebrow>
+            <CodeBlock variant="light">
+              {"acme-skills/\n├── README.md              "}
+              <Cmt># optional, informational</Cmt>
+              {"\n├── "}
+              <Acc>founding-engineer/</Acc>
+              {"\n│   └── SKILL.md\n├── "}
+              <Acc>code-review/</Acc>
+              {"\n│   └── SKILL.md\n├── "}
+              <Acc>platform-engineer/</Acc>
+              {"\n│   ├── SKILL.md\n│   └── playbook.md\n└── docs/\n    └── contributing.md    "}
+              <Cmt># ignored by crew search</Cmt>
+            </CodeBlock>
+            <p className={styles.note}>
+              Any top-level directory with a valid <code>SKILL.md</code> is a skill. Everything else
+              is ignored. You can still nest things — but only the top level is indexed.
+            </p>
+          </div>
+
+          <div>
+            <Eyebrow>Day one for a new teammate</Eyebrow>
+            <CodeBlock>
+              <Prompt /> crew tap add <Acc>@acme/skills</Acc>
+              {"\n"}
+              <Ok>✓</Ok> cloned <Key>acme</Key> → ~/.crew/taps/acme (42 skills)
+              {"\n\n"}
+              <Prompt /> crew install <Acc>acme/team-baseline</Acc>
+              {"\n"}
+              <Cmt># meta-skill pulling in everything the team considers standard</Cmt>
+              {"\n"}
+              <Cmt># (e.g. founding-engineer, code-review, pr-descriptions, on-call…)</Cmt>
+              {"\n"}
+              <Ok>✓</Ok> resolved 14 dependencies
+              {"\n"}
+              <Ok>✓</Ok> installed across every detected agent
+              {"\n\n"}
+              <Prompt /> crew autoupdate enable
+              {"\n"}
+              <Ok>✓</Ok> agent loaded · keeps skills current every 4h
+            </CodeBlock>
+            <p className={styles.note}>
+              A meta-skill is an ordinary skill whose body describes the team's conventions and
+              whose <code>dependencies</code> list pulls in the rest. Onboarding becomes one
+              command.
+            </p>
+          </div>
+        </div>
+      </Container>
+    </Section>
+  );
+}

--- a/site/components/sections/Teams.module.css
+++ b/site/components/sections/Teams.module.css
@@ -1,0 +1,40 @@
+.grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0;
+  border-top: 1px solid var(--line);
+  border-left: 1px solid var(--line);
+}
+
+.card {
+  padding: 32px;
+  border-right: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.title {
+  font-size: 24px;
+  letter-spacing: -0.015em;
+  margin: 0 0 12px;
+  line-height: 1.15;
+  font-weight: 600;
+  text-wrap: balance;
+  max-width: 16ch;
+}
+
+.body {
+  color: var(--ink-2);
+  font-size: 15px;
+  margin: 0;
+  line-height: 1.55;
+}
+
+.codeWrap {
+  margin-top: 40px;
+}
+
+@media (max-width: 860px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/site/components/sections/Teams.tsx
+++ b/site/components/sections/Teams.tsx
@@ -1,0 +1,100 @@
+import { Acc, Cmt, CodeBlock, Key, Ok, Prompt } from "../primitives/CodeBlock";
+import { Container } from "../primitives/Container";
+import { Eyebrow } from "../primitives/Eyebrow";
+import { Section } from "../primitives/Section";
+import { SectionHead } from "../primitives/SectionHead";
+import styles from "./Teams.module.css";
+
+const CARDS: readonly {
+  readonly kicker: string;
+  readonly title: string;
+  readonly body: React.ReactNode;
+}[] = [
+  {
+    kicker: "One repo, every laptop",
+    title: "Your team's skills repo is your registry.",
+    body: (
+      <>
+        Point crew at a private GitHub repo once. Every new skill that lands on <code>main</code>{" "}
+        shows up in everyone's <code>crew search</code>. No internal tool to build. No package
+        server to run.
+      </>
+    ),
+  },
+  {
+    kicker: "Onboarding, one command",
+    title: "New hires are productive on day one.",
+    body: (
+      <>
+        Publish a <code>team-baseline</code> meta-skill that depends on everything you consider
+        standard — review checklists, on-call playbooks, style guides. A single{" "}
+        <code>crew install</code> catches them up.
+      </>
+    ),
+  },
+  {
+    kicker: "Review in PRs",
+    title: "Skills get better like code does.",
+    body: (
+      <>
+        Propose a change to the team's prompt library the same way you propose a change to anything
+        else — a branch, a PR, comments, squash-merge. Everyone pulls the update on their next{" "}
+        <code>crew update</code>.
+      </>
+    ),
+  },
+  {
+    kicker: "Private by default",
+    title: "Internal stays internal.",
+    body: (
+      <>
+        Crew clones taps with whatever git credentials you already have. Your private repo stays
+        private — crew never phones home, never uploads, never indexes anything outside the machines
+        you install it on.
+      </>
+    ),
+  },
+];
+
+export function Teams() {
+  return (
+    <Section id="teams" ruleTop>
+      <Container>
+        <SectionHead
+          number="08"
+          label="For teams"
+          title="Fun for the whole team."
+          description="The best skills on your team are trapped in one engineer's shell history. Crew gives your team a shared shelf — a private git repo that everyone installs from, reviews in PRs, and keeps in sync without thinking about it."
+        />
+
+        <div className={styles.grid}>
+          {CARDS.map((c) => (
+            <div key={c.kicker} className={styles.card}>
+              <Eyebrow>{c.kicker}</Eyebrow>
+              <h3 className={styles.title}>{c.title}</h3>
+              <p className={styles.body}>{c.body}</p>
+            </div>
+          ))}
+        </div>
+
+        <div className={styles.codeWrap}>
+          <CodeBlock>
+            <Cmt># Monday, 9:04am. A new engineer opens their laptop.</Cmt>
+            {"\n"}
+            <Prompt /> crew tap add <Acc>@acme/skills</Acc>
+            {"\n"}
+            <Ok>✓</Ok> cloned <Key>acme</Key> → 42 skills available
+            {"\n\n"}
+            <Prompt /> crew install <Acc>acme/team-baseline</Acc>
+            {"\n"}
+            <Ok>✓</Ok> resolved 14 dependencies
+            {"\n"}
+            <Ok>✓</Ok> installed across every detected agent
+            {"\n\n"}
+            <Cmt># Monday, 9:06am. They know how the team ships code.</Cmt>
+          </CodeBlock>
+        </div>
+      </Container>
+    </Section>
+  );
+}

--- a/site/components/sections/ValueProp.module.css
+++ b/site/components/sections/ValueProp.module.css
@@ -1,0 +1,98 @@
+.section {
+  padding: 80px 0 88px;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  background:
+    radial-gradient(
+      1000px 300px at 15% 0%,
+      color-mix(in oklab, var(--accent) 10%, transparent),
+      transparent 60%
+    ),
+    var(--bg);
+}
+
+.label {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--mute);
+  margin: 0 0 28px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.label::before {
+  content: "";
+  width: 32px;
+  height: 1px;
+  background: var(--mute);
+}
+
+.title {
+  font-family: var(--font-sans);
+  font-weight: 600;
+  font-size: 64px;
+  line-height: 1.02;
+  letter-spacing: -0.035em;
+  margin: 0;
+  max-width: 980px;
+  text-wrap: balance;
+}
+
+.mark {
+  background: linear-gradient(
+    180deg,
+    transparent 62%,
+    color-mix(in oklab, var(--accent) 40%, transparent) 62%,
+    color-mix(in oklab, var(--accent) 40%, transparent) 94%,
+    transparent 94%
+  );
+  padding: 0 4px;
+}
+
+.sub {
+  margin: 28px 0 0;
+  font-size: 18px;
+  color: var(--ink-2);
+  max-width: 720px;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 16px;
+  align-items: start;
+}
+
+.sub::before {
+  content: "→";
+  font-family: var(--font-mono);
+  color: var(--accent-ink);
+  font-size: 20px;
+  line-height: 1.5;
+}
+
+.codePaper {
+  font-family: var(--font-mono);
+  background: #fff;
+  border: 1px solid var(--line);
+  padding: 1px 6px;
+  border-radius: 3px;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 32px;
+}
+
+.chips strong {
+  color: var(--ink);
+  font-weight: 600;
+}
+
+@media (max-width: 860px) {
+  .title {
+    font-size: 40px;
+  }
+}

--- a/site/components/sections/ValueProp.tsx
+++ b/site/components/sections/ValueProp.tsx
@@ -1,0 +1,38 @@
+import { Container } from "../primitives/Container";
+import { Pill } from "../primitives/Pill";
+import styles from "./ValueProp.module.css";
+
+export function ValueProp() {
+  return (
+    <section className={styles.section}>
+      <Container>
+        <p className={styles.label}>The whole idea, in one line</p>
+        <h2 className={styles.title}>
+          Crew turns <span className={styles.mark}>any&nbsp;git&nbsp;repo</span> into a registry of
+          agent skills.
+        </h2>
+        <p className={styles.sub}>
+          <span>
+            Push a <code className={styles.codePaper}>SKILL.md</code>. Share a link. That's the
+            package index. No servers, no accounts, no hosted registry — crew, the CLI, and every
+            skill you install are all open source under MIT.
+          </span>
+        </p>
+        <div className={styles.chips}>
+          <Pill>
+            <strong>open source</strong> · MIT
+          </Pill>
+          <Pill>
+            <strong>no hosted registry</strong> · git is the backend
+          </Pill>
+          <Pill>
+            <strong>no account</strong> · nothing to sign up for
+          </Pill>
+          <Pill>
+            <strong>no telemetry</strong> · crew never phones home
+          </Pill>
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/site/lib/agents.ts
+++ b/site/lib/agents.ts
@@ -1,0 +1,30 @@
+/**
+ * The agents crew installs into. Sourced from the §7.2 table in the
+ * CLI's PRD. Kept alphabetical so the rendered chips match `crew agents`.
+ */
+
+export interface Agent {
+  readonly name: string;
+  /** Human-readable display name, e.g. for richer UI. */
+  readonly display: string;
+}
+
+export const AGENTS: readonly Agent[] = [
+  { name: "amp", display: "Amp" },
+  { name: "autohand", display: "Autohand" },
+  { name: "claude-code", display: "Claude Code" },
+  { name: "codex", display: "Codex" },
+  { name: "command-code", display: "Command Code" },
+  { name: "cursor", display: "Cursor" },
+  { name: "factory", display: "Factory" },
+  { name: "gemini-cli", display: "Gemini CLI" },
+  { name: "github-copilot", display: "GitHub Copilot" },
+  { name: "goose", display: "Goose" },
+  { name: "junie", display: "Junie" },
+  { name: "kiro", display: "Kiro" },
+  { name: "mistral-vibe", display: "Mistral Vibe" },
+  { name: "nanobot", display: "Nanobot" },
+  { name: "opencode", display: "OpenCode" },
+  { name: "pi", display: "pi" },
+  { name: "roo-code", display: "Roo Code" },
+];

--- a/site/next.config.mjs
+++ b/site/next.config.mjs
@@ -1,0 +1,12 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  // Static-only landing page; no server components with runtime work,
+  // no API routes. Output a fully-static site that Vercel can edge-cache.
+  output: "export",
+  images: {
+    unoptimized: true,
+  },
+};
+
+export default nextConfig;

--- a/site/package.json
+++ b/site/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "crew-site",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Landing site for crew (https://crew.logic.inc).",
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "lint:fix": "biome check --write .",
+    "format": "biome format --write .",
+    "check": "bun run typecheck && bun run lint && bun run build"
+  },
+  "dependencies": {
+    "next": "^15.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.4.12",
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/site/styles/tokens.css
+++ b/site/styles/tokens.css
@@ -1,0 +1,41 @@
+/*
+ * Design tokens — the single source of truth for color, type, spacing,
+ * and radii. Every component reads these via `var(--foo)`. To retheme
+ * the whole site, edit this file.
+ */
+
+:root {
+  /* Ink & paper */
+  --bg: #faf8f5;
+  --ink: #17161a;
+  --ink-2: #3a3740;
+  --mute: #6e6a74;
+  --line: #e7e2d9;
+  --line-2: #d5cfc3;
+  --paper: #f2ede3;
+
+  /* Accent + semantic */
+  --accent: oklch(0.68 0.15 58);
+  --accent-ink: oklch(0.38 0.09 55);
+  --ok: oklch(0.6 0.12 150);
+  --warn: oklch(0.62 0.16 25);
+
+  /* Terminal palette */
+  --term-bg: #17161a;
+  --term-ink: #ece6d8;
+  --term-mute: #8a8478;
+  --term-ok: oklch(0.78 0.15 150);
+  --term-warn: oklch(0.78 0.17 60);
+  --term-accent: oklch(0.82 0.13 60);
+  --term-key: oklch(0.82 0.12 250);
+  --term-prompt: #d0c7b0;
+
+  /* Typography */
+  --font-sans: "Inter", system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, monospace;
+
+  /* Layout */
+  --wrap-max: 1160px;
+  --wrap-pad: 32px;
+  --nav-h: 56px;
+}

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -1,0 +1,33 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "jsx": "preserve",
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "noPropertyAccessFromIndexSignature": false,
+    "noImplicitReturns": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "useUnknownInCatchVariables": true,
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "incremental": true,
+    "noEmit": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/site/types/css-modules.d.ts
+++ b/site/types/css-modules.d.ts
@@ -1,0 +1,11 @@
+/**
+ * CSS Module imports. Next.js doesn't generate per-file typed bindings
+ * out of the box, so we treat module objects as plain Records. The
+ * `styles.foo` style stays ergonomic — if a class doesn't exist, the
+ * value is just `undefined` at runtime (React ignores undefined
+ * className values), which we'd catch visually while building.
+ */
+declare module "*.module.css" {
+  const classes: Record<string, string>;
+  export default classes;
+}


### PR DESCRIPTION
## Summary

- New self-contained Next.js 15 + React 19 sub-project at `site/` (own `package.json`, `tsconfig`, `biome.json`).
- Full conversion of the HTML design mock into React components: **17 design primitives** + **15 page sections**.
- CI workflow (`.github/workflows/site-ci.yml`) runs typecheck + lint + build on any change under `site/**`.
- Root `biome.json` excludes `site/` — the sub-project owns its own lint rules.

## Layout

\`\`\`
site/
├─ app/
│   ├─ layout.tsx             # fonts, metadata, <html>/<body>
│   ├─ page.tsx               # composes every section
│   └─ globals.css            # reset + tokens import
├─ styles/
│   └─ tokens.css             # single source of truth: palette, type, spacing
├─ components/
│   ├─ primitives/            # Brand, Button, Chip, CodeBlock, Container, Eyebrow,
│   │                         # Mono, Pill, Section, SectionHead, Terminal, TerminalLine
│   └─ sections/              # one file per page section, each composes primitives
└─ lib/
    └─ agents.ts              # the 17 agents, mirrors the CLI's registry
\`\`\`

## Design system

All design tokens live in \`styles/tokens.css\` as CSS custom properties (\`--bg\`, \`--ink\`, \`--accent\`, etc.). Every component reads them via \`var(--foo)\`. To retheme the whole site, edit that one file.

Each primitive is a colocated \`.tsx\` + \`.module.css\` pair. Section components compose primitives; \`page.tsx\` composes sections.

## Content

Preserved verbatim from the design mock, with small corrections to reflect the current CLI:
- \`crew targets\` → \`crew agents\` (the rename we landed earlier)
- Agents strip shows a subset of the 17 real adapters
- Default tap URL placeholders point at \`with-logic/crew-skills\`

Copy review and logo integration are a follow-up PR — this one is purely the scaffold + conversion.

## Build

- Next.js is configured for \`output: \"export\"\` so Vercel deploys as a fully static site.
- Local: \`cd site && bun run build\` produces \`site/out/\` (~117 KB index.html + shared JS chunks).
- No client-side JS needed beyond React hydration; the page is static content.

## Test plan

- [x] \`bun run typecheck\` clean.
- [x] \`bun run lint\` clean.
- [x] \`bun run build\` produces a static export with the expected content.
- [x] CLI's \`bun run check\` still passes at 100% coverage.
- [ ] Vercel preview build (will attach once the PR is open).