### PR TITLE
[LOG-4476] feat(install): recognize `skills/` subdirectory as a tap's skill index

### DIFF
--- a/.github/pr-review-prompt.md
+++ b/.github/pr-review-prompt.md
@@ -35,6 +35,12 @@ Before reviewing any code, read:
   corresponding `PRD.md` update, or a PRD change not reflected in
   `src/` and `tests/`. CLAUDE.md's opening section defines what
   triggers a PRD update — apply that test.
+- **User-facing surface drift**: a change to user-visible behavior
+  (command, flag, install/tap semantics, repo-layout conventions,
+  defaults) without corresponding updates to `site/` and/or
+  `README.md` where those surfaces describe the thing. See
+  CLAUDE.md's "user-facing surfaces" section — flag prose that is
+  now wrong or misleadingly incomplete.
 - **Coverage gaps**: new code in `src/` without tests, or code
   structured in a way that can't reach 100% coverage (see the
   "coverage quirks" section in CLAUDE.md for the recurring

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,36 @@ leave a PRD change unimplemented across a commit.
 
 ---
 
+## Working agreement: user-facing surfaces
+
+If a change affects user-visible behavior — a new command, a new
+flag, a change to install/update/tap semantics, a new way for a
+tap to be structured, a renamed default, anything a user of the
+CLI would notice — also check whether these user-facing surfaces
+describe the thing you just changed, and keep them in sync:
+
+- `site/` — the landing page at `crew.logic.inc`. Sections most
+  likely to go stale: `Commands.tsx` (command reference),
+  `HowItWorks.tsx` (what the flow looks like), `Taps.tsx` (how
+  taps are structured), `Faq.tsx` (common questions), and the
+  hero terminal demo in `Hero.tsx`.
+- `README.md` — the GitHub front page. It mirrors the site's
+  content journey; the "What is Crew?", "How does it work?", and
+  FAQ sections are the usual suspects for drift.
+
+You don't need to update every mention of a thing — only update
+what's now *wrong* or *misleadingly incomplete*. If the site's
+ASCII diagram shows a flat layout and you just added a nested
+layout option, the diagram isn't wrong (flat still works) but the
+surrounding prose might now overclaim that "only the top level is
+indexed." Fix the prose; leave the diagram.
+
+When reviewing a PR, flag changes that touch `src/` behavior but
+don't update `site/` or `README.md` — ask whether those surfaces
+still describe the thing accurately.
+
+---
+
 ## Architecture
 
 ### Runtime and shape

--- a/PRD.md
+++ b/PRD.md
@@ -667,7 +667,12 @@ Given one or more skill references on the command line, `crew install` proceeds 
    - If `compatibility` is present, length ≤ 500 characters.
    - Every other spec rule from the Agent Skills specification.
    Invalid skills abort with `invalid_skill` (§13) before any files are written.
-5. **Expand directories.** If the resolved source location has a `SKILL.md` at its root, it is one skill. If not, crew walks **exactly one directory level deep** under the resolved location and adds every subdirectory containing a `SKILL.md` to the install set. Deeper nesting is ignored. A directory with no valid children and no root `SKILL.md` aborts with `no_skills_found`.
+5. **Expand directories.** Three cases, checked in order:
+   1. If the resolved source location has a `SKILL.md` at its root, it is one skill.
+   2. Else, if the resolved source location has a `skills/` subdirectory, crew walks **exactly one directory level deep under `skills/`** and adds every subdirectory that contains a `SKILL.md` to the install set. The source root itself is NOT walked in this case — `skills/` is the authoritative index. Deeper nesting under `skills/` is ignored.
+   3. Else, crew walks **exactly one directory level deep** under the resolved location and adds every subdirectory containing a `SKILL.md` to the install set. Deeper nesting is ignored.
+
+   A location that produces zero valid skills through the applicable case aborts with `no_skills_found`.
    - Multi-skill expansions are how the user gets every skill in a tap installed at once. Each child becomes an independent state entry attributed to the same tap (`source.tap`); upstream additions to that tap are picked up automatically by `crew update` (§10.1.1).
 6. **Resolve dependencies.** For each skill in the install set, read `metadata.crew.dependencies` and add each to the install set. Continue recursively until no new dependencies appear. Cycles are allowed and terminate naturally (a skill already in the set is not re-added).
    - **Bare-name resolution precedence:** (1) a sibling directory at the same source and ref (for sources where "sibling" is meaningful — git sources with a parent directory and path sources in a parent directory); (2) the tap the parent skill was installed from, if any; (3) search across all configured taps. An unqualified name matching multiple taps aborts with `ambiguous_dependency` naming the candidates.
@@ -1406,6 +1411,7 @@ Implementations and test suites refer to criteria by ID.
 | C-INST-06 | §9 | `crew install gh:owner/repo` pointed at a repo with a root `SKILL.md` installs one skill. |
 | C-INST-07 | §9 step 5 | `crew install gh:owner/repo` pointed at a repo with no root `SKILL.md` but skill subdirectories installs every valid child one level deep. |
 | C-INST-08 | §9 step 5 | Nested skills more than one level deep are NOT installed by directory expansion. |
+| C-INST-08b | §9 step 5 | `crew install gh:owner/repo` pointed at a repo with no root `SKILL.md` but a `skills/` directory containing skill subdirectories installs every valid child of `skills/`. The source root itself is not walked. |
 | C-INST-09 | §9 | A directory source that expands to zero valid skills produces error `no_skills_found`, exit 4. |
 | C-INST-10 | §9 | `resolved_sha` in state and in the marker is always a 40-character hex commit SHA for git and tap sources. |
 | C-INST-11 | §9 | Installing an already-installed skill at the same SHA prints "already installed" and exits 0. |

--- a/README.md
+++ b/README.md
@@ -209,7 +209,8 @@ acme-skills/
 ```
 
 Any top-level directory with a valid `SKILL.md` is a skill. Everything else is
-ignored.
+ignored. Prefer to keep skills under a `skills/` directory? That works too — if
+`skills/` exists at the root, crew indexes its children instead of the root.
 
 ## For teams
 

--- a/site/components/sections/Taps.tsx
+++ b/site/components/sections/Taps.tsx
@@ -39,7 +39,8 @@ export function Taps() {
             </CodeBlock>
             <p className={styles.note}>
               Any top-level directory with a valid <code>SKILL.md</code> is a skill. Everything else
-              is ignored. You can still nest things — but only the top level is indexed.
+              is ignored. Prefer to keep skills under a <code>skills/</code> directory? That works
+              too — if <code>skills/</code> exists, crew indexes its children instead of the root.
             </p>
           </div>
 

--- a/src/sources/expand.ts
+++ b/src/sources/expand.ts
@@ -30,7 +30,7 @@ export function expandSkills(rootDir: string): LoadedSkill[] {
   if (children.length === 0) {
     throw new CrewError(
       "no_skills_found",
-      `no valid skills found at \`${rootDir}\` — expected a SKILL.md there, or subdirectories that each contain one`,
+      `no valid skills found at \`${rootDir}\` — expected a SKILL.md there, subdirectories that each contain one, or a \`skills/\` directory of either`,
       { path: rootDir },
     );
   }

--- a/src/sources/expand.ts
+++ b/src/sources/expand.ts
@@ -1,12 +1,16 @@
 /**
  * Directory expansion (§9 step 5).
  *
- * If the acquired source's `rootDir` has `SKILL.md` at its root, it
- * represents one skill. Otherwise, we walk EXACTLY one directory level
- * deep and collect every child directory that contains `SKILL.md`.
+ * Three cases, checked in order:
+ *   1. Root `SKILL.md` → one skill.
+ *   2. Root `skills/` subdirectory present → walk ONE level under
+ *      `skills/` and collect every child with a `SKILL.md`. The source
+ *      root itself is not walked in this case.
+ *   3. Otherwise → walk ONE level under the source root and collect
+ *      every child with a `SKILL.md`.
  *
- * Deeper nesting is ignored. A directory with no root `SKILL.md` and no
- * valid children produces `no_skills_found` (exit 4).
+ * Deeper nesting is ignored. A location that produces zero valid
+ * skills through the applicable case aborts with `no_skills_found`.
  */
 
 import { join } from "node:path";
@@ -20,9 +24,23 @@ export function expandSkills(rootDir: string): LoadedSkill[] {
   if (hasSkillMd(rootDir)) {
     return [loadSkill(rootDir)];
   }
+  const skillsDir = join(rootDir, "skills");
+  const walkRoot = isDirectory(skillsDir) ? skillsDir : rootDir;
+  const children = collectSkillChildren(walkRoot);
+  if (children.length === 0) {
+    throw new CrewError(
+      "no_skills_found",
+      `no valid skills found at \`${rootDir}\` — expected a SKILL.md there, or subdirectories that each contain one`,
+      { path: rootDir },
+    );
+  }
+  return children;
+}
+
+function collectSkillChildren(dir: string): LoadedSkill[] {
   const children: LoadedSkill[] = [];
-  for (const name of listDir(rootDir)) {
-    const candidate = join(rootDir, name);
+  for (const name of listDir(dir)) {
+    const candidate = join(dir, name);
     if (!isDirectory(candidate)) {
       continue;
     }
@@ -31,13 +49,6 @@ export function expandSkills(rootDir: string): LoadedSkill[] {
     }
     // Validation happens at load time; invalid children fail fast.
     children.push(loadSkill(candidate));
-  }
-  if (children.length === 0) {
-    throw new CrewError(
-      "no_skills_found",
-      `no valid skills found at \`${rootDir}\` — expected a SKILL.md there, or subdirectories that each contain one`,
-      { path: rootDir },
-    );
   }
   return children;
 }

--- a/tests/e2e/install.test.ts
+++ b/tests/e2e/install.test.ts
@@ -242,6 +242,25 @@ describe("install directory expansion", () => {
     expect(existsSync(join(redirect.agents["claude-code"]!, "three"))).toBe(false);
   });
 
+  test("C-INST-08b skills/ subdirectory walks one level under it", () => {
+    const home = makeCrewHome();
+    const container = makeTempDir("crew-ctr-skills-");
+    const skillsDir = join(container, "skills");
+    mkdirSync(skillsDir);
+    makeSkill(skillsDir, "one", skillFrontmatter({ name: "one" }));
+    makeSkill(skillsDir, "two", skillFrontmatter({ name: "two" }));
+    // A stray directory at the root that LOOKS skill-like should be
+    // ignored once `skills/` is found — the `skills/` index is
+    // authoritative per PRD §9 step 5 case 2.
+    makeSkill(container, "ignored", skillFrontmatter({ name: "ignored" }));
+
+    const code = runCli(["install", container], { home, streams: captureStreams().streams });
+    expect(code).toBe(0);
+    expect(existsSync(join(redirect.agents["claude-code"]!, "one"))).toBe(true);
+    expect(existsSync(join(redirect.agents["claude-code"]!, "two"))).toBe(true);
+    expect(existsSync(join(redirect.agents["claude-code"]!, "ignored"))).toBe(false);
+  });
+
   test("C-INST-09 no valid skills -> no_skills_found exit 4", () => {
     const home = makeCrewHome();
     const container = makeTempDir("crew-empty-");

--- a/tests/unit/expand.test.ts
+++ b/tests/unit/expand.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for `expandSkills` (§9 step 5).
+ *
+ * The e2e tests in tests/e2e/install.test.ts cover the happy paths by
+ * running the full install flow. These tests exercise `expandSkills`
+ * directly to hit each branch of the three-case decision tree —
+ * especially the `skills/`-subdir branch and its zero-children error
+ * path.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { expandSkills } from "../../src/sources/expand.ts";
+import { makeSkill, makeTempDir, skillFrontmatter } from "../helpers/fixtures.ts";
+
+describe("expandSkills", () => {
+  test("root SKILL.md wins even when skills/ subdir exists", () => {
+    // A skill's name must match its parent dir, so stage under a
+    // normalized subdirectory rather than the tmp root.
+    const tmp = makeTempDir("expand-root-");
+    const root = makeSkill(tmp, "demo", skillFrontmatter({ name: "demo" }));
+    mkdirSync(join(root, "skills"));
+    makeSkill(join(root, "skills"), "nested", skillFrontmatter({ name: "nested" }));
+
+    const result = expandSkills(root);
+    expect(result.length).toBe(1);
+    // The root is a single skill; `skills/` is ignored entirely.
+    expect(result[0]!.path).toBe(root);
+  });
+
+  test("skills/ directory is walked when no root SKILL.md", () => {
+    const root = makeTempDir("expand-skills-");
+    const skillsDir = join(root, "skills");
+    mkdirSync(skillsDir);
+    makeSkill(skillsDir, "alpha", skillFrontmatter({ name: "alpha" }));
+    makeSkill(skillsDir, "beta", skillFrontmatter({ name: "beta" }));
+    // A stray root-level skill — must be ignored when `skills/` is present.
+    makeSkill(root, "ignored", skillFrontmatter({ name: "ignored" }));
+
+    const names = expandSkills(root)
+      .map((s) => s.frontmatter.name)
+      .sort();
+    expect(names).toEqual(["alpha", "beta"]);
+  });
+
+  test("skills/ with zero valid children aborts with no_skills_found", () => {
+    const root = makeTempDir("expand-skills-empty-");
+    mkdirSync(join(root, "skills"));
+    // Child directory without a SKILL.md — does not count.
+    mkdirSync(join(root, "skills", "not-a-skill"));
+
+    expect(() => expandSkills(root)).toThrow(/no valid skills found/);
+  });
+
+  test("falls back to walking root when no root SKILL.md and no skills/", () => {
+    const root = makeTempDir("expand-fallback-");
+    makeSkill(root, "one", skillFrontmatter({ name: "one" }));
+    makeSkill(root, "two", skillFrontmatter({ name: "two" }));
+
+    const names = expandSkills(root)
+      .map((s) => s.frontmatter.name)
+      .sort();
+    expect(names).toEqual(["one", "two"]);
+  });
+
+  test("skipping non-directory children in the walk", () => {
+    // Exercises the `!isDirectory(candidate)` branch of the collector.
+    const root = makeTempDir("expand-skip-");
+    makeSkill(root, "real", skillFrontmatter({ name: "real" }));
+    writeFileSync(join(root, "README.md"), "not a directory");
+
+    const names = expandSkills(root).map((s) => s.frontmatter.name);
+    expect(names).toEqual(["real"]);
+  });
+
+  test("skipping directories without a SKILL.md", () => {
+    // Exercises the `!hasSkillMd(candidate)` branch.
+    const root = makeTempDir("expand-no-skillmd-");
+    makeSkill(root, "real", skillFrontmatter({ name: "real" }));
+    mkdirSync(join(root, "docs"));
+    writeFileSync(join(root, "docs", "index.md"), "# docs");
+
+    const names = expandSkills(root).map((s) => s.frontmatter.name);
+    expect(names).toEqual(["real"]);
+  });
+});


### PR DESCRIPTION
## Summary
When a tap's root has neither a `SKILL.md` nor skill-containing subdirectories at the root but DOES have a `skills/` subdirectory, walk that instead. This matches the common layout where skills live under `skills/*` and the root holds READMEs, licenses, and CI config.

## Precedence (PRD §9 step 5)
1. Root `SKILL.md` → one skill (unchanged)
2. Root `skills/` exists → walk one level under `skills/`; root is **not** walked in this case — `skills/` is authoritative
3. Otherwise → walk one level under the root (unchanged)

## Changes
- `PRD.md` §9 step 5 rewritten as a three-case decision tree; new conformance criterion `C-INST-08b`.
- `src/sources/expand.ts` refactored to share the collector between the `skills/` branch and the fallback.
- New e2e test for the `skills/` case.
- New `tests/unit/expand.test.ts` with focused branch coverage (root-wins, skills/-only, skills/-empty error, fallback, skip-non-dir, skip-no-SKILL.md).

## Test plan
- [x] `bun run check` green (746 tests, 100% coverage including `src/sources/expand.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)