### PR TITLE
[LOG-4699] Release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.7.0] — 2026-05-06
+
+### Changed
+
+- Rebranded the product from Crew to **Homecrew** across the website, README, CLI help text, installer script, and macOS autoupdate service label (`Homecrew Skill Autoupdate`). The `crew` executable, `~/.crew` directory, `.crew.json`, and `metadata.crew` file names are unchanged.
+- Added Logic App, Inc. copyright attribution to the MIT license and package metadata.
+
 ## [0.6.0] — 2026-04-23
 
 ### Added

--- a/PRD.md
+++ b/PRD.md
@@ -2,7 +2,7 @@
 
 **A package manager for Agent Skills.**
 
-Version: 0.6.0
+Version: 0.7.0
 Status: Specification, ready for implementation
 Platform: macOS (Apple Silicon and Intel)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crew",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A package manager for Agent Skills",
   "author": "Logic App, Inc.",
   "license": "MIT",

--- a/site/public/latest-version.json
+++ b/site/public/latest-version.json
@@ -1,13 +1,13 @@
 {
-  "tag_name": "v0.6.0",
+  "tag_name": "v0.7.0",
   "assets": [
     {
       "name": "crew-macos-arm64",
-      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.6.0/crew-macos-arm64"
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.7.0/crew-macos-arm64"
     },
     {
       "name": "crew-macos-x64",
-      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.6.0/crew-macos-x64"
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.7.0/crew-macos-x64"
     }
   ]
 }

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -5,5 +5,5 @@
  * without touching anything else. The value written to the `installed_by`
  * marker field and printed by `crew version` is derived from here.
  */
-export const CREW_VERSION = "0.6.0";
+export const CREW_VERSION = "0.7.0";
 export const CREW_INSTALLED_BY = `crew/${CREW_VERSION}`;


### PR DESCRIPTION
## Changed

- **Rebranded to Homecrew.** The product is now called **Homecrew** across the website, README, CLI help text, installer script, and macOS autoupdate attribution (`Homecrew Skill Autoupdate`). Nothing you type changes — the command, all paths (`~/.crew`), config files (`.crew.json`, `metadata.crew`), and markers stay exactly the same.
- Logic App, Inc. is now listed as the copyright holder in the MIT license and package metadata.