### PR TITLE
[LOG-4705] Skip Linear ticket creation when unavailable

### DIFF
--- a/.github/workflows/create-linear-ticket.yml
+++ b/.github/workflows/create-linear-ticket.yml
@@ -51,16 +51,16 @@ jobs:
             const repoOwner = process.env.REPO_OWNER;
             const repoName = process.env.REPO_NAME;
 
-            if (!apiKey) {
-              core.setFailed('LINEAR_API_KEY is not set');
-              return;
-            }
-
             // A title "has a ticket" iff it contains [XXX-N] with any
             // uppercase team key. If so, do nothing.
             const hasTicket = /\[[A-Z]+-\d+\]/.test(prTitle);
             if (hasTicket) {
               core.info(`PR title already has a ticket marker — skipping: ${prTitle}`);
+              return;
+            }
+
+            if (!apiKey) {
+              core.info('LINEAR_API_KEY is not available in this workflow context — skipping ticket creation.');
               return;
             }
 


### PR DESCRIPTION
## Summary
- Skip Linear ticket creation when the Linear API key is unavailable in a workflow context
- Preserve the existing early return for PR titles that already include a ticket marker

## Why this can happen
GitHub Actions does not expose repository secrets to every pull request workflow run. Untrusted actors such as Dependabot and PRs from forks can trigger the workflow, but GitHub withholds secrets like `LINEAR_API_KEY` so those runs cannot exfiltrate private credentials. In those contexts `secrets.LINEAR_API_KEY` resolves as unavailable/empty, so Linear ticket creation needs to be treated as an optional integration instead of a required check.

## Verification
- git diff --check
- bun run lint