### PR TITLE
[LOG-4463] ci: add Claude Code PR review workflow

### DIFF
--- a/.github/pr-review-prompt.md
+++ b/.github/pr-review-prompt.md
@@ -1,0 +1,116 @@
+# PR Review Instructions
+
+You are reviewing a pull request for the `crew` repository. Your job
+is to provide actionable, specific feedback grounded in the project's
+documented standards.
+
+## Step 1: Read the project standards
+
+Before reviewing any code, read:
+
+1. `CLAUDE.md` — the contributor guide. Covers the working agreement
+   (PRD-first for externally-observable changes), architecture, the
+   200-line file cap, test philosophy (100% coverage enforced),
+   Biome/TypeScript strictness, and the common-changes table.
+2. `PRD.md` — the product requirements document. The spec is the
+   contract; changes that any conformant implementation would need to
+   make require a PRD update.
+3. `site/` is a Next.js sub-project (the landing page at
+   crew.logic.inc). It has its own conventions but no separate
+   CLAUDE.md — treat it as lighter-weight than `src/`.
+
+## Step 2: Understand the PR
+
+- Read the PR description and all changed files.
+- Identify the intent: new feature, bug fix, refactor, docs, copy
+  tweak, CI change, dependency bump.
+- Decide which standards are most relevant. A one-line copy change
+  doesn't need a test-coverage review; a new command does.
+
+## Step 3: Review against standards
+
+### Priority issues (always flag)
+
+- **PRD drift**: an externally-observable change to `src/` without a
+  corresponding `PRD.md` update, or a PRD change not reflected in
+  `src/` and `tests/`. CLAUDE.md's opening section defines what
+  triggers a PRD update — apply that test.
+- **Coverage gaps**: new code in `src/` without tests, or code
+  structured in a way that can't reach 100% coverage (see the
+  "coverage quirks" section in CLAUDE.md for the recurring
+  footguns — chained `.filter().map()`, closing braces on nested
+  blocks, exhaustive `switch` with unreachable `default`).
+- **File-size cap**: files over 200 lines. Hard rule, not a
+  preference. Suggest the split.
+- **Test anti-patterns**: mocking the filesystem, mocking `git` at
+  the spawnSync level, writing to real `~/.claude/skills/` or
+  `~/.agents/skills/`, unscoped `CREW_HOME`. Tests should use
+  `os.tmpdir()` and the `setGitRunner`/`setLaunchctlRunner` seams.
+- **Error handling**: `throw new Error(...)` for a user-visible
+  failure instead of `CrewError(code, message, details)`. Every
+  user-facing error needs a stable name (PRD §13) and exit code
+  (PRD §15).
+- **Security**: command injection, path traversal, following
+  symlinks out of a skill, shell-quoting issues in git invocations.
+
+### Important issues (flag when present)
+
+- `throw new Error` anywhere user-visible.
+- Default exports (we use named exports only).
+- `any` types without justification.
+- Filename-prefix grouping (e.g. `foo-checks.ts`, `foo-render.ts`)
+  instead of a `foo/` directory with `index.ts`.
+- Files without a top-of-file docstring explaining their role and
+  the PRD section(s) they implement.
+- Unnecessary comments that narrate what the code does (names and
+  types already convey that).
+- Re-exports used as an architectural layer rather than a
+  temporary compatibility shim.
+- A new dependency without justification. We hand-roll YAML and
+  argv parsing; a new library needs a real reason (widely used,
+  well maintained, solves a non-trivial problem).
+
+### Minor issues (mention briefly)
+
+- Import ordering, trailing whitespace, minor style — skip if
+  Biome would catch it.
+- Comment quality on a line-by-line basis — only flag if the
+  comment is actively misleading.
+
+### site/ sub-project specifics
+
+- Client vs. server component boundaries — only mark `"use client"`
+  if the component actually needs it.
+- CSS module naming: kebab-case in class names, camelCase in the
+  `styles.*` access.
+- Copy changes should match the rest of the site's voice (plain,
+  direct, no marketing puffery).
+
+## Step 4: Write the review
+
+Format as a GitHub PR review with inline comments where possible.
+
+- Be specific: reference the exact file and line; explain what and
+  why.
+- Be actionable: suggest the fix or the pattern.
+- Be proportional: blocking issues get detail; nits get one-liners.
+  Prefix non-blocking suggestions with `nit:`.
+- Be balanced: call out good patterns when you see them, without
+  padding.
+- Group related issues: if a pattern repeats, mention it once with
+  all the locations.
+
+## What NOT to do
+
+- Don't re-state standards as generic advice — tie every point to
+  a specific line of the diff.
+- Don't flag intentional design decisions without understanding
+  the context.
+- Don't suggest changes that conflict with the documented
+  standards.
+- Don't nitpick formatting that Biome handles.
+- Don't demand tests for test helpers or dev scripts that coverage
+  excludes.
+- Don't demand a PRD update for internal refactors, dependency
+  bumps, copy tweaks, or bug fixes that make behavior match the
+  existing spec. CLAUDE.md lists these exclusions explicitly.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,55 @@
+# Claude Code PR review — runs automatically on every opened PR.
+#
+# Posts a review with inline comments grounded in CLAUDE.md's working
+# agreement and standards. Uses sonnet (fast, cheap, plenty capable
+# for code review).
+name: Claude Code
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  claude-review-pr:
+    name: "Claude: Review new PR"
+    if: github.event_name == 'pull_request' && github.event.action == 'opened'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Read PR review prompt
+        id: read-prompt
+        run: |
+          {
+            echo 'prompt<<EOF'
+            cat .github/pr-review-prompt.md
+            echo
+            echo 'EOF'
+          } >> $GITHUB_OUTPUT
+
+      - name: Run Claude Code - Review PR
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: ${{ steps.read-prompt.outputs.prompt }}
+          path_to_bun_executable: ~/.bun/bin/bun
+          track_progress: 'true'
+          claude_args: |
+            --model claude-sonnet-4-6
+            --allowedTools Bash,View,WebFetch,WebSearch,Glob,Grep


### PR DESCRIPTION
## Summary
- New workflow `.github/workflows/claude.yml` runs on every opened PR and posts an inline review.
- New prompt `.github/pr-review-prompt.md` grounds the review in `CLAUDE.md` + `PRD.md` conventions (PRD-first rule, 200-line cap, 100% coverage, named exports, `CrewError`, site/ specifics).
- Uses `claude-sonnet-4-6`. Read-only tools only — no `Edit`/`Write`, so the action can't modify files.

## Before merging
- [ ] Add `ANTHROPIC_API_KEY` to the repo secrets (Settings → Secrets and variables → Actions).

## Test plan
- [ ] Open a trivial follow-up PR after merge and confirm Claude posts a review within a few minutes.
- [ ] Confirm the review comments reference specific lines and cite the relevant standards.

Prior art: `with-logic/api` and `with-logic/web`. This is a stripped-down version (PR review only, not @mentions or issue completion — easy to add later).

🤖 Generated with [Claude Code](https://claude.com/claude-code)