### PR TITLE
Pre-protection prep: Dependabot config + Site CI renames

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+# Dependabot configuration.
+#
+# Weekly cadence keeps PRs manageable on a small repo. Three ecosystems:
+#
+#   1. npm at the repo root — the crew CLI's deps (typescript, biome,
+#      bun types, etc.). Bun reads npm packages via the same registry.
+#   2. npm in `site/` — the Next.js landing site.
+#   3. github-actions — the workflows under `.github/workflows/`.
+#
+# Security advisories on any of these come in via Dependabot security
+# updates (enabled separately on the repo) regardless of this schedule.
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+
+  - package-ecosystem: "npm"
+    directory: "/site"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps(site)"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/site-ci.yml
+++ b/.github/workflows/site-ci.yml
@@ -1,16 +1,14 @@
 name: Site CI
 
+# Runs on every PR and push to main, regardless of which paths
+# changed. Branch protection requires this job's success context, so
+# path-filtering it would let CLI-only PRs slip through unblocked.
+
 on:
   pull_request:
     branches: [main]
-    paths:
-      - "site/**"
-      - ".github/workflows/site-ci.yml"
   push:
     branches: [main]
-    paths:
-      - "site/**"
-      - ".github/workflows/site-ci.yml"
 
 # Cancel in-progress runs on the same ref when a new push arrives.
 concurrency:
@@ -18,7 +16,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  check:
+  site-check:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     defaults:


### PR DESCRIPTION
Weekly cadence on npm (root), npm (site/), and github-actions. Security advisories continue to arrive separately via Dependabot security updates (enabled on the repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)