### PR TITLE
[LOG-4446] Tighten landing page copy and above-fold spacing

### DIFF
--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -19,21 +19,21 @@ const jetbrainsMono = JetBrains_Mono({
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://crew.logic.inc"),
-  title: "crew — helps teams share agent skills",
+  title: "crew — package manager for agent skills",
   description:
-    "Easily share skills across your team. One command to install. The same skills on every laptop, in every coding agent. Updated automatically.",
+    "Install, share, and update agent skills across Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, Goose, and more.",
   openGraph: {
-    title: "crew — helps teams share agent skills",
+    title: "crew — package manager for agent skills",
     description:
-      "Easily share skills across your team. One command to install. The same skills on every laptop, in every coding agent. Updated automatically.",
+      "Install personal skills, team taps, and git-hosted skill collections into every agent on your Mac.",
     type: "website",
     url: "https://crew.logic.inc",
   },
   twitter: {
     card: "summary_large_image",
-    title: "crew — helps teams share agent skills",
+    title: "crew — package manager for agent skills",
     description:
-      "Easily share skills across your team. One command to install. The same skills on every laptop, in every coding agent.",
+      "Install personal skills, team taps, and git-hosted skill collections into every agent on your Mac.",
   },
 };
 

--- a/site/components/sections/Agents.tsx
+++ b/site/components/sections/Agents.tsx
@@ -15,7 +15,7 @@ export function Agents() {
           description={
             <>
               Any agent coder that reads the{" "}
-              <a href="https://agentskills.io/specification">Agent Skills spec</a> is a valid
+              <a href="https://agentskills.io/specification">agent skills spec</a> is a valid
               target. Crew auto-detects the ones you already have and quietly skips the rest.
             </>
           }

--- a/site/components/sections/BottomCTA.module.css
+++ b/site/components/sections/BottomCTA.module.css
@@ -1,6 +1,11 @@
+.section {
+  padding-top: 24px;
+  padding-bottom: 64px;
+}
+
 .wrap {
   text-align: center;
-  padding: 48px 0;
+  padding: 8px 0 0;
 }
 
 .title {

--- a/site/components/sections/BottomCTA.tsx
+++ b/site/components/sections/BottomCTA.tsx
@@ -9,7 +9,7 @@ export function BottomCTA() {
     <Section tight ruleTop className={styles.section}>
       <Container>
         <div className={styles.wrap}>
-          <Eyebrow centered>Share agent skills across your team</Eyebrow>
+          <Eyebrow centered>A package manager for agent skills</Eyebrow>
           <h2 className={styles.title}>$ crew install &lt;skill&gt;</h2>
           <div className={styles.ctaRow}>
             <Button href="#install">Install crew</Button>

--- a/site/components/sections/BottomCTA.tsx
+++ b/site/components/sections/BottomCTA.tsx
@@ -6,7 +6,7 @@ import styles from "./BottomCTA.module.css";
 
 export function BottomCTA() {
   return (
-    <Section tight ruleTop>
+    <Section tight ruleTop className={styles.section}>
       <Container>
         <div className={styles.wrap}>
           <Eyebrow centered>Share agent skills across your team</Eyebrow>

--- a/site/components/sections/BuildItYourself.module.css
+++ b/site/components/sections/BuildItYourself.module.css
@@ -9,8 +9,8 @@
 }
 
 /* "Software-as-a-Prompt" pill sits on its own line, centered. Small,
-   subtle — signals "this is a secondary path" without hierarchy
-   competition against the install card above. */
+   subtle — signals "this is a secondary path" without fighting the
+   install card above. */
 .tagRow {
   display: flex;
   justify-content: center;
@@ -71,7 +71,7 @@
 }
 
 /* Clean outlined button on the page background — reads as a clickable
-   surface within the dashed paper card, no color competition with the
+   surface within the dashed paper card, no loud color next to the
    accent pill above. */
 .button {
   font-family: var(--font-mono);

--- a/site/components/sections/BuildItYourself.tsx
+++ b/site/components/sections/BuildItYourself.tsx
@@ -42,7 +42,7 @@ export function BuildItYourself({ prompt }: Props) {
       </div>
 
       <h3 id="saap-heading" className={styles.heading}>
-        Create Your Own From Scratch
+        Vibe Your Own
       </h3>
 
       <p className={styles.copy}>
@@ -51,7 +51,7 @@ export function BuildItYourself({ prompt }: Props) {
           PRD
         </a>
         . You can build your own from the same spec — in Go, Rust, Swift, or whatever else. The
-        button below copies a ready-to-paste prompt.
+        button below copies a ready-to-paste prompt for your agent of choice.
       </p>
 
       <div className={styles.buttonRow}>

--- a/site/components/sections/Demo.tsx
+++ b/site/components/sections/Demo.tsx
@@ -10,8 +10,8 @@ export function Demo() {
         <SectionHead
           number="05"
           label="A day with crew"
-          title="What using it actually feels like."
-          description="Six commands that cover 90% of needs."
+          title="The commands you'll use most."
+          description="Search, install, update, repeat."
         />
 
         <CodeBlock>

--- a/site/components/sections/Faq.tsx
+++ b/site/components/sections/Faq.tsx
@@ -51,6 +51,23 @@ const QAS: readonly QA[] = [
     ),
   },
   {
+    id: "solo",
+    q: "Is crew useful if I don't have a team?",
+    a: (
+      <>
+        <p>
+          Yes. Crew is still a package manager for your own skills. Install a skill once and it
+          lands in every detected agent. Add your personal skills repo as a tap and your library
+          becomes searchable. Use a baseline skill to recreate your setup on a new Mac.
+        </p>
+        <p>
+          The team features are the same primitives scaled up: git sources, taps, dependency
+          resolution, source tracking, autoupdate, and local-edit protection.
+        </p>
+      </>
+    ),
+  },
+  {
     id: "private-team",
     q: "How does crew work with a private team skills repo?",
     a: (
@@ -63,7 +80,8 @@ const QAS: readonly QA[] = [
         </p>
         <p>
           Every <code>main</code>-merge automatically becomes installable team-wide. Pair it with{" "}
-          <code>crew autoupdate enable</code> and everyone stays in sync without thinking about it.
+          <code>crew autoupdate enable</code> and every Mac pulls approved skill updates on the next
+          interval.
         </p>
       </>
     ),
@@ -94,7 +112,7 @@ const QAS: readonly QA[] = [
         <p>
           Yes. <code>crew install founding-engineer</code> copies the skill into Claude Code, Codex,
           Cursor, Gemini CLI, GitHub Copilot, Goose, and every other{" "}
-          <a href="#agents">supported agent</a> that's detected on the machine. Agents that share a
+          <a href="#agents">supported agent</a> detected on the machine. Agents that share a
           convention (e.g. most read <code>~/.agents/skills/</code>) get one physical copy; the
           install summary reports each adapter by name.
         </p>
@@ -124,40 +142,12 @@ const QAS: readonly QA[] = [
     ),
   },
   {
-    id: "new-agent",
-    q: "How do I add support for a new agent?",
-    a: (
-      <>
-        Write an adapter — six methods: <code>detect</code>, <code>user_path</code>,{" "}
-        <code>project_path</code>, <code>install</code>, <code>uninstall</code>,{" "}
-        <code>list_installed</code>. Register it. The install pipeline is tool-agnostic; adapters
-        just know where the files go.
-      </>
-    ),
-  },
-  {
     id: "registry",
     q: "Is there a hosted registry?",
     a: (
       <>
         No. The default tap <code>core</code> is a plain git repo. Anyone can host a tap — your
-        team, your company, yourself. Crew never phones home.
-      </>
-    ),
-  },
-  {
-    id: "update-skip",
-    q: (
-      <>
-        How does <code>crew update</code> know when to skip a skill?
-      </>
-    ),
-    a: (
-      <>
-        Skills pinned to an exact SHA are skipped unless <code>--force</code>. Skills pinned to a
-        tag are re-resolved: if the tag moved and <code>--force</code> is given, the new commit is
-        installed. Everything else (branches, default branches, bare tap references) updates to
-        whatever the ref resolves to now.
+        team, your company, yourself. Crew never phones home or uploads your skills.
       </>
     ),
   },
@@ -165,27 +155,6 @@ const QAS: readonly QA[] = [
     id: "platforms",
     q: "What about Linux? Windows?",
     a: "Future work. The v1 spec is macOS-only because launchd is the autoupdate mechanism and each agent adapter encodes platform-specific paths. Nothing in the core design is Mac-specific; it's a scope decision, not a technical one.",
-  },
-  {
-    id: "cross-tap-dep",
-    q: "Can a skill depend on another skill in a different tap?",
-    a: "Yes. Dependency references are full skill references — any form the CLI accepts. You can depend on a bare name (resolved across taps), a qualified tap name, a git URL with a ref, or a subpath inside a monorepo.",
-  },
-  {
-    id: "project-git",
-    q: (
-      <>
-        Does <code>project</code> scope interact with git?
-      </>
-    ),
-    a: (
-      <>
-        Not automatically. <code>--scope project</code> writes into the agent's project-local skills
-        directory relative to your current working directory. Whether you commit that directory is
-        up to you. Many teams do; it means cloning a repo gives you its skills, no{" "}
-        <code>crew install</code> required.
-      </>
-    ),
   },
 ];
 

--- a/site/components/sections/Footer.tsx
+++ b/site/components/sections/Footer.tsx
@@ -19,7 +19,7 @@ const COLUMNS: readonly {
   {
     title: "Resources",
     links: [
-      { href: "https://agentskills.io/specification", label: "Agent Skills spec" },
+      { href: "https://agentskills.io/specification", label: "agent skills spec" },
       { href: "#skill-md", label: "SKILL.md anatomy" },
       { href: "#faq", label: "FAQ" },
     ],
@@ -46,8 +46,8 @@ export function Footer() {
           <div>
             <Brand />
             <p className={styles.lede}>
-              A package manager for agent skills. Install once, everywhere. Ship skills like
-              packages. macOS-first, open source.
+              A macOS package manager for agent skills. Install once, share through git, keep every
+              agent current.
             </p>
           </div>
           {COLUMNS.map((c) => (

--- a/site/components/sections/Hero.module.css
+++ b/site/components/sections/Hero.module.css
@@ -1,5 +1,5 @@
 .hero {
-  padding: 40px 0 48px;
+  padding: 0 0 48px;
   position: relative;
 }
 

--- a/site/components/sections/Hero.tsx
+++ b/site/components/sections/Hero.tsx
@@ -14,10 +14,11 @@ export function Hero() {
               <span className={styles.accent}>share agent skills</span>.
             </h1>
             <p className={styles.lede}>
-              Easily discover and share skills across your team. One command to install. The same
-              skills on every laptop, in every coding agent. Updated automatically.
+              Install skills for yourself or create a shared tap for your team. Crew will keep your
+              skills up to date.
             </p>
             <div className={styles.ctaRow}>
+              <Button href="#install">Install crew</Button>
               <Button href="#how" variant="ghost">
                 How it works
               </Button>
@@ -35,13 +36,40 @@ function HeroTerminal() {
     <Terminal title="~/work · zsh">
       <div className={styles.line}>
         <span className={styles.prompt}>$</span>
+        <span className={styles.cmd}>crew install founding-engineer</span>
+      </div>
+      <div className={styles.line}>
+        <span className={styles.prompt}>&nbsp;</span>
+        <span className={styles.ok}>✓</span>
+        <span className={styles.out}>claude-code &nbsp;→ ~/.claude/skills/founding-engineer</span>
+      </div>
+      <div className={styles.line}>
+        <span className={styles.prompt}>&nbsp;</span>
+        <span className={styles.ok}>✓</span>
+        <span className={styles.out}>
+          codex &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;→ ~/.agents/skills/founding-engineer
+        </span>
+      </div>
+      <div className={styles.line}>
+        <span className={styles.prompt}>&nbsp;</span>
+        <span className={styles.ok}>✓</span>
+        <span className={styles.out}>
+          gemini-cli &nbsp;&nbsp;→ ~/.agents/skills/founding-engineer
+        </span>
+      </div>
+      <div className={styles.line}>
+        <span className={styles.prompt}>&nbsp;</span>
+        <span className={styles.dim}>installed in 5 agents · 0 skipped · 0 failed</span>
+      </div>
+      <div className={styles.line}>
+        <span className={styles.prompt}>$</span>
         <span className={styles.cmd}>crew tap add @acme/skills</span>
       </div>
       <div className={styles.line}>
         <span className={styles.prompt}>&nbsp;</span>
         <span className={styles.ok}>✓</span>
         <span className={styles.out}>
-          cloned <span className={styles.acc}>acme</span> → 42 skills available
+          cloned <span className={styles.acc}>acme</span> → 42 skills searchable
         </span>
       </div>
       <div className={styles.line}>
@@ -59,23 +87,7 @@ function HeroTerminal() {
       <div className={styles.line}>
         <span className={styles.prompt}>&nbsp;</span>
         <span className={styles.ok}>✓</span>
-        <span className={styles.out}>claude-code &nbsp;→ ~/.claude/skills/team-baseline</span>
-      </div>
-      <div className={styles.line}>
-        <span className={styles.prompt}>&nbsp;</span>
-        <span className={styles.ok}>✓</span>
-        <span className={styles.out}>
-          codex &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;→ ~/.agents/skills/team-baseline
-        </span>
-      </div>
-      <div className={styles.line}>
-        <span className={styles.prompt}>&nbsp;</span>
-        <span className={styles.ok}>✓</span>
-        <span className={styles.out}>gemini-cli &nbsp;&nbsp;→ ~/.agents/skills/team-baseline</span>
-      </div>
-      <div className={styles.line}>
-        <span className={styles.prompt}>&nbsp;</span>
-        <span className={styles.dim}>installed in 3 agents · 0 skipped · 0 failed</span>
+        <span className={styles.out}>installed team baseline across every detected agent</span>
       </div>
       <div className={styles.line}>
         <span className={styles.prompt}>$</span>

--- a/site/components/sections/HowItWorks.tsx
+++ b/site/components/sections/HowItWorks.tsx
@@ -13,9 +13,9 @@ const STEPS: readonly {
     title: "Find great skills.",
     body: (
       <>
-        Search across your team's private tap, the default <code>core</code> collection, and
-        anything else you've added. Browse what your team, favorite engineers, and the broader
-        community are publishing.
+        Search across your private taps, your team's repo, the default <code>core</code> collection,
+        and anything else you've added. Your personal library and shared team library use the same
+        command.
       </>
     ),
   },
@@ -36,8 +36,8 @@ const STEPS: readonly {
     body: (
       <>
         One <code>crew install</code> copies the skill into Claude Code, Codex, Cursor, Gemini CLI,
-        GitHub Copilot, Goose, and every other agent on your machine. Grab one skill, or a whole
-        collection at once.
+        GitHub Copilot, Goose, and every other supported agent detected on your machine. Grab one
+        skill, a local folder, a git repo, or a whole tap.
       </>
     ),
   },
@@ -82,7 +82,7 @@ export function HowItWorks() {
           number="03"
           label="How it works"
           title="Find, install, update. Repeat."
-          description="Four everyday motions. No manifest to learn, no plugins to configure — commands that do what they say, across every agent you use."
+          description="Five everyday motions. No proprietary manifest, no hosted account, no per-agent setup loop — just commands that do what they say."
         />
 
         <div className={styles.pipeline}>
@@ -112,7 +112,7 @@ export function HowItWorks() {
               <span className={styles.dEmph}>user</span> and{" "}
               <span className={styles.dEmph}>project</span> scope. Multiple agents that share the
               same convention (Codex, Cursor, Gemini, Goose, and others read{" "}
-              <code>~/.agents/skills/</code>) share a single install copy — one write, every agent.
+              <code>~/.agents/skills/</code>) share a single physical copy.
             </div>
           </aside>
         </div>

--- a/site/components/sections/Problem.tsx
+++ b/site/components/sections/Problem.tsx
@@ -11,34 +11,35 @@ const CELLS: readonly {
 }[] = [
   {
     num: "01",
-    subtitle: "share with peers",
-    title: "Publish a skill.",
+    subtitle: "use your own",
+    title: "Install skills without manual copying.",
     body: (
       <>
-        Any git repo with a <code>SKILL.md</code> at the root is installable. Push to GitHub, send
-        the link — <code>crew install @you/skill</code> and your friend has it.
+        Point crew at a local directory, a git repo, or a tap entry. It validates the{" "}
+        <code>SKILL.md</code>, copies it into the right agent directories, and records what it
+        wrote.
       </>
     ),
   },
   {
     num: "02",
-    subtitle: "share with your team",
+    subtitle: "share with a team",
     title: "Your skills repo is your registry.",
     body: (
       <>
-        Point crew at a shared repo — a <em>tap</em> — and everyone on the team pulls the same
-        skills, reviewed in PRs, versioned in git. Onboarding is one command.
+        Point crew at a shared repo — a <em>tap</em> — and everyone pulls the same skills, reviewed
+        in PRs and versioned in git. A baseline skill can onboard a new laptop in one command.
       </>
     ),
   },
   {
     num: "03",
-    subtitle: "share with the industry",
-    title: "Discover what actually works.",
+    subtitle: "stay current",
+    title: "Update skills like packages.",
     body: (
       <>
-        Browse the default <code>core</code> tap and community taps for battle-tested skills —
-        review conventions, language idioms, framework playbooks. Fork, tweak, publish your own.
+        <code>crew update</code> refreshes taps, resolves refs to commit SHAs, skips pinned skills,
+        and refuses to overwrite local edits unless you explicitly force it.
       </>
     ),
   },
@@ -51,8 +52,8 @@ export function Problem() {
         <SectionHead
           number="01"
           label="Why crew"
-          title="Your team has great skills. You should have all of them."
-          description="Right now, the best prompts and agent playbooks either sit on one person's machine or get copy-pasted through gists and Slack messages that nobody keeps current. Crew gives them a home, a way to be shared, and kept up to date. Anyone can publish. Anyone can install."
+          title="Package-manager workflows for agent skills."
+          description="The best prompts and agent playbooks often live as copied folders, gists, or private notes. Crew gives them install commands, source tracking, update behavior, and a git-native way to share them without a hosted registry."
         />
         <div className={styles.grid}>
           {CELLS.map((c) => (

--- a/site/components/sections/SkillMdExample.tsx
+++ b/site/components/sections/SkillMdExample.tsx
@@ -20,7 +20,7 @@ export function SkillMdExample() {
           description={
             <>
               Crew reads the{" "}
-              <a href="https://agentskills.io/specification">Agent Skills specification</a>{" "}
+              <a href="https://agentskills.io/specification">agent skills specification</a>{" "}
               directly. Crew-specific metadata lives under <code>metadata.crew</code> so the skill
               stays fully spec-compliant — readable by any agent, not just the ones crew installs
               into.

--- a/site/components/sections/Taps.tsx
+++ b/site/components/sections/Taps.tsx
@@ -15,9 +15,9 @@ export function Taps() {
           title="A tap is just a git repo full of skills."
           description={
             <>
-              No hosted registry, no server, no account. Your team's skills repo <em>is</em> the
-              package index. Fork it, branch it, review it in pull requests, and{" "}
-              <code>crew update</code> pulls it like any other.
+              No hosted registry, no server, no account. Your personal skills repo, team repo, or
+              public collection <em>is</em> the package index. Fork it, branch it, review it in pull
+              requests, and <code>crew update</code> pulls it like any other.
             </>
           }
         />
@@ -66,8 +66,8 @@ export function Taps() {
             </CodeBlock>
             <p className={styles.note}>
               A meta-skill is an ordinary skill whose body describes the team's conventions and
-              whose <code>dependencies</code> list pulls in the rest. Onboarding becomes one
-              command.
+              whose <code>dependencies</code> list pulls in the rest. The same pattern works for a
+              solo baseline: one command to recreate your preferred agent setup on a new Mac.
             </p>
           </div>
         </div>

--- a/site/components/sections/Teams.tsx
+++ b/site/components/sections/Teams.tsx
@@ -63,8 +63,8 @@ export function Teams() {
         <SectionHead
           number="08"
           label="For teams"
-          title="Fun for the whole team."
-          description="The best skills on your team are trapped on the other engineers' computers. Crew gives your team a shared shelf — a private git repo that everyone installs from, reviews in PRs, and keeps in sync without thinking about it."
+          title="Turn team know-how into installable skills."
+          description="Your team's best agent playbooks should not be trapped on one engineer's laptop. Crew turns a private git repo into a shared package source that people install from, review in PRs, and keep in sync without another internal service."
         />
 
         <div className={styles.grid}>

--- a/site/components/sections/ValueProp.tsx
+++ b/site/components/sections/ValueProp.tsx
@@ -8,24 +8,24 @@ export function ValueProp() {
       <Container>
         <p className={styles.label}>What is Crew?</p>
         <h2 className={styles.title}>
-          Crew turns <span className={styles.mark}>any&nbsp;git&nbsp;repo</span> into a registry of
-          agent skills.
+          Crew treats <span className={styles.mark}>agent&nbsp;skills</span> like packages.
         </h2>
         <p className={styles.sub}>
           <span>
-            Push a <code className={styles.codePaper}>SKILL.md</code>. Share a link. That's the
-            package index. No servers, no accounts, no hosted registry.
+            Install one skill for yourself, publish a repo for your team, or tap into a shared
+            collection. Git is the package index; <code className={styles.codePaper}>SKILL.md</code>{" "}
+            is the manifest.
           </span>
         </p>
         <div className={styles.chips}>
           <Pill>
-            <strong>no hosted registry</strong> · git is the backend
+            <strong>multi-agent</strong> · one install, every detected agent
+          </Pill>
+          <Pill>
+            <strong>team taps</strong> · private git repos become registries
           </Pill>
           <Pill>
             <strong>no telemetry</strong> · crew never phones home
-          </Pill>
-          <Pill>
-            <strong>open source</strong> · MIT
           </Pill>
         </div>
       </Container>

--- a/site/lib/prd.ts
+++ b/site/lib/prd.ts
@@ -12,7 +12,7 @@ import { join } from "node:path";
 export const PRD_CONTENT: string = readFileSync(join(process.cwd(), "..", "PRD.md"), "utf8");
 
 /** Preamble that frames the task for the agent. Prepended to the PRD. */
-export const SAAP_PREAMBLE = `You are going to implement a working \`crew\` — a package manager for Agent Skills (the SKILL.md spec at agentskills.io) — from the PRD that follows this preamble.
+export const SAAP_PREAMBLE = `You are going to implement a working \`crew\` — a package manager for agent skills (the SKILL.md spec at agentskills.io) — from the PRD that follows this preamble.
 
 Rules:
 - The PRD is the contract. Build to spec.


### PR DESCRIPTION

<img width="1512" height="857" alt="image" src="https://github.com/user-attachments/assets/f17c185f-c2fb-4f5a-950e-2e29be5397d8" />

## Summary
- Tighten the above-the-fold spacing between the bottom CTA and hero.
- Refresh landing page positioning around team skill sharing while preserving solo-user package-manager value.
- Update supporting copy for taps, workflow demo, FAQ, footer/metadata, and the PRD prompt callout.
- Normalize the phrase "agent skills" to lowercase in site copy.

## Test plan
- [x] `cd site && bun run check`
- [ ] Visually confirm the CTA and hero fit above the fold on a ~800px-tall viewport
- [ ] Review the landing page copy in browser for final wording