### PR TITLE
[LOG-4464] site: widen hero terminal

### DIFF
--- a/site/components/sections/Hero.module.css
+++ b/site/components/sections/Hero.module.css
@@ -5,8 +5,8 @@
 
 .grid {
   display: grid;
-  grid-template-columns: 1.15fr 1fr;
-  gap: 64px;
+  grid-template-columns: 1fr 1fr;
+  gap: 48px;
   align-items: start;
 }
 


### PR DESCRIPTION
Before:
<img width="1512" height="859" alt="image" src="https://github.com/user-attachments/assets/0c3365c3-c8ef-49b8-a52c-c38f92ceb896" />

After:
<img width="1512" height="857" alt="image" src="https://github.com/user-attachments/assets/6c294a11-0ce9-423e-adff-b5337a037687" />

## Summary
- Hero grid: `1.15fr 1fr` → `1fr 1fr`, gap `64px` → `48px`. Terminal picks up the extra width.

## Test plan
- [ ] Visually confirm the terminal is wider without the headline wrapping awkwardly
- [ ] Mobile (< 860px) still collapses to a single column

🤖 Generated with [Claude Code](https://claude.com/claude-code)