### PR TITLE
[LOG-4527] Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.6.0] — 2026-04-23
+
+### Added
+
+- **Namespace grouping.** Tap authors can organize skills under a `skills/<namespace>/` directory. Install a whole namespace (`crew install marketing`), a skill within one (`crew install marketing/email-outreach`), or use the fully-qualified 3-segment form (`crew install acme/marketing/email-outreach`).
+- **`--tap`, `--bundle`, `--skill` flags on `crew install`.** Explicitly force how a bare name is interpreted when it could match more than one thing.
+- **Interactive ambiguity prompt.** When a name is ambiguous, crew shows a numbered menu on TTY and returns a structured `ambiguous_reference` error with copy-pasteable commands in non-interactive contexts.
+- **`skills/` subdirectory support.** Taps whose skills live under a `skills/` subdirectory (rather than the repo root) are now recognized automatically; the `skills/` tree is used exclusively when present.
+
+### Changed
+
+- Install refs now support a 3-segment form: `<tap>/<namespace>/<skill>`. Existing 1- and 2-segment refs are unchanged.
+- README updated with a Namespaces section documenting the new directory layout and install forms.
+
 ## [0.5.0] — 2026-04-20
 
 ### Changed

--- a/PRD.md
+++ b/PRD.md
@@ -2,7 +2,7 @@
 
 **A package manager for Agent Skills.**
 
-Version: 0.5.0
+Version: 0.6.0
 Status: Specification, ready for implementation
 Platform: macOS (Apple Silicon and Intel)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crew",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A package manager for Agent Skills",
   "type": "module",
   "module": "src/index.ts",

--- a/site/public/latest-version.json
+++ b/site/public/latest-version.json
@@ -1,13 +1,13 @@
 {
-  "tag_name": "v0.5.0",
+  "tag_name": "v0.6.0",
   "assets": [
     {
       "name": "crew-macos-arm64",
-      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.5.0/crew-macos-arm64"
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.6.0/crew-macos-arm64"
     },
     {
       "name": "crew-macos-x64",
-      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.5.0/crew-macos-x64"
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.6.0/crew-macos-x64"
     }
   ]
 }

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -5,5 +5,5 @@
  * without touching anything else. The value written to the `installed_by`
  * marker field and printed by `crew version` is derived from here.
  */
-export const CREW_VERSION = "0.5.0";
+export const CREW_VERSION = "0.6.0";
 export const CREW_INSTALLED_BY = `crew/${CREW_VERSION}`;


### PR DESCRIPTION
## What's new in v0.6.0

### Added

- **Namespace grouping in taps.** Tap authors can now organize skills one level deeper under `skills/`:
  ```
  acme-skills/
  └── skills/
      ├── marketing/
      │   ├── email-outreach/SKILL.md
      │   └── social-posts/SKILL.md
      └── engineering/
          ├── code-review/SKILL.md
          └── pr-descriptions/SKILL.md
  ```
  Install an entire namespace at once (`crew install marketing`), a single skill inside one (`crew install marketing/email-outreach`), or pin to an exact tap with the full 3-segment form (`crew install acme/marketing/email-outreach`).

- **New disambiguation flags.** When a bare name could mean more than one thing, new flags let you be explicit without retyping the full ref:
  - `--tap acme` — install everything in that tap
  - `--bundle marketing` — install an entire namespace
  - `--skill pdf` — install a single skill by name

- **Smart ambiguity resolution.** When a name is genuinely ambiguous across taps, skills, or namespaces, crew presents a numbered menu on interactive terminals and returns a structured error with copy-pasteable install commands in non-interactive contexts.

- **`skills/` subdirectory as the authoritative skill index.** Taps that keep skills under a `skills/` directory (rather than at the repo root) are now recognized automatically. Root-level files like READMEs and CI configs are no longer mistaken for skill directories.

### Changed

- **3-segment install refs.** `crew install <tap>/<namespace>/<skill>` is now a valid, always-unambiguous ref form. Existing 1- and 2-segment refs continue to work unchanged.
- **README** updated with a Namespaces section showing the new directory layout and all three install forms.