### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.4.0] — 2026-04-20
+
+### Added
+
+- `crew self-update` command: upgrade the `crew` binary from GitHub releases. `--check` reports available updates without downloading; `--version <tag>` pins a release; `--force` reinstalls. Atomic swap — the running process is unaffected.
+- Background new-version notice: each invocation spawns a detached subprocess (at most once per 24 h) to check for newer releases and prints a one-line stderr nudge when one exists. Suppressed in CI, non-TTY stderr, `--json`, `--quiet`, and via `CREW_NO_UPDATE_CHECK=1`.
+- `agent-skills` fallback adapter: installs skills to `~/.agents/skills/` for any SKILL.md-compliant agent not in crew's known adapter list. Activates only when no other adapter is detected; shows up in `crew agents`.
+- Installer (`install.sh`) now runs `crew update` after placing the binary to pre-fetch the default `core` tap, so `crew search` and `crew list-skills` work immediately on a fresh install. Network failure is non-fatal.
+- Site command reference now includes `crew tap update`, `crew autoupdate disable`, and `crew self-update`.
+
+### Changed
+
+- Config-validation and `--agent` resolver error messages changed from "target" / "unknown target" / "known targets" to "agent" to match the rest of the CLI.
+- `crew install` help summary broadened to reflect 15+ supported agents.
+- README: added curl installer snippet at the top and a `crew self-update` upgrade section.
+- Site `crew autoupdate enable` demo output corrected to match real CLI output.
+
+### Fixed
+
+- PRD / `state.json` marker field name corrected from `adapters` to `agents` (wire format was already `agents`; the spec and conformance criteria were wrong).
+
 ## [0.3.1] — 2026-04-20
 
 ### Added

--- a/PRD.md
+++ b/PRD.md
@@ -2,7 +2,7 @@
 
 **A package manager for Agent Skills.**
 
-Version: 0.3.1
+Version: 0.4.0
 Status: Specification, ready for implementation
 Platform: macOS (Apple Silicon and Intel)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crew",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "A package manager for Agent Skills",
   "type": "module",
   "module": "src/index.ts",

--- a/site/components/sections/Footer.tsx
+++ b/site/components/sections/Footer.tsx
@@ -1,3 +1,4 @@
+import { CREW_VERSION_TAG } from "../../lib/version";
 import { Brand } from "../primitives/Brand";
 import { Container } from "../primitives/Container";
 import styles from "./Footer.module.css";
@@ -63,7 +64,7 @@ export function Footer() {
           ))}
         </div>
         <div className={styles.bot}>
-          <span>crew · v0.3.1 · macOS (arm64, x86_64)</span>
+          <span>crew · {CREW_VERSION_TAG} · macOS (arm64, x86_64)</span>
           <span>$ crew help</span>
         </div>
       </Container>

--- a/site/components/sections/Nav.tsx
+++ b/site/components/sections/Nav.tsx
@@ -1,3 +1,4 @@
+import { CREW_VERSION_TAG } from "../../lib/version";
 import { Brand } from "../primitives/Brand";
 import styles from "./Nav.module.css";
 
@@ -14,7 +15,7 @@ export function Nav() {
     <nav className={styles.nav}>
       <div className={styles.inner}>
         <Brand href="/" />
-        <span className={styles.version}>v0.3.1</span>
+        <span className={styles.version}>{CREW_VERSION_TAG}</span>
         <div className={styles.links}>
           {LINKS.map((l) => (
             <a key={l.href} href={l.href}>

--- a/site/lib/version.ts
+++ b/site/lib/version.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * The crew version displayed in the site chrome (Nav, Footer, …).
+ *
+ * Sourced from `site/public/latest-version.json`, which the release
+ * script regenerates on every version bump. Reading it at build time
+ * inlines the tag into the static bundle so the site always advertises
+ * the latest shipped release.
+ */
+interface LatestVersion {
+  readonly tag_name: string;
+}
+
+const raw = readFileSync(join(process.cwd(), "public", "latest-version.json"), "utf8");
+const parsed = JSON.parse(raw) as LatestVersion;
+
+export const CREW_VERSION_TAG: string = parsed.tag_name;

--- a/site/public/latest-version.json
+++ b/site/public/latest-version.json
@@ -1,13 +1,13 @@
 {
-  "tag_name": "v0.3.1",
+  "tag_name": "v0.4.0",
   "assets": [
     {
       "name": "crew-macos-arm64",
-      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.3.1/crew-macos-arm64"
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.4.0/crew-macos-arm64"
     },
     {
       "name": "crew-macos-x64",
-      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.3.1/crew-macos-x64"
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.4.0/crew-macos-x64"
     }
   ]
 }

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -5,5 +5,5 @@
  * without touching anything else. The value written to the `installed_by`
  * marker field and printed by `crew version` is derived from here.
  */
-export const CREW_VERSION = "0.3.1";
+export const CREW_VERSION = "0.4.0";
 export const CREW_INSTALLED_BY = `crew/${CREW_VERSION}`;

--- a/tests/self-update/command.test.ts
+++ b/tests/self-update/command.test.ts
@@ -14,6 +14,7 @@ import { writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { runCli } from "../../src/cli/main.ts";
 import { CrewError } from "../../src/core/errors.ts";
+import { CREW_VERSION } from "../../src/core/version.ts";
 import { readVersionCheck, writeVersionCheck } from "../../src/self-update/check.ts";
 import {
   resetAssetDownloader,
@@ -61,6 +62,8 @@ function currentAssetName(): string {
   return process.arch === "arm64" ? "crew-macos-arm64" : "crew-macos-x64";
 }
 
+const RUNNING_TAG = `v${CREW_VERSION}`;
+
 describe("crew self-update --check", () => {
   test("prints a human-readable update-available summary and refreshes the record", () => {
     const home = makeCrewHome();
@@ -79,12 +82,12 @@ describe("crew self-update --check", () => {
   test("prints 'on the latest' when versions match", () => {
     const home = makeCrewHome();
     setReleaseFetcher(() => ({
-      tag: "v0.3.1",
+      tag: RUNNING_TAG,
       assets: { [currentAssetName()]: "https://example.com/asset" },
     }));
     const cap = captureStreams();
     runCli(["self-update", "--check"], { home, streams: cap.streams });
-    expect(cap.stdout()).toContain("You're on v0.3.1");
+    expect(cap.stdout()).toContain(`You're on ${RUNNING_TAG}`);
     expect(cap.stdout()).toContain("the latest");
   });
 
@@ -133,13 +136,13 @@ describe("crew self-update (full upgrade)", () => {
   test("'already on the latest' path prints a friendly message", () => {
     const home = makeCrewHome();
     setReleaseFetcher(() => ({
-      tag: "v0.3.1",
+      tag: RUNNING_TAG,
       assets: { [currentAssetName()]: "https://example.com/asset" },
     }));
     const cap = captureStreams();
     const code = runCli(["self-update"], { home, streams: cap.streams });
     expect(code).toBe(0);
-    expect(cap.stdout()).toContain("Already on v0.3.1");
+    expect(cap.stdout()).toContain(`Already on ${RUNNING_TAG}`);
   });
 
   test("network failure surfaces as self_update_unavailable (exit 5)", () => {
@@ -197,7 +200,7 @@ describe("post-command update notice", () => {
     const fetches: string[] = [];
     setReleaseFetcher((url) => {
       fetches.push(url);
-      return { tag: "v0.3.1", assets: {} };
+      return { tag: RUNNING_TAG, assets: {} };
     });
     const cap = captureStreams();
     // No record on disk → stale → should trigger one fetch.

--- a/tests/self-update/notice.test.ts
+++ b/tests/self-update/notice.test.ts
@@ -6,10 +6,13 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { CREW_VERSION } from "../../src/core/version.ts";
 import { writeVersionCheck } from "../../src/self-update/check.ts";
 import { resetReleaseFetcher, setReleaseFetcher } from "../../src/self-update/github.ts";
 import { maybeEmitUpdateNotice, type NoticeContext } from "../../src/self-update/notice.ts";
 import { captureStreams, makeCrewHome } from "../helpers/env.ts";
+
+const RUNNING_TAG = `v${CREW_VERSION}`;
 
 const savedEnv = {
   CREW_NOW: process.env["CREW_NOW"],
@@ -157,7 +160,7 @@ describe("maybeEmitUpdateNotice — fetch + emission", () => {
 
   test("no notice when cached tag matches running version", () => {
     const h = makeHarness();
-    writeVersionCheck("v0.3.1", h.home);
+    writeVersionCheck(RUNNING_TAG, h.home);
     maybeEmitUpdateNotice(h.ctx({ now: new Date("2026-04-20T12:00:00Z") }));
     expect(h.streams.stderr()).toBe("");
   });
@@ -170,7 +173,7 @@ describe("maybeEmitUpdateNotice — fetch + emission", () => {
   });
 
   test("no record + fetch says we're on latest: writes record, no notice", () => {
-    const h = makeHarness("v0.3.1");
+    const h = makeHarness(RUNNING_TAG);
     maybeEmitUpdateNotice(h.ctx());
     expect(h.fetches.length).toBe(1);
     expect(h.streams.stderr()).toBe("");
@@ -180,7 +183,7 @@ describe("maybeEmitUpdateNotice — fetch + emission", () => {
     const h = makeHarness("v99.99.99");
     // Record two days old with a stale tag
     process.env["CREW_NOW"] = "2026-04-18T00:00:00Z";
-    writeVersionCheck("v0.3.1", h.home);
+    writeVersionCheck(RUNNING_TAG, h.home);
     process.env["CREW_NOW"] = "2026-04-20T12:00:00Z";
     maybeEmitUpdateNotice(h.ctx({ now: new Date("2026-04-20T12:00:00Z") }));
     expect(h.fetches.length).toBe(1);
@@ -202,7 +205,7 @@ describe("maybeEmitUpdateNotice — fetch + emission", () => {
     // Old stale record with the current running version cached — after
     // a failed fetch we fall back to the stale value (no nag).
     process.env["CREW_NOW"] = "2026-04-18T00:00:00Z";
-    writeVersionCheck("v0.3.1", h.home);
+    writeVersionCheck(RUNNING_TAG, h.home);
     process.env["CREW_NOW"] = "2026-04-20T12:00:00Z";
     maybeEmitUpdateNotice(h.ctx({ now: new Date("2026-04-20T12:00:00Z") }));
     expect(h.fetches.length).toBe(1);


### PR DESCRIPTION
## What's new in 0.4.0

### Added

- **`crew self-update`** — upgrade the `crew` binary itself directly from GitHub releases. `--check` reports whether a newer version is available without downloading anything; `--version <tag>` pins a specific release; `--force` reinstalls the current version. The running process is never interrupted — the new binary is atomically swapped in after download.
- **Automatic new-version notice** — every `crew` invocation quietly checks for a newer release in the background and prints a one-line nudge on stderr when one is found. The check never blocks the command you're running. Suppressed in CI, non-TTY stderr, `--json`/`--quiet` modes, and via `CREW_NO_UPDATE_CHECK=1`.
- **`agent-skills` fallback adapter** — if you have a SKILL.md-compliant agent coder that `crew` doesn't explicitly know about yet, `crew install` now succeeds instead of bailing with `no_agents`. Skills land in `~/.agents/skills/` (the cross-tool spec path). The fallback activates only when no other adapter is detected, so existing Codex/Cursor/Gemini CLI users see no change.
- **Installer pre-fetches the default tap** — `install.sh` now runs `crew update` after placing the binary, so `crew search` and `crew list-skills` return results immediately on a fresh install rather than showing an empty index. Network failure is a warning, not a hard error.
- **Full command reference on the site** — `crew tap update`, `crew autoupdate disable`, and `crew self-update` were previously missing from the reference page; all three now appear in the correct groups.

### Changed

- Error messages that previously said "target" / "unknown target" / "known targets" now say "agent" — matching the rest of the CLI surface.
- `crew install` help text broadened from "Claude Code, Codex, Gemini — whichever ones you have" to reflect that 15+ agents are supported.
- README now includes the `curl` one-liner installer at the top and a `crew self-update` upgrade section.
- Site demo block for `crew autoupdate enable` rewritten to match real command output (the old output was fabricated).

### Fixed

- PRD marker field `adapters` renamed to `agents` to match what `state.json` actually writes — relevant if you inspect crew's state file or build tooling against it.