### PR TITLE
[LOG-4708] Verify release downloads with checksums

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -938,9 +938,10 @@ binaries, the site just advertises the pointer).
 
 Every release MUST publish a `SHA256SUMS` asset containing SHA-256 hashes
 for `crew-macos-arm64` and `crew-macos-x64`. The hosted installer
-(`https://crew.logic.inc/install.sh`) MUST download this file from the same
-release as the selected binary and verify the chosen asset before installing
-it. A checksum mismatch or missing checksum is a failed install.
+(`https://crew.logic.inc/install.sh`) and `crew self-update` MUST download
+this file from the same release as the selected binary and verify the chosen
+asset before installing it. A checksum mismatch or missing checksum is a
+failed install/update.
 
 Implementations MAY accept `CREW_SELF_UPDATE_RELEASES_URL` to override
 the latest-release URL (used by tests and private forks).
@@ -952,14 +953,20 @@ the latest-release URL (used by tests and private forks).
    - Otherwise fetch the latest-release URL.
 2. If the resolved tag matches the running `CREW_VERSION` and `--force`
    is not set, print "already on the latest version" and exit 0.
-3. Download the asset matching the current CPU architecture
+3. Resolve the asset matching the current CPU architecture
    (`arm64` → `crew-macos-arm64`, `x86_64` → `crew-macos-x64`).
-4. Mark the downloaded file executable. On macOS, clear the
+4. Download both the `SHA256SUMS` asset and the selected binary asset from
+   the resolved release.
+5. Verify that the downloaded binary's SHA-256 digest matches the entry for
+   its asset name in `SHA256SUMS`. If the checksum file is missing,
+   unreachable, malformed for the selected asset, lacks the selected asset,
+   or the digest does not match, fail with `self_update_unavailable`.
+6. Mark the downloaded file executable. On macOS, clear the
    `com.apple.quarantine` extended attribute.
-5. Atomically rename the downloaded file over `process.execPath`. The
+7. Atomically rename the downloaded file over `process.execPath`. The
    running process keeps executing on the old inode; subsequent
    invocations run the new binary.
-6. Record the new version in the version-check file (§10.4) so the
+8. Record the new version in the version-check file (§10.4) so the
    update notice doesn't nag the user about a version they already
    installed.
 
@@ -976,9 +983,12 @@ the latest-release URL (used by tests and private forks).
 
 **Errors.**
 
-- `self_update_unavailable` (exit 5) — the release feed or the asset
-  download couldn't be reached, the release doesn't have an asset for
-  the current arch, or the named `--version` doesn't exist.
+- `self_update_unavailable` (exit 5) — the release feed, checksum asset,
+  or binary asset couldn't be reached; the release doesn't have an asset
+  for the current arch; the release doesn't have a `SHA256SUMS` asset; the
+  checksum file doesn't contain a valid entry for the selected asset; the
+  downloaded binary doesn't match its checksum; or the named `--version`
+  doesn't exist.
 - `self_update_failed` (exit 8) — the replacement step failed (e.g. the
   binary path isn't writable). The old binary is left in place.
 
@@ -1647,8 +1657,8 @@ Implementations and test suites refer to criteria by ID.
 |---|---|---|
 | C-SELF-01 | §10.3 | `crew self-update --check` queries the release feed, prints the latest tag, and makes no filesystem changes. |
 | C-SELF-02 | §10.3 | `crew self-update` on a version equal to `latest_tag` prints "already on the latest version" and exits 0. |
-| C-SELF-03 | §10.3 | `crew self-update` downloads the asset for the current arch, `chmod +x`s it, and atomically renames over the running binary. |
-| C-SELF-04 | §10.3 | A release-feed or asset-download failure produces `self_update_unavailable`, exit 5. |
+| C-SELF-03 | §10.3 | `crew self-update` downloads `SHA256SUMS` and the asset for the current arch, verifies the asset digest, `chmod +x`s it, and atomically renames over the running binary. |
+| C-SELF-04 | §10.3 | A release-feed, asset-download, or checksum-verification failure produces `self_update_unavailable`, exit 5. |
 | C-SELF-05 | §10.3 | A failure to replace the binary produces `self_update_failed`, exit 8. The old binary is left in place. |
 | C-SELF-06 | §10.3 | `crew self-update --version v0.1.0` targets the named tag instead of the latest, and errors `self_update_unavailable` if the tag does not exist. |
 | C-SELF-07 | §10.4 | A human `crew` invocation whose stderr is a TTY and whose cached `latest_tag` differs from `CREW_VERSION` emits exactly one stderr notice naming both versions. |

--- a/PRD.md
+++ b/PRD.md
@@ -925,7 +925,8 @@ Both endpoints emit the same JSON shape:
   "tag_name": "v0.4.0",
   "assets": [
     { "name": "crew-macos-arm64", "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.4.0/crew-macos-arm64" },
-    { "name": "crew-macos-x64",   "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.4.0/crew-macos-x64" }
+    { "name": "crew-macos-x64",   "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.4.0/crew-macos-x64" },
+    { "name": "SHA256SUMS",       "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.4.0/SHA256SUMS" }
   ]
 }
 ```
@@ -934,6 +935,12 @@ The shape matches GitHub's native release response so implementations
 don't need to branch on which endpoint returned the data. The static
 file's asset URLs point at GitHub release downloads (GitHub hosts the
 binaries, the site just advertises the pointer).
+
+Every release MUST publish a `SHA256SUMS` asset containing SHA-256 hashes
+for `crew-macos-arm64` and `crew-macos-x64`. The hosted installer
+(`https://crew.logic.inc/install.sh`) MUST download this file from the same
+release as the selected binary and verify the chosen asset before installing
+it. A checksum mismatch or missing checksum is a failed install.
 
 Implementations MAY accept `CREW_SELF_UPDATE_RELEASES_URL` to override
 the latest-release URL (used by tests and private forks).

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ for examples.
 |---|---|
 | `crew doctor [--verify] [--repair]` | Check integrity between state, markers, and agent directories. `--repair` fixes recoverable drift without ever touching customized files. |
 | `crew cache clean` | Remove ephemeral caches and unreferenced store entries. |
-| `crew self-update [--check]` | Replace the running binary with the latest release. `--check` reports without downloading. |
+| `crew self-update [--check]` | Replace the running binary with the latest verified release. `--check` reports without downloading. |
 
 **Meta**
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ curl -fsSL https://crew.logic.inc/install.sh | sh
 
 A single binary. Drops itself at `~/.local/bin/crew`, plus whatever skills you
 install go under `~/.crew/` and into your agents' skills directories. Nothing
-else. Safe to re-run — upgrades in place. Set `CREW_INSTALL_PREFIX` to pick a
-different location.
+else. The installer verifies the downloaded binary against the release
+`SHA256SUMS` file before installing. Safe to re-run — upgrades in place. Set
+`CREW_INSTALL_PREFIX` to pick a different location.
 
 Uninstall with `rm -rf ~/.crew && rm ~/.local/bin/crew`.
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -264,6 +264,10 @@ if [ -d site/public ]; then
     {
       "name": "crew-macos-x64",
       "browser_download_url": "https://github.com/with-logic/crew/releases/download/${next_tag}/crew-macos-x64"
+    },
+    {
+      "name": "SHA256SUMS",
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/${next_tag}/SHA256SUMS"
     }
   ]
 }

--- a/site/components/sections/Commands.tsx
+++ b/site/components/sections/Commands.tsx
@@ -177,7 +177,7 @@ const GROUPS: readonly Group[] = [
         ),
         description: (
           <>
-            Upgrade the <code>crew</code> binary itself to the latest release.{" "}
+            Upgrade the <code>crew</code> binary itself to the latest verified release.{" "}
             <span className={styles.flag}>--check</span> reports without downloading.
           </>
         ),

--- a/site/components/sections/Install.tsx
+++ b/site/components/sections/Install.tsx
@@ -47,8 +47,9 @@ export function Install() {
 
         <p className={styles.footnote}>
           A single binary. Drops itself in <code>~/.local/bin/crew</code>, plus whatever skills you
-          install go under <code>~/.crew/</code> and into your agents' skills directories. Nothing
-          else. Uninstall with <code>rm -rf ~/.crew &amp;&amp; rm ~/.local/bin/crew</code>.
+          install go under <code>~/.crew/</code> and into your agents' skills directories. The
+          installer verifies the release checksum before installing. Uninstall with{" "}
+          <code>rm -rf ~/.crew &amp;&amp; rm ~/.local/bin/crew</code>.
         </p>
 
         <BuildItYourself prompt={SAAP_FULL_PROMPT} />

--- a/site/public/install.sh
+++ b/site/public/install.sh
@@ -77,6 +77,8 @@ if ! curl -fsSL -o "$tmpfile" "$url"; then
   die "download failed — $url was not reachable. Check the release page at https://github.com/$repo/releases for available versions."
 fi
 
+# Integrity check: same-source means this catches corruption in transit,
+# not a compromised release. Signature verification is planned next.
 log "Verifying checksum"
 if ! curl -fsSL -o "$checksums" "$checksums_url"; then
   die "checksum download failed — $checksums_url was not reachable. Refusing to install an unverified binary."

--- a/site/public/install.sh
+++ b/site/public/install.sh
@@ -8,10 +8,11 @@
 # What it does:
 #   1. Detects your macOS CPU architecture (arm64 or x86_64).
 #   2. Downloads the latest crew release from GitHub.
-#   3. Installs to $CREW_INSTALL_PREFIX (default: ~/.local/bin).
-#   4. Clears the macOS quarantine attribute so Gatekeeper doesn't
+#   3. Verifies the binary against the release SHA256SUMS file.
+#   4. Installs to $CREW_INSTALL_PREFIX (default: ~/.local/bin).
+#   5. Clears the macOS quarantine attribute so Gatekeeper doesn't
 #      block the first run.
-#   5. Tells you how to put the install dir on your PATH if it isn't.
+#   6. Tells you how to put the install dir on your PATH if it isn't.
 #
 # Safe to re-run — upgrades in place.
 #
@@ -37,6 +38,7 @@ die()  { warn "$*"; exit 1; }
 [ "$(uname -s)" = "Darwin" ] || die "Homecrew is macOS-only for now. Linux and Windows are tracked but not yet shipping."
 
 command -v curl >/dev/null 2>&1 || die "\`curl\` is required but not on PATH."
+command -v shasum >/dev/null 2>&1 || die "\`shasum\` is required but not on PATH."
 
 arch="$(uname -m)"
 case "$arch" in
@@ -59,18 +61,35 @@ if [ -z "$version" ]; then
   [ -n "$version" ] || die "could not determine the latest release"
 fi
 
-url="https://github.com/$repo/releases/download/$version/$asset"
+base_url="https://github.com/$repo/releases/download/$version"
+url="$base_url/$asset"
+checksums_url="$base_url/SHA256SUMS"
 log "Downloading $asset ($version)"
 
-# ---------- Download to a tmp file --------------------------------------
+# ---------- Download and verify -----------------------------------------
 
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
 tmpfile="$tmpdir/crew"
+checksums="$tmpdir/SHA256SUMS"
 
 if ! curl -fsSL -o "$tmpfile" "$url"; then
   die "download failed — $url was not reachable. Check the release page at https://github.com/$repo/releases for available versions."
 fi
+
+log "Verifying checksum"
+if ! curl -fsSL -o "$checksums" "$checksums_url"; then
+  die "checksum download failed — $checksums_url was not reachable. Refusing to install an unverified binary."
+fi
+
+expected="$(awk -v asset="$asset" '$2 == asset { print $1; found = 1 } END { if (!found) exit 1 }' "$checksums")" || {
+  die "checksum file did not contain an entry for $asset. Refusing to install."
+}
+actual="$(shasum -a 256 "$tmpfile" | awk '{ print $1 }')"
+if [ "$actual" != "$expected" ]; then
+  die "checksum mismatch for $asset. Expected $expected but got $actual. Refusing to install."
+fi
+ok "checksum verified"
 
 chmod +x "$tmpfile"
 

--- a/site/public/latest-version.json
+++ b/site/public/latest-version.json
@@ -8,6 +8,10 @@
     {
       "name": "crew-macos-x64",
       "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.7.0/crew-macos-x64"
+    },
+    {
+      "name": "SHA256SUMS",
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.7.0/SHA256SUMS"
     }
   ]
 }

--- a/src/self-update/checksum.ts
+++ b/src/self-update/checksum.ts
@@ -1,0 +1,69 @@
+/**
+ * Release checksum verification for binary self-update (§10.3).
+ *
+ * `crew self-update` verifies the downloaded macOS binary against the
+ * release's SHA256SUMS asset before making it executable or replacing
+ * the running binary.
+ */
+
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { CrewError } from "../core/errors.ts";
+import { downloadAssetToTemp } from "./download.ts";
+
+export const CHECKSUMS_ASSET_NAME = "SHA256SUMS";
+
+const SHA256_HEX = /^[a-fA-F0-9]{64}$/;
+
+export function checksumAssetUrl(assets: Readonly<Record<string, string>>, tag: string): string {
+  const url = assets[CHECKSUMS_ASSET_NAME];
+  if (url) return url;
+  throw new CrewError(
+    "self_update_unavailable",
+    `release ${tag} has no asset named \`${CHECKSUMS_ASSET_NAME}\``,
+    { tag, assetName: CHECKSUMS_ASSET_NAME },
+  );
+}
+
+export function downloadChecksums(url: string, timeoutSeconds: number): string {
+  return readFileSync(downloadAssetToTemp(url, timeoutSeconds), "utf8");
+}
+
+export function verifyAssetChecksum(path: string, assetName: string, checksumsText: string): void {
+  const expected = expectedChecksum(checksumsText, assetName);
+  const actual = createHash("sha256").update(readFileSync(path)).digest("hex");
+  if (actual === expected) return;
+  throw new CrewError("self_update_unavailable", `checksum mismatch for ${assetName}`, {
+    assetName,
+    expected,
+    actual,
+  });
+}
+
+export function expectedChecksum(checksumsText: string, assetName: string): string {
+  for (const line of checksumsText.split(/\r?\n/)) {
+    const parsed = parseChecksumLine(line);
+    if (!parsed) continue;
+    const [hash, name] = parsed;
+    if (name !== assetName) continue;
+    if (SHA256_HEX.test(hash)) return hash.toLowerCase();
+    throw new CrewError(
+      "self_update_unavailable",
+      `checksum entry for ${assetName} is not a valid SHA-256 digest`,
+      { assetName, checksum: hash },
+    );
+  }
+  throw new CrewError("self_update_unavailable", `checksum file has no entry for ${assetName}`, {
+    assetName,
+  });
+}
+
+function parseChecksumLine(line: string): readonly [string, string] | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  const firstSpace = trimmed.search(/\s/);
+  if (firstSpace < 0) return null;
+  const hash = trimmed.slice(0, firstSpace);
+  const name = trimmed.slice(firstSpace).trim().replace(/^\*/, "");
+  return [hash, name];
+}

--- a/src/self-update/upgrade.ts
+++ b/src/self-update/upgrade.ts
@@ -9,6 +9,7 @@
 import { CrewError } from "../core/errors.ts";
 import { CREW_VERSION } from "../core/version.ts";
 import { writeVersionCheck } from "./check.ts";
+import { checksumAssetUrl, downloadChecksums, verifyAssetChecksum } from "./checksum.ts";
 import { assetNameForArch, downloadAssetToTemp, installBinary } from "./download.ts";
 import { fetchRelease, releasesByTagUrl, releasesLatestUrl } from "./github.ts";
 
@@ -58,7 +59,10 @@ export function runSelfUpdate(options: SelfUpdateOptions): SelfUpdateResult {
     );
   }
 
+  const checksumUrl = checksumAssetUrl(release.assets, release.tag);
+  const checksumsText = downloadChecksums(checksumUrl, DOWNLOAD_TIMEOUT_SECONDS);
   const tempPath = downloadAssetToTemp(downloadUrl, DOWNLOAD_TIMEOUT_SECONDS);
+  verifyAssetChecksum(tempPath, assetName, checksumsText);
   installBinary(tempPath, resolveDest(options.execPath));
   writeVersionCheck(release.tag, options.home);
   return { currentVersion, latestTag: release.tag, replaced: true };

--- a/tests/self-update/checksum.test.ts
+++ b/tests/self-update/checksum.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Tests for self-update SHA256SUMS parsing and verification (§10.3).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  checksumAssetUrl,
+  expectedChecksum,
+  verifyAssetChecksum,
+} from "../../src/self-update/checksum.ts";
+import { makeCrewHome } from "../helpers/env.ts";
+import { checksumTextFor, currentAssetName, releaseAssets, sha256Hex } from "./helpers.ts";
+
+describe("checksumAssetUrl", () => {
+  test("returns the release SHA256SUMS asset URL", () => {
+    expect(checksumAssetUrl(releaseAssets(), "v1.2.3")).toContain("SHA256SUMS");
+  });
+
+  test("missing SHA256SUMS is self_update_unavailable", () => {
+    expect(() => checksumAssetUrl({}, "v1.2.3")).toThrow(/SHA256SUMS/);
+  });
+});
+
+describe("expectedChecksum", () => {
+  test("finds the selected asset and normalizes uppercase hex", () => {
+    const asset = currentAssetName();
+    const hash = sha256Hex("binary").toUpperCase();
+    const text = `\nnot-a-checksum\n${sha256Hex("other")}  other\n${hash} *${asset}\n`;
+    expect(expectedChecksum(text, asset)).toBe(hash.toLowerCase());
+  });
+
+  test("invalid selected digest is self_update_unavailable", () => {
+    expect(() => expectedChecksum(`nothex  ${currentAssetName()}\n`, currentAssetName())).toThrow(
+      /not a valid SHA-256/,
+    );
+  });
+
+  test("missing selected asset is self_update_unavailable", () => {
+    expect(() => expectedChecksum(checksumTextFor("binary", "other"), currentAssetName())).toThrow(
+      /no entry/,
+    );
+  });
+});
+
+describe("verifyAssetChecksum", () => {
+  test("accepts a matching downloaded binary", () => {
+    const home = makeCrewHome();
+    const path = join(home, "crew");
+    writeFileSync(path, "binary");
+    expect(() =>
+      verifyAssetChecksum(path, currentAssetName(), checksumTextFor("binary")),
+    ).not.toThrow();
+  });
+
+  test("checksum mismatch is self_update_unavailable", () => {
+    const home = makeCrewHome();
+    const path = join(home, "crew");
+    writeFileSync(path, "tampered");
+    expect(() => verifyAssetChecksum(path, currentAssetName(), checksumTextFor("binary"))).toThrow(
+      /checksum mismatch/,
+    );
+  });
+});

--- a/tests/self-update/command.test.ts
+++ b/tests/self-update/command.test.ts
@@ -24,6 +24,7 @@ import {
 } from "../../src/self-update/download.ts";
 import { resetReleaseFetcher, setReleaseFetcher } from "../../src/self-update/github.ts";
 import { captureStreams, makeCrewHome } from "../helpers/env.ts";
+import { currentAssetName, downloaderForBinary, releaseAssets } from "./helpers.ts";
 
 // Force darwin for the happy-path tests — `runSelfUpdate`'s platform
 // guard rejects non-macOS hosts. Without this override every test in
@@ -57,10 +58,6 @@ afterEach(() => {
   resetAssetDownloader();
   resetXattrClearer();
 });
-
-function currentAssetName(): string {
-  return process.arch === "arm64" ? "crew-macos-arm64" : "crew-macos-x64";
-}
 
 const RUNNING_TAG = `v${CREW_VERSION}`;
 
@@ -113,9 +110,9 @@ describe("crew self-update (full upgrade)", () => {
 
     setReleaseFetcher(() => ({
       tag: "v99.99.99",
-      assets: { [currentAssetName()]: "https://example.com/asset" },
+      assets: releaseAssets(),
     }));
-    setAssetDownloader((_url, path) => writeFileSync(path, "NEW"));
+    setAssetDownloader(downloaderForBinary("NEW"));
     setXattrClearer(() => {});
 
     const savedTarget = process.env["CREW_SELF_UPDATE_TARGET"];

--- a/tests/self-update/helpers.ts
+++ b/tests/self-update/helpers.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared fixtures for self-update checksum tests.
+ */
+
+import { createHash } from "node:crypto";
+import { writeFileSync } from "node:fs";
+import { type AssetDownloader, assetNameForArch } from "../../src/self-update/download.ts";
+
+export const ASSET_URL = "https://example.com/asset";
+export const CHECKSUMS_URL = "https://example.com/SHA256SUMS";
+
+export function currentAssetName(): string {
+  return assetNameForArch();
+}
+
+export function sha256Hex(bytes: string): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+export function releaseAssets(bytesUrl: string = ASSET_URL): Record<string, string> {
+  return { [currentAssetName()]: bytesUrl, SHA256SUMS: CHECKSUMS_URL };
+}
+
+export function checksumTextFor(bytes: string, assetName: string = currentAssetName()): string {
+  return `${sha256Hex(bytes)}  ${assetName}\n`;
+}
+
+export function downloaderForBinary(bytes: string): AssetDownloader {
+  return (url, destPath) => {
+    const body = url === CHECKSUMS_URL ? checksumTextFor(bytes) : bytes;
+    writeFileSync(destPath, body);
+  };
+}

--- a/tests/self-update/upgrade.test.ts
+++ b/tests/self-update/upgrade.test.ts
@@ -22,6 +22,12 @@ import {
 import { resetReleaseFetcher, setReleaseFetcher } from "../../src/self-update/github.ts";
 import { runSelfUpdate, runSelfUpdateCheck } from "../../src/self-update/upgrade.ts";
 import { makeCrewHome } from "../helpers/env.ts";
+import {
+  checksumTextFor,
+  currentAssetName,
+  downloaderForBinary,
+  releaseAssets,
+} from "./helpers.ts";
 
 // Force `process.platform === "darwin"` for the duration of this file.
 // `runSelfUpdate`'s platform guard rejects non-macOS hosts (§10.3), so
@@ -42,12 +48,6 @@ afterEach(() => {
   resetXattrClearer();
 });
 
-/** The fake asset name that assetNameForArch returns on this machine. */
-function currentAssetName(): string {
-  if (process.arch === "arm64") return "crew-macos-arm64";
-  return "crew-macos-x64";
-}
-
 describe("runSelfUpdate", () => {
   test("downloads + swaps + refreshes version-check when newer", () => {
     const home = makeCrewHome();
@@ -56,9 +56,9 @@ describe("runSelfUpdate", () => {
 
     setReleaseFetcher(() => ({
       tag: "v99.99.99",
-      assets: { [currentAssetName()]: "https://example.com/asset" },
+      assets: releaseAssets(),
     }));
-    setAssetDownloader((_url, destPath) => writeFileSync(destPath, "NEW"));
+    setAssetDownloader(downloaderForBinary("NEW"));
     setXattrClearer(() => {});
 
     const result = runSelfUpdate({ home, force: false, execPath: dest });
@@ -79,7 +79,7 @@ describe("runSelfUpdate", () => {
     // Stub a release that matches the running CREW_VERSION.
     setReleaseFetcher(() => ({
       tag: `v${CREW_VERSION}`,
-      assets: { [currentAssetName()]: "https://example.com/asset" },
+      assets: releaseAssets(),
     }));
     let downloaderCalled = false;
     setAssetDownloader(() => {
@@ -102,9 +102,9 @@ describe("runSelfUpdate", () => {
 
     setReleaseFetcher(() => ({
       tag: `v${CREW_VERSION}`,
-      assets: { [currentAssetName()]: "https://example.com/asset" },
+      assets: releaseAssets(),
     }));
-    setAssetDownloader((_url, destPath) => writeFileSync(destPath, "FORCED"));
+    setAssetDownloader(downloaderForBinary("FORCED"));
     setXattrClearer(() => {});
 
     const result = runSelfUpdate({ home, force: true, execPath: dest });
@@ -124,6 +124,36 @@ describe("runSelfUpdate", () => {
     );
   });
 
+  test("self_update_unavailable when release has no checksum asset", () => {
+    const home = makeCrewHome();
+    const dest = join(home, "crew-bin");
+    writeFileSync(dest, "OLD");
+
+    setReleaseFetcher(() => ({
+      tag: "v99.99.99",
+      assets: { [currentAssetName()]: "https://example.com/asset" },
+    }));
+
+    expect(() => runSelfUpdate({ home, force: false, execPath: dest })).toThrow(/SHA256SUMS/);
+  });
+
+  test("checksum mismatch leaves the old binary in place", () => {
+    const home = makeCrewHome();
+    const dest = join(home, "crew-bin");
+    writeFileSync(dest, "OLD");
+
+    setReleaseFetcher(() => ({ tag: "v99.99.99", assets: releaseAssets() }));
+    setAssetDownloader((url, destPath) => {
+      const body = url.includes("SHA256SUMS") ? checksumTextFor("EXPECTED") : "TAMPERED";
+      writeFileSync(destPath, body);
+    });
+
+    expect(() => runSelfUpdate({ home, force: false, execPath: dest })).toThrow(
+      /checksum mismatch/,
+    );
+    expect(readFileSync(dest, "utf8")).toBe("OLD");
+  });
+
   test("accepts an explicit tag", () => {
     const home = makeCrewHome();
     const dest = join(home, "crew-bin");
@@ -132,9 +162,9 @@ describe("runSelfUpdate", () => {
     let requestedUrl = "";
     setReleaseFetcher((url) => {
       requestedUrl = url;
-      return { tag: "v0.5.0", assets: { [currentAssetName()]: "https://example.com/asset" } };
+      return { tag: "v0.5.0", assets: releaseAssets() };
     });
-    setAssetDownloader((_url, destPath) => writeFileSync(destPath, "NEW"));
+    setAssetDownloader(downloaderForBinary("NEW"));
     setXattrClearer(() => {});
 
     runSelfUpdate({ home, force: false, execPath: dest, tag: "v0.5.0" });


### PR DESCRIPTION
## Summary
- Make the hosted installer download SHA256SUMS from the selected GitHub release and verify the chosen macOS binary before installing
- Make `crew self-update` download SHA256SUMS, verify the selected binary, and fail with `self_update_unavailable` before replacement on missing or mismatched checksums
- Add SHA256SUMS to the generated latest-version.json release feed
- Document the checksum requirement in the PRD, README, site install section, and self-update command reference

## Verification
- bash -n site/public/install.sh
- bash -n scripts/release.sh
- git diff --check
- bun run lint
- cd site && bun run lint
- cd site && bun run check
- bun test tests/self-update (tests passed; partial-suite coverage threshold exits non-zero as expected)
- bun run check
- cd site && bun run check
