### PR TITLE
Installer primes taps; site config + copy polish

### DIFF
--- a/site/components/sections/Teams.tsx
+++ b/site/components/sections/Teams.tsx
@@ -64,7 +64,7 @@ export function Teams() {
           number="08"
           label="For teams"
           title="Fun for the whole team."
-          description="The best skills on your team are trapped in one engineer's shell history. Crew gives your team a shared shelf — a private git repo that everyone installs from, reviews in PRs, and keeps in sync without thinking about it."
+          description="The best skills on your team are trapped on the other engineers' computers. Crew gives your team a shared shelf — a private git repo that everyone installs from, reviews in PRs, and keeps in sync without thinking about it."
         />
 
         <div className={styles.grid}>

--- a/site/next.config.mjs
+++ b/site/next.config.mjs
@@ -1,3 +1,8 @@
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
@@ -7,6 +12,9 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  // Pin the workspace root to site/. Otherwise Next.js walks up, finds
+  // the crew CLI's bun.lock one level higher, and guesses wrong.
+  outputFileTracingRoot: __dirname,
 };
 
 export default nextConfig;

--- a/site/public/install.sh
+++ b/site/public/install.sh
@@ -96,6 +96,17 @@ else
   warn "binary installed but \`$dest version\` failed. Try running it manually."
 fi
 
+# ---------- Prime the default taps --------------------------------------
+
+# Fetch the default tap(s) so `crew search` works immediately. Non-fatal
+# on network failure — a later `crew install` / `crew update` will retry.
+log "Fetching default skill taps"
+if "$dest" update >/dev/null 2>&1; then
+  ok "skill taps ready"
+else
+  warn "couldn't fetch taps right now — run \`crew update\` once you're online."
+fi
+
 # ---------- PATH hint ---------------------------------------------------
 
 case ":${PATH:-}:" in


### PR DESCRIPTION
## Summary

- **Installer**: `install.sh` now runs `crew update` after installing the binary so the default `core` tap is pre-fetched. `crew search` / `crew list-skills` work out of the box instead of showing an empty index until the first `crew update`. Non-fatal on network failure.
- **Next config**: pin `outputFileTracingRoot` to `site/`. Next.js was walking up and finding the crew CLI's `bun.lock`, warning about an ambiguous workspace root on every `bun run dev`.
- **Teams copy**: "trapped in one engineer's shell history" → "trapped on the other engineers' computers".

## Test plan

- [ ] Fresh install via `curl -fsSL .../install.sh | sh` prints `==> Fetching default skill taps` and `✓ skill taps ready`.
- [ ] `crew search` immediately after install returns skills.
- [ ] Installer still succeeds (exits 0) when the tap fetch fails — warning, not a hard error.
- [ ] `bun run dev` in `site/` no longer prints the "multiple lockfiles" warning.
- [ ] Teams section renders the new line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)