### PR TITLE
[LOG-4458] ci: create Linear tickets for PRs without a ticket marker

### DIFF
--- a/.github/workflows/create-linear-ticket.yml
+++ b/.github/workflows/create-linear-ticket.yml
@@ -98,7 +98,7 @@ jobs:
             // 2. Check for an existing ticket (idempotent on reruns).
             // We search on the PR URL appearing in the description.
             const existingData = await linear(
-              `query($teamId: String!, $needle: String!) {
+              `query($teamId: ID!, $needle: String!) {
                  issues(filter: {
                    team: { id: { eq: $teamId } },
                    description: { contains: $needle }
@@ -115,7 +115,7 @@ jobs:
               // 3. Create a ticket.
               const description = `${prBody}\n\nCreated from GitHub PR: ${repoOwner}/${repoName}#${prNumber}\n${prUrl}`;
               const createData = await linear(
-                `mutation($teamId: String!, $title: String!, $description: String!) {
+                `mutation($teamId: ID!, $title: String!, $description: String!) {
                    issueCreate(input: { teamId: $teamId, title: $title, description: $description }) {
                      success
                      issue { id identifier url number }

--- a/.github/workflows/create-linear-ticket.yml
+++ b/.github/workflows/create-linear-ticket.yml
@@ -1,13 +1,15 @@
 # Creates a Linear ticket for PRs that lack one.
 #
-# Policy: if the PR title already contains a ticket marker like
-# `[LOG-123]` (any team key), do nothing. If the title contains
-# `[NO-TICKET]`, the downstream action creates a Linear ticket and
-# rewrites the title. If the title has neither, the preceding step
-# prepends `[NO-TICKET]` so the downstream action picks it up.
+# Policy:
+#   - If the PR title already has a ticket marker like `[LOG-123]`,
+#     do nothing.
+#   - Otherwise (either `[NO-TICKET]` or no marker at all), create a
+#     Linear ticket, rewrite the title to `[LOG-N] <original>`, and
+#     post a comment linking to the ticket.
 #
-# This is the "missing-ticket === [NO-TICKET]" extension: you never
-# have to remember to type `[NO-TICKET]`.
+# Self-contained: talks directly to the Linear GraphQL API and the
+# GitHub API via github-script's preloaded octokit. No external action
+# dependency, no build step.
 name: Create Linear Ticket
 run-name: '${{ github.actor }} - Create Linear Ticket'
 
@@ -28,36 +30,123 @@ jobs:
     timeout-minutes: 2
     runs-on: ubuntu-latest
     steps:
-      # Normalize: if the title lacks a [XXX-N] ticket marker and
-      # doesn't already say [NO-TICKET], prepend [NO-TICKET]. The
-      # downstream action then handles it.
-      - name: Normalize PR title
-        if: github.event.pull_request.state == 'open'
+      - name: Create or find Linear ticket
         uses: actions/github-script@v7
         env:
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+          LINEAR_TEAM_KEY: ${{ vars.LINEAR_TEAM_KEY || 'LOG' }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const title = process.env.PR_TITLE || '';
-            const hasTicket = /\[[A-Z]+-\d+\]/.test(title);
-            const hasNoTicketMarker = title.includes('[NO-TICKET]');
-            if (hasTicket || hasNoTicketMarker) {
-              core.info(`Title already has a marker — leaving untouched: ${title}`);
+            const apiKey = process.env.LINEAR_API_KEY;
+            const teamKey = process.env.LINEAR_TEAM_KEY;
+            const prNumber = Number(process.env.PR_NUMBER);
+            const prTitle = process.env.PR_TITLE || '';
+            const prBody = process.env.PR_BODY || '';
+            const repoOwner = process.env.REPO_OWNER;
+            const repoName = process.env.REPO_NAME;
+
+            if (!apiKey) {
+              core.setFailed('LINEAR_API_KEY is not set');
               return;
             }
-            const newTitle = `[NO-TICKET] ${title}`.trim();
-            core.info(`Prepending [NO-TICKET] → ${newTitle}`);
+
+            // A title "has a ticket" iff it contains [XXX-N] with any
+            // uppercase team key. If so, do nothing.
+            const hasTicket = /\[[A-Z]+-\d+\]/.test(prTitle);
+            if (hasTicket) {
+              core.info(`PR title already has a ticket marker — skipping: ${prTitle}`);
+              return;
+            }
+
+            // Strip [NO-TICKET] if present; the rest is the clean title.
+            const cleanTitle = prTitle.replace(/\[NO-TICKET\]/i, '').trim();
+            const prUrl = `https://github.com/${repoOwner}/${repoName}/pull/${prNumber}`;
+
+            async function linear(query, variables) {
+              const res = await fetch('https://api.linear.app/graphql', {
+                method: 'POST',
+                headers: {
+                  'Content-Type': 'application/json',
+                  'Authorization': apiKey,
+                },
+                body: JSON.stringify({ query, variables }),
+              });
+              const json = await res.json();
+              if (json.errors) {
+                throw new Error(`Linear API error: ${JSON.stringify(json.errors)}`);
+              }
+              return json.data;
+            }
+
+            // 1. Resolve the team by key.
+            const teamsData = await linear(`
+              query { teams { nodes { id key } } }
+            `);
+            const team = teamsData.teams.nodes.find((t) => t.key === teamKey);
+            if (!team) {
+              const available = teamsData.teams.nodes.map((t) => t.key).join(', ');
+              core.setFailed(`Team ${teamKey} not found. Available: ${available}`);
+              return;
+            }
+
+            // 2. Check for an existing ticket (idempotent on reruns).
+            // We search on the PR URL appearing in the description.
+            const existingData = await linear(
+              `query($teamId: String!, $needle: String!) {
+                 issues(filter: {
+                   team: { id: { eq: $teamId } },
+                   description: { contains: $needle }
+                 }) { nodes { id identifier url number } }
+               }`,
+              { teamId: team.id, needle: `${repoOwner}/${repoName}/pull/${prNumber}` }
+            );
+
+            let ticket;
+            if (existingData.issues.nodes.length > 0) {
+              ticket = existingData.issues.nodes[0];
+              core.info(`Found existing Linear ticket: ${ticket.identifier}`);
+            } else {
+              // 3. Create a ticket.
+              const description = `${prBody}\n\nCreated from GitHub PR: ${repoOwner}/${repoName}#${prNumber}\n${prUrl}`;
+              const createData = await linear(
+                `mutation($teamId: String!, $title: String!, $description: String!) {
+                   issueCreate(input: { teamId: $teamId, title: $title, description: $description }) {
+                     success
+                     issue { id identifier url number }
+                   }
+                 }`,
+                { teamId: team.id, title: cleanTitle, description }
+              );
+              if (!createData.issueCreate.success || !createData.issueCreate.issue) {
+                core.setFailed('Linear issueCreate returned success=false');
+                return;
+              }
+              ticket = createData.issueCreate.issue;
+              core.info(`Created Linear ticket: ${ticket.identifier}`);
+            }
+
+            // 4. Rewrite the PR title.
+            const newTitle = `[${ticket.identifier}] ${cleanTitle}`;
             await github.rest.pulls.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
+              owner: repoOwner,
+              repo: repoName,
+              pull_number: prNumber,
               title: newTitle,
             });
 
-      - name: Create Linear Ticket
-        uses: with-logic/pipeline@v1.0.0
-        with:
-          linear_api_key: '${{ secrets.LINEAR_API_KEY }}'
-          linear_team_key: "${{ vars.LINEAR_TEAM_KEY || 'LOG' }}"
-          github_token: '${{ secrets.GITHUB_TOKEN }}'
+            // 5. Comment with the ticket link (only when newly created,
+            // to avoid repeated comments on rerun).
+            if (existingData.issues.nodes.length === 0) {
+              await github.rest.issues.createComment({
+                owner: repoOwner,
+                repo: repoName,
+                issue_number: prNumber,
+                body: `Created Linear ticket: [${ticket.identifier}](${ticket.url})`,
+              });
+            }

--- a/.github/workflows/create-linear-ticket.yml
+++ b/.github/workflows/create-linear-ticket.yml
@@ -1,0 +1,63 @@
+# Creates a Linear ticket for PRs that lack one.
+#
+# Policy: if the PR title already contains a ticket marker like
+# `[LOG-123]` (any team key), do nothing. If the title contains
+# `[NO-TICKET]`, the downstream action creates a Linear ticket and
+# rewrites the title. If the title has neither, the preceding step
+# prepends `[NO-TICKET]` so the downstream action picks it up.
+#
+# This is the "missing-ticket === [NO-TICKET]" extension: you never
+# have to remember to type `[NO-TICKET]`.
+name: Create Linear Ticket
+run-name: '${{ github.actor }} - Create Linear Ticket'
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: 'linear-ticket-${{ github.event.pull_request.number }}'
+  cancel-in-progress: true
+
+jobs:
+  create-linear-ticket:
+    timeout-minutes: 2
+    runs-on: ubuntu-latest
+    steps:
+      # Normalize: if the title lacks a [XXX-N] ticket marker and
+      # doesn't already say [NO-TICKET], prepend [NO-TICKET]. The
+      # downstream action then handles it.
+      - name: Normalize PR title
+        if: github.event.pull_request.state == 'open'
+        uses: actions/github-script@v7
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const title = process.env.PR_TITLE || '';
+            const hasTicket = /\[[A-Z]+-\d+\]/.test(title);
+            const hasNoTicketMarker = title.includes('[NO-TICKET]');
+            if (hasTicket || hasNoTicketMarker) {
+              core.info(`Title already has a marker — leaving untouched: ${title}`);
+              return;
+            }
+            const newTitle = `[NO-TICKET] ${title}`.trim();
+            core.info(`Prepending [NO-TICKET] → ${newTitle}`);
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              title: newTitle,
+            });
+
+      - name: Create Linear Ticket
+        uses: with-logic/pipeline@v1.0.0
+        with:
+          linear_api_key: '${{ secrets.LINEAR_API_KEY }}'
+          linear_team_key: "${{ vars.LINEAR_TEAM_KEY || 'LOG' }}"
+          github_token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/create-linear-ticket.yml
+++ b/.github/workflows/create-linear-ticket.yml
@@ -115,7 +115,7 @@ jobs:
               // 3. Create a ticket.
               const description = `${prBody}\n\nCreated from GitHub PR: ${repoOwner}/${repoName}#${prNumber}\n${prUrl}`;
               const createData = await linear(
-                `mutation($teamId: ID!, $title: String!, $description: String!) {
+                `mutation($teamId: String!, $title: String!, $description: String!) {
                    issueCreate(input: { teamId: $teamId, title: $title, description: $description }) {
                      success
                      issue { id identifier url number }


### PR DESCRIPTION
## Summary
- New workflow `.github/workflows/create-linear-ticket.yml` runs on opened/edited/synchronize.
- **Self-contained** — talks directly to Linear's GraphQL API and GitHub's REST API via `actions/github-script@v7`'s preloaded octokit. No dependency on `with-logic/pipeline` (which this public repo can't resolve).
- Folds the "missing-ticket treated as `[NO-TICKET]`" rule in: a title has a ticket iff it matches `[XXX-N]`; otherwise we always create one, whether or not `[NO-TICKET]` is present.

## Behavior
| Title | Action |
| --- | --- |
| `[LOG-42] fix bug` | no-op — already has a ticket |
| `[NO-TICKET] something` | create ticket, rewrite to `[LOG-N] something` |
| `ci: add workflow` | create ticket, rewrite to `[LOG-N] ci: add workflow` |

The search query is idempotent (looks for the PR URL in a ticket description), so reruns on `edited`/`synchronize` don't create duplicates.

## Why inlined instead of using `with-logic/pipeline`
The pipeline action is private and its `access_level` is `organization`, which should in theory allow this repo to consume it — but in practice the runner fails with `Unable to resolve action with-logic/pipeline, not found` from this public repo. Inlining sidesteps the access question entirely, keeps the workflow readable, and lets us extend the behavior (the "missing-ticket" rule) without cross-repo changes.

## Before merging
- [x] Add `LINEAR_API_KEY` to repo secrets.
- [ ] Optional: set `LINEAR_TEAM_KEY` repo variable (defaults to `LOG`).

## Test plan
- [x] Workflow succeeded on this PR (ticket `LOG-4458` created, title rewritten, comment posted).
- [ ] After merge, open a trivial PR without a ticket marker and confirm a new Linear ticket is created.
- [ ] After merge, open a PR with `[LOG-N]` already in the title and confirm the workflow is a no-op.

&#x1F916; Generated with [Claude Code](https://claude.com/claude-code)
