### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.5.0] — 2026-04-20
+
+### Changed
+
+- Hero terminal on the marketing site now displays explicit per-agent install rows (e.g. `claude-code`, `codex`, `gemini-cli`) plus a summary line, making crew's multi-agent install visible at a glance.
+- Site copy and README reframed around team sharing and user value: new tagline, reworked hero lede and terminal demo, value-first headlines, and four new FAQ entries covering comparisons with skills.sh / `gh skill`, private team repos, skill dependencies, and multi-agent install.
+
 ## [0.4.0] — 2026-04-20
 
 ### Added

--- a/PRD.md
+++ b/PRD.md
@@ -2,7 +2,7 @@
 
 **A package manager for Agent Skills.**
 
-Version: 0.4.0
+Version: 0.5.0
 Status: Specification, ready for implementation
 Platform: macOS (Apple Silicon and Intel)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crew",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A package manager for Agent Skills",
   "type": "module",
   "module": "src/index.ts",

--- a/site/public/latest-version.json
+++ b/site/public/latest-version.json
@@ -1,13 +1,13 @@
 {
-  "tag_name": "v0.4.0",
+  "tag_name": "v0.5.0",
   "assets": [
     {
       "name": "crew-macos-arm64",
-      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.4.0/crew-macos-arm64"
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.5.0/crew-macos-arm64"
     },
     {
       "name": "crew-macos-x64",
-      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.4.0/crew-macos-x64"
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.5.0/crew-macos-x64"
     }
   ]
 }

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -5,5 +5,5 @@
  * without touching anything else. The value written to the `installed_by`
  * marker field and printed by `crew version` is derived from here.
  */
-export const CREW_VERSION = "0.4.0";
+export const CREW_VERSION = "0.5.0";
 export const CREW_INSTALLED_BY = `crew/${CREW_VERSION}`;


### PR DESCRIPTION
## What's new in v0.5.0

### Changed

- **Website: hero terminal now shows per-agent install rows** — the landing page terminal demo was updated to display explicit install lines for each detected agent (claude-code, codex, gemini-cli) plus a summary line, making crew's multi-agent superpower visible at a glance instead of implied by a single vague line.
- **Website: messaging reframed around teams and value** — the tagline, hero copy, FAQ, and README now lead with what teams *get* (shared skills, zero-effort updates, consistent installs across every laptop and every coding agent) rather than how it works under the hood. Four new FAQ entries cover how crew compares to skills.sh / `gh skill`, private team repos, skill dependencies, and multi-agent install.