### PR TITLE
[LOG-4706] Add public contribution and security docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing
+
+Thanks for helping improve Homecrew.
+
+This file is the short public contributor guide. If you are changing code, also
+read [CLAUDE.md](./CLAUDE.md); it is the implementation briefing for humans and
+AI agents working in this repository.
+
+## Before You Open a PR
+
+- Search existing issues and pull requests first.
+- Keep PRs small and focused. One behavior change per PR is easiest to review.
+- For security issues, do not open a public issue. Email security@logic.inc.
+- Do not include secrets, private tap contents, access tokens, or credentials in
+  issues, tests, logs, screenshots, or fixtures.
+
+## Spec-Visible Changes
+
+`PRD.md` is the contract for observable CLI behavior. Update `PRD.md` first if
+your change affects anything a user or second implementation could observe, such
+as:
+
+- A command, alias, flag, or output shape.
+- Reference parsing or resolution behavior.
+- Config, state, marker, or tap schema.
+- Error names, exit codes, or conformance criteria.
+- Supported agent adapters.
+
+After the PRD update, make the matching code and test changes in the same PR.
+
+## Development Setup
+
+```sh
+bun install
+bun run src/index.ts version
+bun run build
+```
+
+Run the full gate before asking for review:
+
+```sh
+bun run check
+```
+
+That runs typecheck, Biome, and the full test suite with 100% line and function
+coverage. For a docs-only PR, `bun run lint` is usually enough.
+
+## Local Testing
+
+Use a temporary `CREW_HOME` when trying a local build:
+
+```sh
+CREW_HOME=/tmp/crew-test dist/crew install <ref>
+```
+
+Tests must not write to real agent skill directories such as `~/.claude/skills`
+or `~/.agents/skills`.
+
+## Review Expectations
+
+We optimize for behavior that is easy to explain, test, and maintain. Expect
+review questions about user impact, docs coverage, PRD alignment, and test
+coverage. If a change touches user-visible behavior, check whether the README
+and site still describe it accurately.

--- a/README.md
+++ b/README.md
@@ -472,8 +472,9 @@ without disturbing your real `~/.crew`.
 
 ### Contributing
 
-Please read [`CLAUDE.md`](./CLAUDE.md) before making changes — it's the
-briefing for anyone (human or AI) working on the code. Highlights:
+Please read [`CONTRIBUTING.md`](./CONTRIBUTING.md) first. If you're changing
+code, also read [`CLAUDE.md`](./CLAUDE.md) — it's the implementation briefing
+for anyone (human or AI) working in this repository. Highlights:
 
 - [`PRD.md`](./PRD.md) is the spec and the contract. If a change is
   observable by an external observer (new command, new flag, new error
@@ -490,6 +491,11 @@ briefing for anyone (human or AI) working on the code. Highlights:
 - Errors are `CrewError(code, message, details)` with a stable machine name
   (PRD §13) and a fixed exit code (PRD §15). Never `throw new Error(...)`
   for a user-visible failure.
+
+### Security
+
+Please report security issues privately to security@logic.inc. See
+[`SECURITY.md`](./SECURITY.md) for scope and reporting details.
 
 ### License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security issues privately by emailing security@logic.inc.
+
+Do not open a public GitHub issue for a suspected vulnerability. Include as
+much of the following as you can:
+
+- The affected `crew` version or commit.
+- Your macOS version and CPU architecture.
+- The command or workflow that exposes the issue.
+- Reproduction steps, proof of concept, or relevant logs.
+- Impact: what an attacker could read, write, execute, or cause a user to trust.
+
+We will review the report, follow up if we need more detail, and coordinate a
+fix and disclosure timeline.
+
+## Scope
+
+Security reports are especially useful for:
+
+- Installer or self-update issues, including release artifact integrity.
+- A way for a tap, skill, or repository to make `crew` execute code during
+  install, update, search, or uninstall.
+- A way for `crew` to overwrite files it did not create.
+- A way to escape the intended `~/.crew/` or agent skills directories.
+- Vulnerabilities in release, checksum, or update metadata.
+- Leaks of local filesystem paths, credentials, private tap contents, or other
+  user data.
+
+Normal bugs, feature requests, docs fixes, and support questions can use GitHub
+issues.
+
+## Supported Versions
+
+Security fixes target the latest released version and the current `main`
+branch. Older releases may be fixed when the risk justifies it, but users should
+expect to upgrade with `crew self-update`.


### PR DESCRIPTION
## Summary
- Add a public CONTRIBUTING.md for outside contributors
- Add SECURITY.md with security@logic.inc as the private reporting channel
- Link both docs from the README development section

## Verification
- git diff --check
- bun run lint