### PR TITLE
Hero terminal: show per-agent install rows

### DIFF
--- a/site/components/sections/Hero.tsx
+++ b/site/components/sections/Hero.tsx
@@ -65,13 +65,13 @@ function HeroTerminal() {
         <span className={styles.prompt}>&nbsp;</span>
         <span className={styles.ok}>✓</span>
         <span className={styles.out}>
-          codex &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;→ ~/.agents/skills/team-baseline
+          codex &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;→ ~/.agents/skills/team-baseline
         </span>
       </div>
       <div className={styles.line}>
         <span className={styles.prompt}>&nbsp;</span>
         <span className={styles.ok}>✓</span>
-        <span className={styles.out}>gemini-cli &nbsp;→ ~/.agents/skills/team-baseline</span>
+        <span className={styles.out}>gemini-cli &nbsp;&nbsp;→ ~/.agents/skills/team-baseline</span>
       </div>
       <div className={styles.line}>
         <span className={styles.prompt}>&nbsp;</span>

--- a/site/components/sections/Hero.tsx
+++ b/site/components/sections/Hero.tsx
@@ -59,7 +59,23 @@ function HeroTerminal() {
       <div className={styles.line}>
         <span className={styles.prompt}>&nbsp;</span>
         <span className={styles.ok}>✓</span>
-        <span className={styles.out}>installed across every detected agent</span>
+        <span className={styles.out}>claude-code &nbsp;→ ~/.claude/skills/team-baseline</span>
+      </div>
+      <div className={styles.line}>
+        <span className={styles.prompt}>&nbsp;</span>
+        <span className={styles.ok}>✓</span>
+        <span className={styles.out}>
+          codex &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;→ ~/.agents/skills/team-baseline
+        </span>
+      </div>
+      <div className={styles.line}>
+        <span className={styles.prompt}>&nbsp;</span>
+        <span className={styles.ok}>✓</span>
+        <span className={styles.out}>gemini-cli &nbsp;→ ~/.agents/skills/team-baseline</span>
+      </div>
+      <div className={styles.line}>
+        <span className={styles.prompt}>&nbsp;</span>
+        <span className={styles.dim}>installed in 3 agents · 0 skipped · 0 failed</span>
       </div>
       <div className={styles.line}>
         <span className={styles.prompt}>$</span>


### PR DESCRIPTION
## Summary

Replaces the single \`installed across every detected agent\` line in the hero terminal with explicit per-adapter rows (claude-code, codex, gemini-cli) plus a summary line — matching what the real CLI prints.

Before:

\`\`\`
$ crew install acme/team-baseline
✓ resolved 14 dependencies from tap acme
✓ installed across every detected agent
\`\`\`

After:

\`\`\`
$ crew install acme/team-baseline
✓ resolved 14 dependencies from tap acme
✓ claude-code   → ~/.claude/skills/team-baseline
✓ codex         → ~/.agents/skills/team-baseline
✓ gemini-cli    → ~/.agents/skills/team-baseline
  installed in 3 agents · 0 skipped · 0 failed
\`\`\`

Makes one of crew's differentiators (one install hits multiple agents) visible at a glance instead of implied.

One file changed: \`site/components/sections/Hero.tsx\`.

## Test plan

- [ ] Site typecheck + lint + build (\`bun run check\` in \`site/\`)
- [ ] Vercel preview: hero terminal renders cleanly with the new rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)