### PR TITLE
[LOG-4505] feat(install): render already-installed skills as full per-agent blocks

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -687,7 +687,8 @@ Given one or more skill references on the command line, `crew install` proceeds 
    - `description` is present, non-empty, length ≤ 1024 characters.
    - If `compatibility` is present, length ≤ 500 characters.
    - Every other spec rule from the Agent Skills specification.
-   Invalid skills abort with `invalid_skill` (§13) before any files are written.
+
+   A skill that fails validation is recorded as a failed skill with its message and path; the run continues. No validation failure aborts the whole command. See the exit-code rules in step 9.
 5. **Expand directories.** Three cases, checked in order:
    1. If the resolved source location has a `SKILL.md` at its root, it is one skill.
    2. Else, if the resolved source location has a `skills/` subdirectory, crew walks under `skills/` and collects skills:
@@ -705,6 +706,18 @@ Given one or more skill references on the command line, `crew install` proceeds 
 7. **Determine agent set.** Start with every agent whose `detect()` returns true or that appears in `forced_agents`. Remove any listed in `disabled_agents`. Apply `--agent` restrictions if given. If this produces the empty set, abort with `no_agents`.
 8. **Stage into the store.** For each skill in the install set, create `~/.crew/store/<name>@<short-sha>/` (where `<short-sha>` is the first 8 chars of `resolved_sha`) and copy the skill's files into it. If the store entry already exists and its content hash matches, reuse it.
 9. **Install into each agent.** For each skill × each agent in the agent set × the scope, run the install algorithm from §7.3. Record per-agent results (success, skipped-customized, skipped-untracked, failed). A failure in one (skill, agent) pair does not stop others.
+
+   **Skill outcome.** After per-agent installs complete, each attempted skill has one of two outcomes:
+   - **succeeded** — the skill validated AND at least one agent install succeeded (`anySuccess` in the per-skill record).
+   - **failed** — the skill failed validation, OR every agent install failed, OR the skill was otherwise prevented from landing anywhere.
+
+   **Exit code.** `crew install` computes its exit code from the set of attempted skills:
+   - `0` — every attempted skill succeeded (or no work was needed because everything was already installed).
+   - `1` — at least one skill succeeded AND at least one skill failed (partial success).
+   - `4` — zero skills succeeded AND at least one skill failed validation. The error name is `invalid_skill` (§13).
+   - `1` — zero skills succeeded AND no validation failures occurred (purely operational failures — agent errors, source unreachable, etc.).
+
+   The human output always renders a per-skill line noting whether each attempted skill succeeded or failed, with the failure reason for each failed skill. `--json` emits a `results` array with the same per-skill outcomes.
 10. **Update state.** For each successfully installed (skill, agent) pair, add or replace the entry in `state.json` per §11.1. Do this under the state lock (§14).
     - Skills named directly on the command line (the "roots") are
       recorded with `explicit: true`. Skills pulled in only via
@@ -1450,6 +1463,9 @@ Implementations and test suites refer to criteria by ID.
 | C-INST-17 | §9 | `--scope project` writes to the agent's project-scope path instead of the user-scope path. |
 | C-INST-18 | §11.1 | A project-scope install records `project_root` in the state entry equal to the user's working directory at install time. User-scope installs do NOT have a `project_root`. |
 | C-INST-19 | §9 | `state.json` may contain multiple project-scope entries for the same skill name, each with a different `project_root` — they're independent installs, not duplicates. |
+| C-INST-20 | §9 step 9 | A validation failure on any skill is recorded as a failed skill; the run continues through the remaining skills. It does not abort the command. |
+| C-INST-21 | §9 step 9 | Exit codes: `0` if every attempted skill succeeded; `1` if some succeeded and some failed; `4` with error `invalid_skill` if zero succeeded and ≥1 failed validation; `1` if zero succeeded and all failures were operational (non-validation). |
+| C-INST-22 | §9 step 9 | Every attempted skill appears in the human output with a per-skill success/failure line. `--json` includes a `results` array with the same per-skill outcomes. |
 
 #### C-NS: Namespaces (§8.3, §9 step 5)
 

--- a/src/commands/info/index.ts
+++ b/src/commands/info/index.ts
@@ -134,10 +134,15 @@ function loadDescriptionFromAny(
   return null;
 }
 
-/** Walk a source directory and gather SkillInfo per skill we find. */
+/**
+ * Walk a source directory and gather SkillInfo per skill we find.
+ * `expandSkills` returns `{ valid, skipped }`; `info` is a
+ * read-only "show me what's valid here" command, so skipped skills
+ * are deliberately dropped. `crew install` surfaces those (§9 step 9).
+ */
 function buildSkillInfos(dir: string): SkillInfo[] {
-  const skills = expandSkills(dir);
-  return skills.map((s) => ({
+  const { valid } = expandSkills(dir);
+  return valid.map((s) => ({
     name: s.frontmatter.name,
     description: s.frontmatter.description,
     license: s.frontmatter.license ?? null,

--- a/src/commands/install/collision-prompt.ts
+++ b/src/commands/install/collision-prompt.ts
@@ -1,0 +1,75 @@
+/**
+ * Tap-vs-other-tap-skill collision prompt (§16.4).
+ *
+ * A bare positional `foo` that matches both a configured tap name
+ * AND a same-named skill in one or more OTHER taps triggers this
+ * prompt. Binary Y/n for a single other tap; numbered menu for two
+ * or more. The CLI's `installCommand` calls `resolveCollisions`
+ * first, which delegates to `promptForCollision` here.
+ *
+ * This module is focused enough to keep the top-level command file
+ * under the 200-line cap.
+ */
+
+import { CrewError } from "../../core/errors.ts";
+import type { TapConfig } from "../../core/types.ts";
+import { countSkills } from "../../install/collision-check.ts";
+import type { CommandContext } from "../types.ts";
+
+export function promptForCollision(
+  ctx: CommandContext,
+  collision: { tap: TapConfig; otherTaps: readonly TapConfig[] },
+  trimmed: string,
+  raw: string,
+): string {
+  const count = countSkills(collision.tap, ctx.home);
+  const skillsLine = count === null ? "" : ` (${count} skill${count === 1 ? "" : "s"})`;
+  const qualifiedFor = (t: TapConfig): string => `${t.name}/${trimmed}`;
+
+  if (collision.otherTaps.length === 1) {
+    const other = collision.otherTaps[0]!;
+    const qualified = qualifiedFor(other);
+    const message =
+      `\`${trimmed}\` matches both a tap and a skill (from ${other.name}).\n` +
+      `  [Y] install tap \`${trimmed}\`${skillsLine}\n` +
+      `  [n] install skill \`${qualified}\`\n` +
+      `Choice [Y/n]: `;
+    const answer = ctx.prompt(message);
+    if (answer === "abort") throw abortError(collision, trimmed);
+    if (answer === "no") return qualified;
+    return raw;
+  }
+
+  // Two or more other taps host the same-named skill. The binary Y/n
+  // can't name them all, so render a numbered menu. Choice 1 is the
+  // tap (default); 2..N are the skills in config order.
+  const choiceCount = 1 + collision.otherTaps.length;
+  const lines: string[] = [
+    `\`${trimmed}\` matches a tap and skills in ${collision.otherTaps.length} other taps.`,
+    `  [1] install tap \`${trimmed}\`${skillsLine}`,
+  ];
+  for (let i = 0; i < collision.otherTaps.length; i++) {
+    lines.push(`  [${i + 2}] install skill \`${qualifiedFor(collision.otherTaps[i]!)}\``);
+  }
+  lines.push(`Choice [1-${choiceCount}, default 1]: `);
+  const answer = ctx.promptChoice(lines.join("\n"), choiceCount);
+  if (answer === "abort") throw abortError(collision, trimmed);
+  if (answer.index === 0) return raw;
+  return qualifiedFor(collision.otherTaps[answer.index - 1]!);
+}
+
+export function abortError(
+  collision: { tap: TapConfig; otherTaps: readonly TapConfig[] },
+  trimmed: string,
+): CrewError {
+  const qualifieds = collision.otherTaps.map((t) => `\`${t.name}/${trimmed}\``).join(", ");
+  const message =
+    collision.otherTaps.length === 1
+      ? `\`${trimmed}\` is both a tap name and a skill name (in ${collision.otherTaps[0]!.name}) — pass --yes to install the tap, or qualify the skill as ${qualifieds}`
+      : `\`${trimmed}\` is both a tap name and a skill name (in ${collision.otherTaps.length} other taps) — pass --yes to install the tap, or qualify a skill as one of: ${qualifieds}`;
+  return new CrewError("usage_error", message, {
+    name: trimmed,
+    tap: collision.tap.name,
+    otherTaps: collision.otherTaps.map((t) => t.name),
+  });
+}

--- a/src/commands/install/index.ts
+++ b/src/commands/install/index.ts
@@ -14,7 +14,7 @@ import { runInstall } from "../../install/flow.ts";
 import type { KindHint } from "../../install/resolve-ref/index.ts";
 import type { CommandContext, CommandOutput } from "../types.ts";
 import { promptBareNameAmbiguity } from "./ambiguity-prompt.ts";
-import { renderInstall } from "./render.ts";
+import { renderInstall } from "./render/index.ts";
 
 /** Read --tap / --bundle / --skill, enforce mutual exclusivity. */
 function readKindHint(ctx: CommandContext): KindHint {

--- a/src/commands/install/index.ts
+++ b/src/commands/install/index.ts
@@ -8,12 +8,13 @@
 
 import { readConfig } from "../../config/load.ts";
 import { CrewError } from "../../core/errors.ts";
-import type { Config, TapConfig } from "../../core/types.ts";
-import { countSkills, detectCollision } from "../../install/collision-check.ts";
+import type { Config } from "../../core/types.ts";
+import { detectCollision } from "../../install/collision-check.ts";
 import { runInstall } from "../../install/flow.ts";
 import type { KindHint } from "../../install/resolve-ref/index.ts";
 import type { CommandContext, CommandOutput } from "../types.ts";
 import { promptBareNameAmbiguity } from "./ambiguity-prompt.ts";
+import { promptForCollision } from "./collision-prompt.ts";
 import { renderInstall } from "./render/index.ts";
 
 /** Read --tap / --bundle / --skill, enforce mutual exclusivity. */
@@ -55,15 +56,26 @@ export function installCommand(ctx: CommandContext): CommandOutput {
     kindHint,
   });
 
-  // Exit-code rules (§18.6 clarification): exit 1 if any root skill has
-  // zero successful targets; otherwise 0. The clean "already installed"
-  // short-circuit case is exit 0 per §5.4.
+  // Exit-code rules (PRD §9 step 9). Per-skill outcome is
+  // "succeeded" iff the skill validated AND at least one agent
+  // install succeeded. Validation failures land in result.skipped;
+  // agent-level failures live in result.summary.records with
+  // `anySuccess === false`.
+  const succeeded = result.summary.records.filter((r) => r.anySuccess).length;
+  const operationalFailures = result.summary.records.filter((r) => !r.anySuccess).length;
+  const validationFailures = result.skipped.length;
+  const failed = operationalFailures + validationFailures;
   const allAlreadyInstalled =
     result.alreadyInstalled.length > 0 && result.summary.records.length === 0;
   let exitCode = 0;
-  if (!allAlreadyInstalled) {
-    const anyRootFail = result.summary.records.some((r) => !r.anySuccess);
-    if (anyRootFail) exitCode = 1;
+  if (failed === 0) {
+    exitCode = 0; // Every attempted skill succeeded, or nothing to do.
+  } else if (succeeded > 0 || allAlreadyInstalled) {
+    exitCode = 1; // Partial success.
+  } else if (validationFailures > 0) {
+    exitCode = 4; // Zero succeeded; at least one invalid skill.
+  } else {
+    exitCode = 1; // Zero succeeded; purely operational failures.
   }
 
   const human = renderInstall(
@@ -71,6 +83,7 @@ export function installCommand(ctx: CommandContext): CommandOutput {
       records: result.summary.records,
       alreadyInstalled: result.alreadyInstalled,
       resolved: result.resolved,
+      skipped: result.skipped,
       dryRun: ctx.flags.dryRun,
       cwd: ctx.cwd,
       width: ctx.width,
@@ -84,6 +97,7 @@ export function installCommand(ctx: CommandContext): CommandOutput {
     json: {
       already_installed: result.alreadyInstalled,
       records: result.summary.records,
+      skipped: result.skipped,
       dry_run: ctx.flags.dryRun,
     },
   };
@@ -132,64 +146,6 @@ function resolveCollisions(ctx: CommandContext, config: Config): string[] {
     refs.push(promptBareNameAmbiguity(ctx, config, trimmed, raw));
   }
   return refs;
-}
-
-function promptForCollision(
-  ctx: CommandContext,
-  collision: { tap: TapConfig; otherTaps: readonly TapConfig[] },
-  trimmed: string,
-  raw: string,
-): string {
-  const count = countSkills(collision.tap, ctx.home);
-  const skillsLine = count === null ? "" : ` (${count} skill${count === 1 ? "" : "s"})`;
-  const qualifiedFor = (t: TapConfig): string => `${t.name}/${trimmed}`;
-
-  if (collision.otherTaps.length === 1) {
-    const other = collision.otherTaps[0]!;
-    const qualified = qualifiedFor(other);
-    const message =
-      `\`${trimmed}\` matches both a tap and a skill (from ${other.name}).\n` +
-      `  [Y] install tap \`${trimmed}\`${skillsLine}\n` +
-      `  [n] install skill \`${qualified}\`\n` +
-      `Choice [Y/n]: `;
-    const answer = ctx.prompt(message);
-    if (answer === "abort") throw abortError(collision, trimmed);
-    if (answer === "no") return qualified;
-    return raw;
-  }
-
-  // Two or more other taps host the same-named skill. The binary Y/n
-  // can't name them all, so render a numbered menu. Choice 1 is the
-  // tap (default); 2..N are the skills in config order.
-  const choiceCount = 1 + collision.otherTaps.length;
-  const lines: string[] = [
-    `\`${trimmed}\` matches a tap and skills in ${collision.otherTaps.length} other taps.`,
-    `  [1] install tap \`${trimmed}\`${skillsLine}`,
-  ];
-  for (let i = 0; i < collision.otherTaps.length; i++) {
-    lines.push(`  [${i + 2}] install skill \`${qualifiedFor(collision.otherTaps[i]!)}\``);
-  }
-  lines.push(`Choice [1-${choiceCount}, default 1]: `);
-  const answer = ctx.promptChoice(lines.join("\n"), choiceCount);
-  if (answer === "abort") throw abortError(collision, trimmed);
-  if (answer.index === 0) return raw;
-  return qualifiedFor(collision.otherTaps[answer.index - 1]!);
-}
-
-function abortError(
-  collision: { tap: TapConfig; otherTaps: readonly TapConfig[] },
-  trimmed: string,
-): CrewError {
-  const qualifieds = collision.otherTaps.map((t) => `\`${t.name}/${trimmed}\``).join(", ");
-  const message =
-    collision.otherTaps.length === 1
-      ? `\`${trimmed}\` is both a tap name and a skill name (in ${collision.otherTaps[0]!.name}) — pass --yes to install the tap, or qualify the skill as ${qualifieds}`
-      : `\`${trimmed}\` is both a tap name and a skill name (in ${collision.otherTaps.length} other taps) — pass --yes to install the tap, or qualify a skill as one of: ${qualifieds}`;
-  return new CrewError("usage_error", message, {
-    name: trimmed,
-    tap: collision.tap.name,
-    otherTaps: collision.otherTaps.map((t) => t.name),
-  });
 }
 
 const BARE_NAME = /^[a-z0-9][a-z0-9-]*$/i;

--- a/src/commands/install/render.ts
+++ b/src/commands/install/render.ts
@@ -42,9 +42,22 @@ export function renderInstall(input: RenderInstallInput, style: Styler): string[
   const dryTag = input.dryRun ? style.dim(" (dry run)") : "";
 
   if (input.records.length === 0 && input.alreadyInstalled.length > 0) {
-    // Every root was already installed — one-liner per skill, nothing more.
+    // Every root was already installed — render each as a full block so
+    // the user can see exactly where it lives, matching the fresh-install
+    // layout but with dim markers.
+    let first = true;
     for (const existing of input.alreadyInstalled) {
-      lines.push(renderAlreadyInstalled(existing, byName.get(existing.name), style, input.width));
+      if (!first) lines.push("");
+      first = false;
+      lines.push(
+        ...renderAlreadyInstalled(
+          existing,
+          byName.get(existing.name),
+          input.cwd,
+          input.width,
+          style,
+        ),
+      );
     }
     return lines;
   }
@@ -61,7 +74,9 @@ export function renderInstall(input: RenderInstallInput, style: Styler): string[
   // user sees "you already had this" before the fresh work.
   for (const existing of input.alreadyInstalled) {
     lines.push("");
-    lines.push(renderAlreadyInstalled(existing, byName.get(existing.name), style, input.width));
+    lines.push(
+      ...renderAlreadyInstalled(existing, byName.get(existing.name), input.cwd, input.width, style),
+    );
   }
 
   for (const record of input.records) {
@@ -81,25 +96,35 @@ export function renderInstall(input: RenderInstallInput, style: Styler): string[
 function renderAlreadyInstalled(
   existing: AlreadyInstalled,
   resolved: ResolvedSkill | undefined,
-  style: Styler,
+  cwd: string,
   width: number,
-): string {
-  const bits: string[] = [
-    style.symbol("muted"),
-    style.bold(existing.name),
-    style.dim("already installed"),
-  ];
+  style: Styler,
+): string[] {
+  const lines: string[] = [];
+  const tagParts: string[] = [style.dim("(already installed)")];
   const version = formatVersion(existing.ref, existing.resolvedSha);
-  if (version) bits.push(style.dim(`· ${version}`));
-  if (existing.agents.length > 0) {
-    bits.push(style.dim(`· in ${existing.agents.join(", ")}`));
+  if (version) tagParts.push(style.dim(`· ${version}`));
+  const scopeTag = existing.scope === "project" ? ` ${style.dim(`in ${shortenHome(cwd)}`)}` : "";
+  lines.push(`  ${style.bold(existing.name)} ${tagParts.join(" ")}${scopeTag}`);
+  if (resolved?.frontmatter.description) {
+    const desc = firstSentences(resolved.frontmatter.description, 200);
+    const indent = "    ";
+    for (const l of wrap(desc, Math.max(40, width - indent.length))) {
+      lines.push(style.dim(`${indent}${l}`));
+    }
   }
-  const firstLine = `  ${bits.join(" ")}`;
-  if (!resolved?.frontmatter.description) return firstLine;
-  const desc = firstSentences(resolved.frontmatter.description, 180);
-  const indent = "    ";
-  const wrapped = wrap(desc, Math.max(40, width - indent.length));
-  return [firstLine, ...wrapped.map((l) => style.dim(`${indent}${l}`))].join("\n");
+  // One dim-marker row per agent — matches the newly-installed block's
+  // shape so the user can read both side-by-side at a glance.
+  for (const agentName of existing.agents) {
+    const adapter = agentByName(agentName);
+    const installPath = adapter
+      ? shortenHome(join(baseFor(adapter, existing.scope, cwd), existing.name))
+      : "";
+    const pathSuffix = installPath ? `${style.dim("→")} ${style.dim(installPath)}` : "";
+    const parts = [style.symbol("muted"), agentName, pathSuffix].filter((s) => s.length > 0);
+    lines.push(`    ${parts.join(" ")}`);
+  }
+  return lines;
 }
 
 function renderRecord(

--- a/src/commands/install/render/helpers.ts
+++ b/src/commands/install/render/helpers.ts
@@ -1,0 +1,85 @@
+/**
+ * Formatting helpers for `crew install`'s human output.
+ *
+ * Extracted from `./index.ts` to keep that file under the 200-line
+ * cap. Each helper is a pure function with no state.
+ */
+
+import { join } from "node:path";
+import { baseFor } from "../../../agents/adapter.ts";
+import { agentByName } from "../../../agents/registry.ts";
+import type { InstallRecord, PerAgentResult } from "../../../install/perform.ts";
+import { plural, shortenHome } from "../../../util/format.ts";
+import type { Styler } from "../../../util/term.ts";
+
+/** Remedy hints shown when a target install fails. Plain English only. */
+const AGENT_FAIL_REMEDIES: Record<string, string> = {
+  untracked_directory: "something was already there (pass --force to overwrite)",
+  customized: "you've edited this version (pass --force to replace it)",
+  inconsistent_marker: "a leftover marker doesn't match (pass --force to replace)",
+  name_conflict: "a different skill already owns this name",
+  invalid_skill: "the skill's SKILL.md isn't valid",
+  source_unreachable: "couldn't reach the source",
+};
+
+export function renderAgentLine(
+  skillName: string,
+  result: PerAgentResult,
+  scope: "user" | "project",
+  cwd: string,
+  style: Styler,
+): string {
+  const name = result.agent;
+  if (result.kind === "installed" || result.kind === "up_to_date") {
+    const adapter = agentByName(name);
+    const installPath = adapter ? shortenHome(join(baseFor(adapter, scope, cwd), skillName)) : "";
+    const status = result.kind === "up_to_date" ? style.dim("already up to date") : "";
+    const pathSuffix = installPath ? `${style.dim("→")} ${style.dim(installPath)}` : "";
+    const parts = [style.symbol("ok"), name, pathSuffix, status].filter((s) => s.length > 0);
+    return parts.join(" ");
+  }
+  const remedy = AGENT_FAIL_REMEDIES[result.error.code] ?? result.error.code.replace(/_/g, " ");
+  return `${style.symbol("fail")} ${name}  ${style.red(remedy)}`;
+}
+
+export interface Totals {
+  installed: number;
+  upToDate: number;
+  failed: number;
+  total: number;
+}
+
+export function tallyAgents(records: readonly InstallRecord[]): Totals {
+  const t: Totals = { installed: 0, upToDate: 0, failed: 0, total: 0 };
+  for (const r of records) {
+    for (const tgt of r.agents) {
+      t.total++;
+      if (tgt.kind === "installed") t.installed++;
+      else if (tgt.kind === "up_to_date") t.upToDate++;
+      else t.failed++;
+    }
+  }
+  return t;
+}
+
+export function formatTotals(totals: Totals): string {
+  const parts: string[] = [];
+  if (totals.installed > 0) parts.push(plural(totals.installed, "install", "installs"));
+  if (totals.upToDate > 0) parts.push(`${totals.upToDate} already up to date`);
+  if (totals.failed > 0) parts.push(plural(totals.failed, "failure"));
+  return parts.length > 0 ? parts.join(" · ") : "nothing to do";
+}
+
+/**
+ * Build a human-readable "version" tag for an already-installed skill:
+ * the requested ref plus a short SHA when both exist, or just one of
+ * them if that's all we have. Returns "" when neither is set (e.g.
+ * pure path sources with no git identity).
+ */
+export function formatVersion(ref: string | null, sha: string | null): string {
+  const shortSha = sha ? sha.slice(0, 8) : null;
+  if (ref && shortSha && ref !== sha) return `${ref} @ ${shortSha}`;
+  if (shortSha) return shortSha;
+  if (ref) return ref;
+  return "";
+}

--- a/src/commands/install/render/helpers.ts
+++ b/src/commands/install/render/helpers.ts
@@ -9,7 +9,7 @@ import { join } from "node:path";
 import { baseFor } from "../../../agents/adapter.ts";
 import { agentByName } from "../../../agents/registry.ts";
 import type { InstallRecord, PerAgentResult } from "../../../install/perform.ts";
-import { plural, shortenHome } from "../../../util/format.ts";
+import { shortenHome } from "../../../util/format.ts";
 import type { Styler } from "../../../util/term.ts";
 
 /** Remedy hints shown when a target install fails. Plain English only. */
@@ -60,14 +60,6 @@ export function tallyAgents(records: readonly InstallRecord[]): Totals {
     }
   }
   return t;
-}
-
-export function formatTotals(totals: Totals): string {
-  const parts: string[] = [];
-  if (totals.installed > 0) parts.push(plural(totals.installed, "install", "installs"));
-  if (totals.upToDate > 0) parts.push(`${totals.upToDate} already up to date`);
-  if (totals.failed > 0) parts.push(plural(totals.failed, "failure"));
-  return parts.length > 0 ? parts.join(" · ") : "nothing to do";
 }
 
 /**

--- a/src/commands/install/render/index.ts
+++ b/src/commands/install/render/index.ts
@@ -14,14 +14,16 @@ import { agentByName } from "../../../agents/registry.ts";
 import type { ResolvedSkill } from "../../../core/types.ts";
 import type { AlreadyInstalled } from "../../../install/duplicate-rules.ts";
 import type { InstallRecord } from "../../../install/perform.ts";
+import type { SkippedSkill } from "../../../sources/expand.ts";
 import { firstSentences, plural, shortenHome, wrap } from "../../../util/format.ts";
 import type { Styler } from "../../../util/term.ts";
-import { formatTotals, formatVersion, renderAgentLine, tallyAgents } from "./helpers.ts";
+import { formatVersion, renderAgentLine, type Totals, tallyAgents } from "./helpers.ts";
 
 export interface RenderInstallInput {
   readonly records: readonly InstallRecord[];
   readonly alreadyInstalled: readonly AlreadyInstalled[];
   readonly resolved: readonly ResolvedSkill[];
+  readonly skipped: readonly SkippedSkill[];
   readonly dryRun: boolean;
   readonly cwd: string;
   readonly width: number;
@@ -76,12 +78,43 @@ export function renderInstall(input: RenderInstallInput, style: Styler): string[
   }
 
   const totals = tallyAgents(input.records);
-  if (totals.total > 0) {
+  const totalsText = formatTotalsWithSkipped(totals, input.skipped.length);
+  if (totalsText !== null) {
     lines.push("");
-    lines.push(style.dim(formatTotals(totals)));
+    lines.push(style.dim(totalsText));
+  }
+
+  if (input.skipped.length > 0) {
+    lines.push("");
+    lines.push(style.bold(`Failed (${input.skipped.length}):`));
+    for (const s of input.skipped) {
+      // `wrap` always returns at least one element for a non-empty
+      // message — `s.message` is a CrewError message, never empty.
+      const wrapped = wrap(s.message, Math.max(40, input.width - 4));
+      lines.push(`  ${style.symbol("fail")} ${style.red(wrapped[0]!)}`);
+      for (let i = 1; i < wrapped.length; i++) lines.push(`    ${style.red(wrapped[i]!)}`);
+    }
   }
 
   return lines;
+}
+
+/**
+ * Return the dim one-line totals summary, or null when there's
+ * literally nothing to report (no installs, nothing up to date, no
+ * failures, no skips).
+ */
+function formatTotalsWithSkipped(totals: Totals, skippedCount: number): string | null {
+  if (totals.total === 0 && skippedCount === 0) return null;
+  const parts: string[] = [];
+  if (totals.installed > 0) parts.push(plural(totals.installed, "install", "installs"));
+  if (totals.upToDate > 0) parts.push(`${totals.upToDate} already up to date`);
+  if (totals.failed > 0) parts.push(plural(totals.failed, "failure"));
+  if (skippedCount > 0) parts.push(`${skippedCount} failed`);
+  // After the early-return guard above, at least one of
+  // installed / upToDate / failed / skippedCount is > 0, so `parts`
+  // is non-empty. No fallback needed.
+  return parts.join(" · ");
 }
 
 function renderAlreadyInstalled(

--- a/src/commands/install/render/index.ts
+++ b/src/commands/install/render/index.ts
@@ -9,23 +9,14 @@
  */
 
 import { join } from "node:path";
-import { baseFor } from "../../agents/adapter.ts";
-import { agentByName } from "../../agents/registry.ts";
-import type { ResolvedSkill } from "../../core/types.ts";
-import type { AlreadyInstalled } from "../../install/duplicate-rules.ts";
-import type { InstallRecord, PerAgentResult } from "../../install/perform.ts";
-import { firstSentences, plural, shortenHome, wrap } from "../../util/format.ts";
-import type { Styler } from "../../util/term.ts";
-
-/** Remedy hints shown when a target install fails. Plain English only. */
-const AGENT_FAIL_REMEDIES: Record<string, string> = {
-  untracked_directory: "something was already there (pass --force to overwrite)",
-  customized: "you've edited this version (pass --force to replace it)",
-  inconsistent_marker: "a leftover marker doesn't match (pass --force to replace)",
-  name_conflict: "a different skill already owns this name",
-  invalid_skill: "the skill's SKILL.md isn't valid",
-  source_unreachable: "couldn't reach the source",
-};
+import { baseFor } from "../../../agents/adapter.ts";
+import { agentByName } from "../../../agents/registry.ts";
+import type { ResolvedSkill } from "../../../core/types.ts";
+import type { AlreadyInstalled } from "../../../install/duplicate-rules.ts";
+import type { InstallRecord } from "../../../install/perform.ts";
+import { firstSentences, plural, shortenHome, wrap } from "../../../util/format.ts";
+import type { Styler } from "../../../util/term.ts";
+import { formatTotals, formatVersion, renderAgentLine, tallyAgents } from "./helpers.ts";
 
 export interface RenderInstallInput {
   readonly records: readonly InstallRecord[];
@@ -104,7 +95,9 @@ function renderAlreadyInstalled(
   const tagParts: string[] = [style.dim("(already installed)")];
   const version = formatVersion(existing.ref, existing.resolvedSha);
   if (version) tagParts.push(style.dim(`· ${version}`));
-  const scopeTag = existing.scope === "project" ? ` ${style.dim(`in ${shortenHome(cwd)}`)}` : "";
+  // Match `renderRecord`'s scope-tag shape: two leading spaces
+  // inside `style.dim` so color markup brackets the whole tag.
+  const scopeTag = existing.scope === "project" ? style.dim(`  in ${shortenHome(cwd)}`) : "";
   lines.push(`  ${style.bold(existing.name)} ${tagParts.join(" ")}${scopeTag}`);
   if (resolved?.frontmatter.description) {
     const desc = firstSentences(resolved.frontmatter.description, 200);
@@ -151,66 +144,4 @@ function renderRecord(
     lines.push(`    ${renderAgentLine(record.name, t, record.scope, cwd, style)}`);
   }
   return lines;
-}
-
-function renderAgentLine(
-  skillName: string,
-  result: PerAgentResult,
-  scope: "user" | "project",
-  cwd: string,
-  style: Styler,
-): string {
-  const name = result.agent;
-  if (result.kind === "installed" || result.kind === "up_to_date") {
-    const adapter = agentByName(name);
-    const installPath = adapter ? shortenHome(join(baseFor(adapter, scope, cwd), skillName)) : "";
-    const status = result.kind === "up_to_date" ? style.dim("already up to date") : "";
-    const pathSuffix = installPath ? `${style.dim("→")} ${style.dim(installPath)}` : "";
-    const parts = [style.symbol("ok"), name, pathSuffix, status].filter((s) => s.length > 0);
-    return parts.join(" ");
-  }
-  const remedy = AGENT_FAIL_REMEDIES[result.error.code] ?? result.error.code.replace(/_/g, " ");
-  return `${style.symbol("fail")} ${name}  ${style.red(remedy)}`;
-}
-
-interface Totals {
-  installed: number;
-  upToDate: number;
-  failed: number;
-  total: number;
-}
-
-function tallyAgents(records: readonly InstallRecord[]): Totals {
-  const t: Totals = { installed: 0, upToDate: 0, failed: 0, total: 0 };
-  for (const r of records) {
-    for (const tgt of r.agents) {
-      t.total++;
-      if (tgt.kind === "installed") t.installed++;
-      else if (tgt.kind === "up_to_date") t.upToDate++;
-      else t.failed++;
-    }
-  }
-  return t;
-}
-
-function formatTotals(totals: Totals): string {
-  const parts: string[] = [];
-  if (totals.installed > 0) parts.push(plural(totals.installed, "install", "installs"));
-  if (totals.upToDate > 0) parts.push(`${totals.upToDate} already up to date`);
-  if (totals.failed > 0) parts.push(plural(totals.failed, "failure"));
-  return parts.length > 0 ? parts.join(" · ") : "nothing to do";
-}
-
-/**
- * Build a human-readable "version" tag for an already-installed skill:
- * the requested ref plus a short SHA when both exist, or just one of
- * them if that's all we have. Returns "" when neither is set (e.g.
- * pure path sources with no git identity).
- */
-function formatVersion(ref: string | null, sha: string | null): string {
-  const shortSha = sha ? sha.slice(0, 8) : null;
-  if (ref && shortSha && ref !== sha) return `${ref} @ ${shortSha}`;
-  if (shortSha) return shortSha;
-  if (ref) return ref;
-  return "";
 }

--- a/src/install/flow.ts
+++ b/src/install/flow.ts
@@ -16,6 +16,7 @@
 import { writeConfig } from "../config/load.ts";
 import { crewHome } from "../core/paths.ts";
 import type { Config, ResolvedSkill, Scope, StateFile } from "../core/types.ts";
+import type { SkippedSkill } from "../sources/expand.ts";
 import { readState, writeState } from "../state/load.ts";
 import { withStateLock } from "../state/lock.ts";
 import { computeAgentSet } from "./agent-set.ts";
@@ -48,6 +49,12 @@ export interface InstallFlowResult {
    * descriptions, tap attribution, etc. when rendering human output.
    */
   readonly resolved: readonly ResolvedSkill[];
+  /**
+   * Skill directories that failed validation and were soft-skipped
+   * during multi-skill expansion. Empty for single-skill installs
+   * (those hard-fail before reaching here).
+   */
+  readonly skipped: readonly SkippedSkill[];
 }
 
 /** Run the install flow end-to-end. */
@@ -63,6 +70,7 @@ export function runInstall(config: Config, options: InstallOptions): InstallFlow
     skills: resolvedAll,
     requiredBy,
     config: configWithAutoTaps,
+    skipped,
   } = resolveInstallSet(options.refs, config, { cwd, home, kindHint: options.kindHint ?? null });
 
   // Apply §5.4 — duplicate installs. An install with a new active
@@ -86,7 +94,7 @@ export function runInstall(config: Config, options: InstallOptions): InstallFlow
       requiredBy,
       allResolved: resolvedAll,
     });
-    return { summary, alreadyInstalled, resolved: resolvedAll };
+    return { summary, alreadyInstalled, resolved: resolvedAll, skipped };
   }
 
   const summary = withStateLock(() => {
@@ -113,7 +121,7 @@ export function runInstall(config: Config, options: InstallOptions): InstallFlow
     return { ...result, newState: promoted };
   }, home);
 
-  return { summary, alreadyInstalled, resolved: resolvedAll };
+  return { summary, alreadyInstalled, resolved: resolvedAll, skipped };
 }
 
 /**

--- a/src/install/resolve/enqueue.ts
+++ b/src/install/resolve/enqueue.ts
@@ -17,7 +17,7 @@
 import type { Config, LoadedSkill, Source, TapConfig } from "../../core/types.ts";
 import { parseRef } from "../../refs/parse.ts";
 import { acquireTap } from "../../sources/acquire/index.ts";
-import { expandSkills } from "../../sources/expand.ts";
+import { expandSkills, type SkippedSkill } from "../../sources/expand.ts";
 import { findSiblingDep } from "../dep-resolution.ts";
 import { type KindHint, resolveTapRef } from "../resolve-ref/index.ts";
 import { attributeRef } from "../tap-attribution.ts";
@@ -41,7 +41,7 @@ export function enqueueTapRef(
   home: string,
   explicit: boolean,
   kindHint: KindHint,
-): { items: PendingItem[]; config: Config } {
+): { items: PendingItem[]; config: Config; skipped: readonly SkippedSkill[] } {
   // Whole-tap install short-circuit: bare `<name>` that is the name of
   // a configured tap. Cross-tap collisions (a same-named skill in a
   // DIFFERENT tap) are handled earlier in the CLI layer via
@@ -57,19 +57,17 @@ export function enqueueTapRef(
     const matched = config.taps.find((c) => c.name === source.name);
     if (matched) {
       const acquired = acquireTap(matched, home);
-      return {
-        items: expandSkillsAsItems(
-          acquired.rootDir,
-          matched,
-          "",
-          acquired.resolvedSha,
-          source.ref,
-          source.ref !== null,
-          explicit,
-          true,
-        ),
-        config,
-      };
+      const expansion = expandSkillsAsItems(
+        acquired.rootDir,
+        matched,
+        "",
+        acquired.resolvedSha,
+        source.ref,
+        source.ref !== null,
+        explicit,
+        true,
+      );
+      return { items: expansion.items, config, skipped: expansion.skipped };
     }
   }
 
@@ -91,8 +89,9 @@ export function enqueueTapRef(
   if (candidate.kind === "namespace") {
     const acquired = acquireTap(candidate.tap, home);
     const items: PendingItem[] = [];
+    const skipped: SkippedSkill[] = [];
     for (const member of candidate.members) {
-      const member_items = expandSkillsAsItems(
+      const expansion = expandSkillsAsItems(
         member.path,
         candidate.tap,
         member.tapRelativePath,
@@ -102,9 +101,10 @@ export function enqueueTapRef(
         explicit,
         true,
       );
-      for (const it of member_items) items.push(it);
+      items.push(...expansion.items);
+      skipped.push(...expansion.skipped);
     }
-    return { items, config };
+    return { items, config, skipped };
   }
 
   // kind === "skill". The short-circuit above handles kind === "tap"
@@ -112,7 +112,7 @@ export function enqueueTapRef(
   // (2-seg, 3-seg) never resolve to a tap.
   const skill = candidate as Extract<typeof candidate, { kind: "skill" }>;
   const acquired = acquireTap(skill.tap, home);
-  const items = expandSkillsAsItems(
+  const expansion = expandSkillsAsItems(
     skill.location.path,
     skill.tap,
     skill.location.tapRelativePath,
@@ -122,7 +122,12 @@ export function enqueueTapRef(
     explicit,
     false,
   );
-  return { items, config };
+  return { items: expansion.items, config, skipped: expansion.skipped };
+}
+
+interface ExpansionItems {
+  readonly items: PendingItem[];
+  readonly skipped: readonly SkippedSkill[];
 }
 
 /** Walk `dir` and produce one PendingItem per skill found (single or expanded). */
@@ -135,10 +140,10 @@ export function expandSkillsAsItems(
   pinned: boolean,
   explicit: boolean,
   tracksTap: boolean,
-): PendingItem[] {
-  const loaded = expandSkills(dir);
+): ExpansionItems {
+  const { valid, skipped } = expandSkills(dir);
   const items: PendingItem[] = [];
-  for (const l of loaded) {
+  for (const l of valid) {
     // tap-relative path of this skill's directory inside its tap.
     const subSegment = l.path === dir ? "" : l.path.slice(dir.length + 1);
     const tapRelativePath = baseTapPath
@@ -157,7 +162,7 @@ export function expandSkillsAsItems(
       tracksTap,
     });
   }
-  return items;
+  return { items, skipped };
 }
 
 /** Resolve and enqueue items for a dependency reference. */
@@ -167,7 +172,7 @@ export function enqueueDep(
   config: Config,
   cwd: string,
   home: string,
-): { items: PendingItem[]; config: Config } {
+): { items: PendingItem[]; config: Config; skipped: readonly SkippedSkill[] } {
   const source = parseRef(depRef, cwd);
 
   // Bare-name dep with a tap-aware parent: prefer a sibling in the parent's tap.
@@ -193,6 +198,7 @@ export function enqueueDep(
           },
         ],
         config,
+        skipped: [],
       };
     }
     // Fall through to bare-name search across all configured taps.
@@ -207,7 +213,7 @@ export function enqueueDep(
   // subscribe the user to every sibling of the dep's source.
   const attrib = attributeRef(source, config);
   const acquired = acquireTap(attrib.tap, home);
-  const items = expandSkillsAsItems(
+  const expansion = expandSkillsAsItems(
     acquired.rootDir,
     attrib.tap,
     "",
@@ -217,7 +223,7 @@ export function enqueueDep(
     false,
     false,
   );
-  return { items, config: attrib.config };
+  return { items: expansion.items, config: attrib.config, skipped: expansion.skipped };
 }
 
 export function sourceRequestedRef(source: Source): string | null {

--- a/src/install/resolve/index.ts
+++ b/src/install/resolve/index.ts
@@ -18,6 +18,7 @@ import { crewHome } from "../../core/paths.ts";
 import type { Config, ResolvedSkill } from "../../core/types.ts";
 import { parseRef } from "../../refs/parse.ts";
 import { acquireTap } from "../../sources/acquire/index.ts";
+import type { SkippedSkill } from "../../sources/expand.ts";
 import { stageIntoStore } from "../../sources/store.ts";
 import type { KindHint } from "../resolve-ref/index.ts";
 import { attributeRef } from "../tap-attribution.ts";
@@ -52,6 +53,12 @@ export interface ResolveResult {
   readonly requiredBy: RequiredByMap;
   /** Config including any auto-taps we created. Caller writes it. */
   readonly config: Config;
+  /**
+   * Skill directories that failed validation during expansion and
+   * were soft-skipped. The install command surfaces them and factors
+   * them into the exit code per PRD §9 step 9.
+   */
+  readonly skipped: readonly SkippedSkill[];
 }
 
 /**
@@ -70,12 +77,14 @@ export function resolveInstallSet(
   const byName = new Map<string, ResolvedSkill>();
   const requiredBy: RequiredByMap = new Map();
   const pending: PendingItem[] = [];
+  const skipped: SkippedSkill[] = [];
 
   // Step 1–5: resolve every root reference.
   for (const raw of refs) {
     const enqueued = enqueueRoot(raw, config, cwd, home, kindHint);
     config = enqueued.config;
     pending.push(...enqueued.items);
+    skipped.push(...enqueued.skipped);
   }
 
   // Step 6: dependency walk.
@@ -113,6 +122,7 @@ export function resolveInstallSet(
     for (const depRef of deps) {
       const enqueued = enqueueDep(depRef, item, config, cwd, home);
       config = enqueued.config;
+      skipped.push(...enqueued.skipped);
       for (const depItem of enqueued.items) {
         pending.push(depItem);
         const depName = depItem.loaded.frontmatter.name;
@@ -122,7 +132,7 @@ export function resolveInstallSet(
     }
   }
 
-  return { skills: topoSort(byName), requiredBy, config };
+  return { skills: topoSort(byName), requiredBy, config, skipped };
 }
 
 /** Resolve and enqueue the items produced by a single root reference. */
@@ -132,7 +142,7 @@ function enqueueRoot(
   cwd: string,
   home: string,
   kindHint: KindHint,
-): { items: PendingItem[]; config: Config } {
+): { items: PendingItem[]; config: Config; skipped: readonly SkippedSkill[] } {
   const source = parseRef(raw, cwd);
 
   // Bare-name (`<skill>`) and qualified (`<tap>/<skill>`, `<tap>/<ns>/<skill>`) tap refs.
@@ -145,7 +155,7 @@ function enqueueRoot(
   // said "install this". Future additions should follow.
   const attrib = attributeRef(source, config);
   const acquired = acquireTap(attrib.tap, home);
-  const items = expandSkillsAsItems(
+  const expansion = expandSkillsAsItems(
     acquired.rootDir,
     attrib.tap,
     "",
@@ -155,5 +165,5 @@ function enqueueRoot(
     true,
     true,
   );
-  return { items, config: attrib.config };
+  return { items: expansion.items, config: attrib.config, skipped: expansion.skipped };
 }

--- a/src/sources/expand.ts
+++ b/src/sources/expand.ts
@@ -12,8 +12,14 @@
  *      - The source root itself is not walked in this case.
  *   3. Otherwise → walk ONE level under the source root.
  *
- * A location that produces zero valid skills aborts with
- * `no_skills_found`.
+ * Multi-skill expansions (cases 2 + 3) soft-fail: an invalid child
+ * is collected and returned as a `SkippedSkill` instead of aborting
+ * the whole walk. The caller decides how to surface skips; the
+ * install flow reports them and exits non-zero at the end.
+ * A location that produces zero valid skills (and no skips) aborts
+ * with `no_skills_found`. The single-root-skill case (1) keeps
+ * hard-fail semantics — if the user pointed at one skill and it's
+ * invalid, that IS the whole input.
  */
 
 import { join } from "node:path";
@@ -22,62 +28,93 @@ import type { LoadedSkill } from "../core/types.ts";
 import { hasSkillMd, loadSkill } from "../skill/load.ts";
 import { isDirectory, listDir } from "../util/fs.ts";
 
-/** Expand `rootDir` into one or more loaded skills. */
-export function expandSkills(rootDir: string): LoadedSkill[] {
+/** A skill directory that couldn't be loaded. */
+export interface SkippedSkill {
+  /** Absolute path to the (would-be) skill directory. */
+  readonly path: string;
+  /** Human-readable reason from the underlying `CrewError`. */
+  readonly message: string;
+  /** The error code (typically `invalid_skill`). */
+  readonly code: string;
+}
+
+/** Result of an expansion: the valid skills plus any children skipped. */
+export interface ExpansionResult {
+  readonly valid: readonly LoadedSkill[];
+  readonly skipped: readonly SkippedSkill[];
+}
+
+/**
+ * Expand `rootDir` into loaded skills plus any skipped children.
+ * Validation failures (at any level) are recorded in `skipped`
+ * rather than thrown — the caller decides exit code and output.
+ * `no_skills_found` is still thrown when neither a valid skill nor
+ * a validation failure is present (zero candidates).
+ */
+export function expandSkills(rootDir: string): ExpansionResult {
   if (hasSkillMd(rootDir)) {
-    return [loadSkill(rootDir)];
+    const valid: LoadedSkill[] = [];
+    const skipped: SkippedSkill[] = [];
+    pushSoft(rootDir, valid, skipped);
+    return { valid, skipped };
   }
   const skillsDir = join(rootDir, "skills");
-  const children = isDirectory(skillsDir)
+  const result = isDirectory(skillsDir)
     ? collectWithNamespaces(skillsDir)
     : collectSkillChildren(rootDir);
-  if (children.length === 0) {
+  if (result.valid.length === 0 && result.skipped.length === 0) {
     throw new CrewError(
       "no_skills_found",
       `no valid skills found at \`${rootDir}\` — expected a SKILL.md there, subdirectories that each contain one, or a \`skills/\` directory of either`,
       { path: rootDir },
     );
   }
-  return children;
+  return result;
 }
 
 /**
  * Walk `skills/` one level deep, descending into namespace dirs
  * (children that lack a `SKILL.md` but contain child skill dirs).
  */
-function collectWithNamespaces(skillsDir: string): LoadedSkill[] {
-  const children: LoadedSkill[] = [];
+function collectWithNamespaces(skillsDir: string): ExpansionResult {
+  const valid: LoadedSkill[] = [];
+  const skipped: SkippedSkill[] = [];
   for (const name of listDir(skillsDir)) {
     const candidate = join(skillsDir, name);
-    if (!isDirectory(candidate)) {
-      continue;
-    }
+    if (!isDirectory(candidate)) continue;
     if (hasSkillMd(candidate)) {
-      children.push(loadSkill(candidate));
+      pushSoft(candidate, valid, skipped);
       continue;
     }
     // `candidate` has no SKILL.md — treat as a namespace if at least
     // one grandchild has a SKILL.md. Non-namespace dirs under
     // `skills/` (e.g. docs, scripts) are silently ignored.
-    for (const member of collectSkillChildren(candidate)) {
-      children.push(member);
-    }
+    const inner = collectSkillChildren(candidate);
+    valid.push(...inner.valid);
+    skipped.push(...inner.skipped);
   }
-  return children;
+  return { valid, skipped };
 }
 
-function collectSkillChildren(dir: string): LoadedSkill[] {
-  const children: LoadedSkill[] = [];
+function collectSkillChildren(dir: string): ExpansionResult {
+  const valid: LoadedSkill[] = [];
+  const skipped: SkippedSkill[] = [];
   for (const name of listDir(dir)) {
     const candidate = join(dir, name);
-    if (!isDirectory(candidate)) {
-      continue;
-    }
-    if (!hasSkillMd(candidate)) {
-      continue;
-    }
-    // Validation happens at load time; invalid children fail fast.
-    children.push(loadSkill(candidate));
+    if (!isDirectory(candidate)) continue;
+    if (!hasSkillMd(candidate)) continue;
+    pushSoft(candidate, valid, skipped);
   }
-  return children;
+  return { valid, skipped };
+}
+
+function pushSoft(candidate: string, valid: LoadedSkill[], skipped: SkippedSkill[]): void {
+  try {
+    valid.push(loadSkill(candidate));
+  } catch (err) {
+    // `loadSkill` throws only `CrewError`, whose `code` is typed as
+    // a non-null `CrewErrorName`. No fallback needed.
+    const ce = err as CrewError;
+    skipped.push({ path: candidate, message: ce.message, code: ce.code });
+  }
 }

--- a/tests/e2e/install.test.ts
+++ b/tests/e2e/install.test.ts
@@ -155,7 +155,14 @@ describe("install from local path", () => {
     const capture = captureStreams();
     const code = runCli(["install", skill], { home, streams: capture.streams });
     expect(code).toBe(0);
-    expect(capture.stdout()).toContain("already installed");
+    const out = capture.stdout();
+    expect(out).toContain("already installed");
+    // New rendering: a full per-skill block with a per-agent row for
+    // each agent the skill is installed into (muted marker, not ✓).
+    // Verify at least one per-agent row with the destination path is
+    // present — this is the regression guard for the old one-liner.
+    expect(out).toContain("(already installed)");
+    expect(out).toMatch(/claude-code .+demo/);
   });
 
   test("C-INST-15 --dry-run writes no files", () => {

--- a/tests/e2e/install.test.ts
+++ b/tests/e2e/install.test.ts
@@ -273,6 +273,64 @@ describe("install directory expansion", () => {
     expect(existsSync(join(redirect.agents["claude-code"]!, "ignored"))).toBe(false);
   });
 
+  test("C-INST-20 invalid skill in a multi-skill source is soft-skipped", () => {
+    const home = makeCrewHome();
+    const container = makeTempDir("crew-soft-");
+    // A valid skill alongside an invalid one (name doesn't match dir).
+    makeSkill(container, "good-skill", skillFrontmatter({ name: "good-skill" }));
+    makeSkill(container, "bad-dir", skillFrontmatter({ name: "mismatched-name" }));
+    const capture = captureStreams();
+    const code = runCli(["install", container], { home, streams: capture.streams });
+    // Exit 1: partial success, not 4.
+    expect(code).toBe(1);
+    // The valid sibling installed.
+    expect(existsSync(join(redirect.agents["claude-code"]!, "good-skill"))).toBe(true);
+    // The invalid one was reported in stdout, not as a hard error.
+    expect(capture.stdout()).toContain("Failed");
+    expect(capture.stdout()).toContain("bad-dir");
+  });
+
+  test("C-INST-21 multi-skill dir where every skill is invalid: exit 4, all listed in Failed", () => {
+    const home = makeCrewHome();
+    const container = makeTempDir("crew-all-invalid-");
+    // Two siblings, both have mismatched name/dir.
+    makeSkill(container, "bad-one", skillFrontmatter({ name: "wrong-one" }));
+    makeSkill(container, "bad-two", skillFrontmatter({ name: "wrong-two" }));
+    const capture = captureStreams();
+    const code = runCli(["install", container], { home, streams: capture.streams });
+    // Zero succeeded AND ≥1 validation failure → exit 4.
+    expect(code).toBe(4);
+    const out = capture.stdout();
+    expect(out).toContain("Failed");
+    // Both skills reported.
+    expect(out).toContain("bad-one");
+    expect(out).toContain("bad-two");
+  });
+
+  test("C-INST-20 --json surfaces skipped skills", () => {
+    const home = makeCrewHome();
+    const container = makeTempDir("crew-soft-json-");
+    makeSkill(container, "good-skill", skillFrontmatter({ name: "good-skill" }));
+    makeSkill(container, "bad-dir", skillFrontmatter({ name: "mismatched-name" }));
+    const capture = captureStreams();
+    runCli(["install", "--json", container], { home, streams: capture.streams });
+    const parsed = JSON.parse(capture.stdout()) as {
+      skipped: { path: string; message: string; code: string }[];
+    };
+    expect(parsed.skipped.length).toBe(1);
+    expect(parsed.skipped[0]!.code).toBe("invalid_skill");
+  });
+
+  test("C-INST-21 single-skill source still hard-fails on invalid SKILL.md", () => {
+    const home = makeCrewHome();
+    const container = makeTempDir("crew-hard-");
+    const skill = makeSkill(container, "bad-dir", skillFrontmatter({ name: "mismatched-name" }));
+    const capture = captureStreams();
+    const code = runCli(["install", skill], { home, streams: capture.streams });
+    // Exit 4: the user asked for that one skill and it's invalid.
+    expect(code).toBe(4);
+  });
+
   test("C-INST-09 no valid skills -> no_skills_found exit 4", () => {
     const home = makeCrewHome();
     const container = makeTempDir("crew-empty-");

--- a/tests/e2e/install.test.ts
+++ b/tests/e2e/install.test.ts
@@ -162,7 +162,12 @@ describe("install from local path", () => {
     // Verify at least one per-agent row with the destination path is
     // present — this is the regression guard for the old one-liner.
     expect(out).toContain("(already installed)");
-    expect(out).toMatch(/claude-code .+demo/);
+    // Per-agent row carries the muted marker (plain-styler "-"
+    // on non-TTY, "·" on TTY) followed by the agent and a "→"
+    // separator ahead of the install path. The regex nails down
+    // every element so a regression in the muted-marker path
+    // surfaces here.
+    expect(out).toMatch(/[-·]\s+claude-code\s+→.+demo/);
   });
 
   test("C-INST-15 --dry-run writes no files", () => {

--- a/tests/unit/expand.test.ts
+++ b/tests/unit/expand.test.ts
@@ -24,9 +24,9 @@ describe("expandSkills", () => {
     makeSkill(join(root, "skills"), "nested", skillFrontmatter({ name: "nested" }));
 
     const result = expandSkills(root);
-    expect(result.length).toBe(1);
+    expect(result.valid.length).toBe(1);
     // The root is a single skill; `skills/` is ignored entirely.
-    expect(result[0]!.path).toBe(root);
+    expect(result.valid[0]!.path).toBe(root);
   });
 
   test("skills/ directory is walked when no root SKILL.md", () => {
@@ -39,7 +39,7 @@ describe("expandSkills", () => {
     makeSkill(root, "ignored", skillFrontmatter({ name: "ignored" }));
 
     const names = expandSkills(root)
-      .map((s) => s.frontmatter.name)
+      .valid.map((s) => s.frontmatter.name)
       .sort();
     expect(names).toEqual(["alpha", "beta"]);
   });
@@ -59,7 +59,7 @@ describe("expandSkills", () => {
     makeSkill(root, "two", skillFrontmatter({ name: "two" }));
 
     const names = expandSkills(root)
-      .map((s) => s.frontmatter.name)
+      .valid.map((s) => s.frontmatter.name)
       .sort();
     expect(names).toEqual(["one", "two"]);
   });
@@ -70,7 +70,7 @@ describe("expandSkills", () => {
     makeSkill(root, "real", skillFrontmatter({ name: "real" }));
     writeFileSync(join(root, "README.md"), "not a directory");
 
-    const names = expandSkills(root).map((s) => s.frontmatter.name);
+    const names = expandSkills(root).valid.map((s) => s.frontmatter.name);
     expect(names).toEqual(["real"]);
   });
 
@@ -81,7 +81,7 @@ describe("expandSkills", () => {
     mkdirSync(join(root, "docs"));
     writeFileSync(join(root, "docs", "index.md"), "# docs");
 
-    const names = expandSkills(root).map((s) => s.frontmatter.name);
+    const names = expandSkills(root).valid.map((s) => s.frontmatter.name);
     expect(names).toEqual(["real"]);
   });
 
@@ -97,7 +97,7 @@ describe("expandSkills", () => {
     // A regular (non-namespaced) skill at the skills/ root.
     makeSkill(skillsDir, "standalone", skillFrontmatter({ name: "standalone" }));
 
-    const skills = expandSkills(root);
+    const skills = expandSkills(root).valid;
     const names = skills.map((s) => s.frontmatter.name).sort();
     expect(names).toEqual(["email-outreach", "social-posts", "standalone"]);
     // Namespaced skills carry the namespace in their path.
@@ -116,7 +116,7 @@ describe("expandSkills", () => {
     writeFileSync(join(skillsDir, "docs", "README.md"), "# docs");
     makeSkill(skillsDir, "real", skillFrontmatter({ name: "real" }));
 
-    const names = expandSkills(root).map((s) => s.frontmatter.name);
+    const names = expandSkills(root).valid.map((s) => s.frontmatter.name);
     expect(names).toEqual(["real"]);
   });
 
@@ -133,7 +133,7 @@ describe("expandSkills", () => {
     makeSkill(tooDeep, "too-deep", skillFrontmatter({ name: "too-deep" }));
 
     const names = expandSkills(root)
-      .map((s) => s.frontmatter.name)
+      .valid.map((s) => s.frontmatter.name)
       .sort();
     expect(names).toEqual(["real"]);
   });


### PR DESCRIPTION
> **Stacked on #30 → #29 → #28.** Merge those in order first.

## Summary
When `crew install <something-already-installed>` runs, the command currently renders a one-line footnote:

```
  · landing-page-copy already installed · in agent-skills, claude-code, codex, cursor, factory, gemini-cli
    <description>
```

In a multi-skill install where some are new and some are already-installed, this cramped format looks like a footnote compared to the rich per-agent grid used for fresh installs. You have to eyeball two different shapes to see the same kind of information.

This PR renders already-installed skills in the **same block shape** as newly-installed ones:

```
  landing-page-copy  (already installed)
    A rigorous content marketer for landing pages…
    · agent-skills → ~/.agents/skills/landing-page-copy
    · codex → ~/.agents/skills/landing-page-copy
    · cursor → ~/.agents/skills/landing-page-copy
    · gemini-cli → ~/.agents/skills/landing-page-copy
    · claude-code → ~/.claude/skills/landing-page-copy
    · factory → ~/.factory/skills/landing-page-copy
```

Markers are muted (`·`) instead of green (`✓`) so the visual hierarchy still distinguishes "already installed" from "just installed."

## Test plan
- [x] C-INST-11 updated to lock in the new per-agent row.
- [x] `bun run check` green: 804 tests, 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)