### PR TITLE
Design pass on the landing site

### DIFF
--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -23,8 +23,8 @@ export default function Page() {
       <main>
         <Hero />
         <AgentsStrip />
-        <ValueProp />
         <Install />
+        <ValueProp />
         <Problem />
         <HowItWorks />
         <SkillRefs />

--- a/site/components/sections/AgentsStrip.module.css
+++ b/site/components/sections/AgentsStrip.module.css
@@ -2,7 +2,7 @@
   display: flex;
   align-items: center;
   gap: 32px;
-  padding: 22px 0;
+  padding: 18px 0;
   font-family: var(--font-mono);
   font-size: 13px;
   color: var(--mute);

--- a/site/components/sections/Hero.module.css
+++ b/site/components/sections/Hero.module.css
@@ -1,5 +1,5 @@
 .hero {
-  padding: 56px 0 88px;
+  padding: 40px 0 48px;
   position: relative;
 }
 
@@ -62,6 +62,28 @@
   color: var(--accent-ink);
 }
 
+/*
+ * Stylized "crew" in the headline — reads as an inline code span the
+ * way Markdown renders `crew` on GitHub. Keeps the headline font size
+ * so it doesn't feel like a shrunk-down code pill; the subtle paper
+ * background + border + monospace face are the ligature between
+ * "this is the brand name" and "this is also the command you type."
+ */
+.brandCode {
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: 0.82em;
+  background: var(--paper);
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+  padding: 0.02em 0.18em 0.08em;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+  /* Slight optical lift so the border doesn't drop the baseline. */
+  vertical-align: 2px;
+  margin-right: 0.05em;
+}
+
 .lede {
   font-size: 20px;
   color: var(--ink-2);
@@ -85,7 +107,7 @@
   color: var(--mute);
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  margin-top: 36px;
+  margin-top: 28px;
 }
 
 .meta span {

--- a/site/components/sections/Hero.tsx
+++ b/site/components/sections/Hero.tsx
@@ -16,7 +16,8 @@ export function Hero() {
               <span className={styles.os}>MIT</span>
             </p>
             <h1 className={styles.title}>
-              Crew is a package manager <span className={styles.accent}>for agent skills</span>.
+              <code className={styles.brandCode}>crew</code> is a package manager{" "}
+              <span className={styles.accent}>for agent skills</span>.
             </h1>
             <p className={styles.lede}>
               Find great skills. Install them with one command into every coding agent on your

--- a/site/components/sections/Install.module.css
+++ b/site/components/sections/Install.module.css
@@ -4,33 +4,49 @@
   gap: 24px;
 }
 
-.requirements {
-  margin-top: 32px;
-  padding: 20px 24px;
-  background: var(--paper);
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  font-size: 14.5px;
-  color: var(--ink-2);
+/* Requirements pill: centered, pill-shaped, Apple glyph + one line. */
+.reqRow {
   display: flex;
-  gap: 20px;
-  align-items: flex-start;
+  justify-content: center;
+  margin-top: 28px;
 }
 
-.reqBadge {
+.reqPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
   font-family: var(--font-mono);
-  font-size: 11px;
-  color: var(--mute);
+  font-size: 12px;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  padding: 3px 7px;
+  color: var(--ink-2);
+  background: #fff;
   border: 1px solid var(--line-2);
-  border-radius: 3px;
-  flex-shrink: 0;
+  border-radius: 999px;
+  padding: 7px 14px 7px 12px;
 }
 
-.reqStrong {
+.apple {
   color: var(--ink);
+}
+
+/* Longer explanation of what gets installed / how to uninstall. Dim
+   copy under the requirements pill. */
+.footnote {
+  margin: 28px auto 0;
+  max-width: 720px;
+  text-align: center;
+  color: var(--mute);
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.footnote code {
+  font-family: var(--font-mono);
+  background: var(--paper);
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-size: 0.9em;
 }
 
 @media (max-width: 860px) {

--- a/site/components/sections/Install.tsx
+++ b/site/components/sections/Install.tsx
@@ -13,13 +13,7 @@ export function Install() {
           number="02"
           label="Installation"
           title="Installation."
-          description={
-            <>
-              A single macOS binary. Drops nothing on your system outside of <code>~/.crew/</code>{" "}
-              and whichever agent skills directories you install into. Uninstall with{" "}
-              <code>rm -rf ~/.crew &amp;&amp; rm /usr/local/bin/crew</code>.
-            </>
-          }
+          description="Two ways to get it. Pick one."
         />
 
         <div className={styles.grid}>
@@ -45,15 +39,34 @@ export function Install() {
           </div>
         </div>
 
-        <div className={styles.requirements}>
-          <span className={styles.reqBadge}>req</span>
-          <div>
-            <strong className={styles.reqStrong}>Requires:</strong> macOS 13+ (Ventura or later),{" "}
-            <code>git</code> on <code>PATH</code>, and <code>launchctl</code> (present on every
-            macOS). Linux and Windows support is tracked but not shipping in v1.
-          </div>
+        <div className={styles.reqRow}>
+          <span className={styles.reqPill}>
+            <AppleGlyph />
+            Requires macOS 13+
+          </span>
         </div>
+
+        <p className={styles.footnote}>
+          A single macOS binary. Drops nothing on your system outside of <code>~/.crew/</code> and
+          whichever agent skills directories you install into. Uninstall with{" "}
+          <code>rm -rf ~/.crew &amp;&amp; rm /usr/local/bin/crew</code>.
+        </p>
       </Container>
     </Section>
+  );
+}
+
+function AppleGlyph() {
+  return (
+    <svg
+      className={styles.apple}
+      width="14"
+      height="14"
+      viewBox="0 0 384 512"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z" />
+    </svg>
   );
 }

--- a/site/components/sections/Problem.tsx
+++ b/site/components/sections/Problem.tsx
@@ -51,8 +51,8 @@ export function Problem() {
         <SectionHead
           number="01"
           label="Why crew"
-          title="Great skills exist. You should have them all."
-          description="Right now, the best prompts and agent playbooks either sit on one person's machine or get copy-pasted through gists and Slack messages that nobody keeps current. Crew gives them a format, a home, and a way to travel. Anyone can publish. Anyone can install."
+          title="Great skills exist. You should have all of them."
+          description="Right now, the best prompts and agent playbooks either sit on one person's machine or get copy-pasted through gists and Slack messages that nobody keeps current. Crew gives them a home, a way to be shared, and kept up to date. Anyone can publish. Anyone can install."
         />
         <div className={styles.grid}>
           {CELLS.map((c) => (

--- a/site/components/sections/SkillRefs.tsx
+++ b/site/components/sections/SkillRefs.tsx
@@ -42,7 +42,8 @@ const CARDS: readonly {
     title: "founding-engineer",
     desc: (
       <>
-        A skill inside a configured tap. Bare names search every tap; qualify with{" "}
+        A skill inside a configured tap. Bare names search every tap — including the default{" "}
+        <code>core</code> tap, which ships with a curated set of battle-tested skills. Qualify with{" "}
         <code>tap/name</code> to be explicit. Pin with <code>@v1.0</code>.
       </>
     ),

--- a/site/public/install.sh
+++ b/site/public/install.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+#
+# crew installer.
+#
+# Usage:
+#   curl -fsSL https://crew.logic.inc/install.sh | sh
+#
+# What it does:
+#   1. Detects your macOS CPU architecture (arm64 or x86_64).
+#   2. Downloads the latest crew release from GitHub.
+#   3. Installs to $CREW_INSTALL_PREFIX (default: ~/.local/bin).
+#   4. Clears the macOS quarantine attribute so Gatekeeper doesn't
+#      block the first run.
+#   5. Tells you how to put the install dir on your PATH if it isn't.
+#
+# Safe to re-run — upgrades in place.
+#
+# Environment variables:
+#   CREW_INSTALL_PREFIX   Install dir. Default: $HOME/.local/bin.
+#   CREW_VERSION          Specific version to install (e.g. "v0.3.1").
+#                         Default: latest release.
+
+set -euo pipefail
+
+# ---------- Pretty output ------------------------------------------------
+
+BOLD=$(printf '\033[1m'); RESET=$(printf '\033[0m')
+DIM=$(printf '\033[2m');  RED=$(printf '\033[31m'); GREEN=$(printf '\033[32m')
+
+log()  { printf '%s==>%s %s\n' "$BOLD" "$RESET" "$*"; }
+ok()   { printf '%s✓%s %s\n' "$GREEN" "$RESET" "$*"; }
+warn() { printf '%s!%s %s\n' "$RED" "$RESET" "$*" >&2; }
+die()  { warn "$*"; exit 1; }
+
+# ---------- Prerequisites ------------------------------------------------
+
+[ "$(uname -s)" = "Darwin" ] || die "crew is macOS-only for now. Linux and Windows are tracked but not yet shipping."
+
+command -v curl >/dev/null 2>&1 || die "\`curl\` is required but not on PATH."
+
+arch="$(uname -m)"
+case "$arch" in
+  arm64)  asset="crew-macos-arm64" ;;
+  x86_64) asset="crew-macos-x64"   ;;
+  *) die "unsupported architecture: $arch" ;;
+esac
+
+# ---------- Resolve version and download URL ----------------------------
+
+repo="with-logic/crew"
+version="${CREW_VERSION:-}"
+
+if [ -z "$version" ]; then
+  log "Fetching latest release from github.com/$repo"
+  # The /releases/latest endpoint 302-redirects to /releases/tag/vX.Y.Z.
+  # Follow with -I so we get just headers, then parse the Location tail.
+  latest_url="$(curl -fsSLI -o /dev/null -w '%{url_effective}' "https://github.com/$repo/releases/latest")"
+  version="${latest_url##*/}"
+  [ -n "$version" ] || die "could not determine the latest release"
+fi
+
+url="https://github.com/$repo/releases/download/$version/$asset"
+log "Downloading $asset ($version)"
+
+# ---------- Download to a tmp file --------------------------------------
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+tmpfile="$tmpdir/crew"
+
+if ! curl -fsSL -o "$tmpfile" "$url"; then
+  die "download failed — $url was not reachable. Check the release page at https://github.com/$repo/releases for available versions."
+fi
+
+chmod +x "$tmpfile"
+
+# Clear macOS quarantine so Gatekeeper doesn't block the first run.
+# `xattr -dr com.apple.quarantine` is a no-op if the attribute isn't
+# set, so we don't need to check first.
+xattr -dr com.apple.quarantine "$tmpfile" 2>/dev/null || true
+
+# ---------- Install to prefix -------------------------------------------
+
+prefix="${CREW_INSTALL_PREFIX:-$HOME/.local/bin}"
+dest="$prefix/crew"
+
+mkdir -p "$prefix"
+mv "$tmpfile" "$dest"
+
+ok "installed crew to $dest"
+
+# Run it once to verify and print the version string.
+if "$dest" version >/dev/null 2>&1; then
+  ok "$("$dest" version)"
+else
+  warn "binary installed but \`$dest version\` failed. Try running it manually."
+fi
+
+# ---------- PATH hint ---------------------------------------------------
+
+case ":${PATH:-}:" in
+  *":$prefix:"*)
+    # Already on PATH — nothing to do.
+    :
+    ;;
+  *)
+    cat <<EOF
+
+${DIM}$prefix is not on your PATH.
+Add this to your shell profile (e.g. ~/.zshrc):
+
+    export PATH="$prefix:\$PATH"
+
+Then open a new terminal, or run:
+
+    export PATH="$prefix:\$PATH"
+${RESET}
+EOF
+    ;;
+esac
+
+log "Done. Try ${BOLD}crew help${RESET} to see what you can do."


### PR DESCRIPTION
Design + content iteration on \`site/\` per review feedback.

## Changes

**Hero**
- Style \`crew\` as inline code in the headline (\`<code>\` with a paper bg + border treatment), so it reads as both the brand name and the command you type.
- Reduce hero padding so the agents strip sits nearer the fold on a 13\" screen.

**Section order: Install now comes right after the agents strip**
- New order: Hero → Agents strip → Install → Value prop → Why crew → How it works → …

**Install section restructure**
- Section head shortened to *\"Two ways to get it. Pick one.\"*
- Homebrew + curl blocks sit directly under the head, no intervening copy.
- Requirements condensed to a centered Apple-glyph pill: *\"Requires macOS 13+\"*.
- The what-gets-installed / uninstall one-liner moves below the pill as dim centered copy.

**A working install script**
- \`site/public/install.sh\` → served at \`https://crew.logic.inc/install.sh\` by Next.js's static export.
- Detects arch (arm64 / x86_64), downloads the matching release binary from \`with-logic/crew\` GitHub releases, installs to \`\$HOME/.local/bin\` (overridable via \`CREW_INSTALL_PREFIX\`), clears macOS quarantine xattr so Gatekeeper doesn't block first run, prints a PATH hint if needed.
- \`CREW_VERSION\` env var can override \"latest\" if a user wants to pin.

**Copy edits**
- \"You should have them all.\" → \"You should have all of them.\"
- \"a format, a home, and a way to travel\" → \"a home, a way to be shared, and kept up to date\"
- Tap source card now mentions that the default \`core\` tap ships with a curated set of battle-tested skills.

## Deferred

- **Codesigning / notarization**: the install script clears the quarantine xattr, which is enough for most configurations. Proper Apple Developer ID codesigning is a separate PR (Apple Developer account, notarytool, GitHub secrets).
- **Real install.sh testing**: while \`with-logic/crew\` is private, the script's GitHub download URLs return 404 anonymously. Will work as soon as the repo flips to public.

## Test plan

- [x] \`bun run typecheck\` clean.
- [x] \`bun run lint\` clean.
- [x] \`bun run build\` produces a static export containing \`install.sh\` at the root.
- [x] \`bash -n install.sh\` syntax clean.
- [ ] Vercel preview build matches expectations (will attach once open).