### PR TITLE
[LOG-4712] Add known tap registry foundation

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -1310,9 +1310,10 @@ populate the registry.
 Each known tap entry has:
 
 - `name` — the tap name crew would use if the user chooses to add it.
-- `url` — git clone URL.
+- `url` — git clone URL. All known taps are git taps; path-kind taps are local
+  user state and are never shipped in the known-tap registry.
 - `subpath` — POSIX path inside the repo that forms the tap root; empty for repo
-  root.
+  root, represented as the empty string `""`.
 - `description` — short human-readable tap description.
 - `trust` — either `official` (published by the owner of the tool/service the tap
   represents) or `curated` (reviewed and selected by the Homecrew maintainers).
@@ -1347,6 +1348,11 @@ Example registry sliver:
   }
 ]
 ```
+
+When a command searches the known-tap registry, matching is case-insensitive. If
+the query matches a tap's `name` or `description`, every skill in that tap is
+included in the result set; if it matches only skill metadata, only matching
+skills are included.
 
 Known-tap registry data is a hint. Before installing anything from a known tap,
 Homecrew still adds/clones the tap and resolves the skill from the cloned tap

--- a/PRD.md
+++ b/PRD.md
@@ -1293,6 +1293,38 @@ acme-skills/
 
 Homecrew ships with a registered default tap named `core` at a URL specified by the implementation's build. The default tap is always listed first in `crew tap list` and cannot be removed via `crew tap remove core` unless `--force` is used.
 
+### 16.2.1 Known tap registry
+
+Homecrew MAY ship a bundled registry of known-but-untapped skill taps. This
+registry is a local discovery artifact, not a configured tap list: entries do
+not appear in `crew tap list`, are not cloned automatically, and do not affect
+install/search behavior unless a command section explicitly says it consults the
+known-tap registry.
+
+The registry exists to solve the blank-canvas problem without cloning many repos
+on first run. Implementations SHOULD build it ahead of release by indexing a
+curated set of trusted taps, then ship the resulting compact snapshot in the
+binary/site assets. A client MUST NOT clone or fetch every known tap merely to
+populate the registry.
+
+Each known tap entry has:
+
+- `name` — the tap name crew would use if the user chooses to add it.
+- `url` — git clone URL.
+- `subpath` — POSIX path inside the repo that forms the tap root; empty for repo
+  root.
+- `description` — short human-readable tap description.
+- `trust` — either `official` (published by the owner of the tool/service the tap
+  represents) or `curated` (reviewed and selected by the Homecrew maintainers).
+- `skills` — precomputed skill summaries. Each skill summary has `name`,
+  `namespace` (`string | null`), `description`, and `path` (POSIX path relative
+  to the tap root).
+
+Known-tap registry data is a hint. Before installing anything from a known tap,
+Homecrew still adds/clones the tap and resolves the skill from the cloned tap
+contents using the normal tap rules. If the upstream repo changed or disappeared
+since the registry was built, the normal tap-add or install error applies.
+
 ### 16.3 Tap management
 
 - `crew tap add <url-or-path> [<name>]` registers a tap.

--- a/PRD.md
+++ b/PRD.md
@@ -1320,6 +1320,34 @@ Each known tap entry has:
   `namespace` (`string | null`), `description`, and `path` (POSIX path relative
   to the tap root).
 
+Example registry sliver:
+
+```json
+[
+  {
+    "name": "supabase",
+    "url": "https://github.com/example/supabase-skills.git",
+    "subpath": "skills",
+    "description": "Supabase database, auth, storage, and edge function workflows.",
+    "trust": "curated",
+    "skills": [
+      {
+        "name": "schema-review",
+        "namespace": "database",
+        "description": "Review SQL migrations and RLS policies for correctness.",
+        "path": "database/schema-review"
+      },
+      {
+        "name": "auth-policy-audit",
+        "namespace": null,
+        "description": "Audit auth flows and access-control assumptions.",
+        "path": "auth-policy-audit"
+      }
+    ]
+  }
+]
+```
+
 Known-tap registry data is a hint. Before installing anything from a known tap,
 Homecrew still adds/clones the tap and resolves the skill from the cloned tap
 contents using the normal tap rules. If the upstream repo changed or disappeared

--- a/src/known-taps/convert.ts
+++ b/src/known-taps/convert.ts
@@ -5,9 +5,14 @@
 import type { TapConfig } from "../core/types.ts";
 import type { KnownTap } from "./types.ts";
 
+/**
+ * Convert a known tap into a user-registered git tap after the user
+ * chooses to add it. Discovery-only rendering must not persist this.
+ */
 export function tapConfigFromKnownTap(tap: KnownTap): TapConfig {
   return {
     name: tap.name,
+    // Known taps are git taps by construction; path taps are local state.
     kind: "git",
     registered: true,
     url: tap.url,

--- a/src/known-taps/convert.ts
+++ b/src/known-taps/convert.ts
@@ -1,0 +1,17 @@
+/**
+ * Conversion helpers for the bundled known-tap registry (§16.2.1).
+ */
+
+import type { TapConfig } from "../core/types.ts";
+import type { KnownTap } from "./types.ts";
+
+export function tapConfigFromKnownTap(tap: KnownTap): TapConfig {
+  return {
+    name: tap.name,
+    kind: "git",
+    registered: true,
+    url: tap.url,
+    subpath: tap.subpath,
+    path: "",
+  };
+}

--- a/src/known-taps/registry.ts
+++ b/src/known-taps/registry.ts
@@ -1,0 +1,11 @@
+/**
+ * Bundled known-tap registry snapshot (§16.2.1).
+ *
+ * This data is intentionally inert: commands must explicitly opt into
+ * consulting it. Keeping it local lets discovery avoid first-run cloning
+ * of every known tap.
+ */
+
+import type { KnownTap } from "./types.ts";
+
+export const KNOWN_TAPS: readonly KnownTap[] = [];

--- a/src/known-taps/search.ts
+++ b/src/known-taps/search.ts
@@ -1,0 +1,66 @@
+/**
+ * Search helpers for the bundled known-tap registry (§16.2.1).
+ */
+
+import { KNOWN_TAPS } from "./registry.ts";
+import type { KnownTap, KnownTapHit, KnownTapSkill } from "./types.ts";
+
+export function searchKnownTaps(
+  query: string,
+  registry: readonly KnownTap[] = KNOWN_TAPS,
+): readonly KnownTapHit[] {
+  const normalized = query.trim().toLowerCase();
+  const hits: KnownTapHit[] = [];
+  for (const tap of registry) {
+    const tapMatches = knownTapMatches(tap, normalized);
+    for (const skill of tap.skills) {
+      if (tapMatches || knownTapSkillMatches(skill, normalized)) hits.push({ tap, skill });
+    }
+  }
+  hits.sort(compareKnownTapHits);
+  return hits;
+}
+
+export function findKnownTapByName(
+  name: string,
+  registry: readonly KnownTap[] = KNOWN_TAPS,
+): KnownTap | null {
+  for (const tap of registry) {
+    if (tap.name === name) return tap;
+  }
+  return null;
+}
+
+export function findKnownTapSkill(
+  tap: KnownTap,
+  name: string,
+  namespace: string | null = null,
+): KnownTapSkill | null {
+  for (const skill of tap.skills) {
+    if (skill.name === name && skill.namespace === namespace) return skill;
+  }
+  return null;
+}
+
+export function knownTapSkillLabel(skill: KnownTapSkill): string {
+  if (skill.namespace === null) return skill.name;
+  return `${skill.namespace}/${skill.name}`;
+}
+
+function knownTapMatches(tap: KnownTap, query: string): boolean {
+  return query === "" || tap.name.includes(query) || tap.description.toLowerCase().includes(query);
+}
+
+function knownTapSkillMatches(skill: KnownTapSkill, query: string): boolean {
+  return (
+    query === "" ||
+    skill.name.includes(query) ||
+    skill.description.toLowerCase().includes(query) ||
+    knownTapSkillLabel(skill).includes(query)
+  );
+}
+
+function compareKnownTapHits(a: KnownTapHit, b: KnownTapHit): number {
+  if (a.tap.name !== b.tap.name) return a.tap.name.localeCompare(b.tap.name);
+  return knownTapSkillLabel(a.skill).localeCompare(knownTapSkillLabel(b.skill));
+}

--- a/src/known-taps/search.ts
+++ b/src/known-taps/search.ts
@@ -12,6 +12,7 @@ export function searchKnownTaps(
   const normalized = query.trim().toLowerCase();
   const hits: KnownTapHit[] = [];
   for (const tap of registry) {
+    // A tap-level match deliberately includes every skill in that tap.
     const tapMatches = knownTapMatches(tap, normalized);
     for (const skill of tap.skills) {
       if (tapMatches || knownTapSkillMatches(skill, normalized)) hits.push({ tap, skill });
@@ -25,8 +26,9 @@ export function findKnownTapByName(
   name: string,
   registry: readonly KnownTap[] = KNOWN_TAPS,
 ): KnownTap | null {
+  // Case-insensitive exact lookup; use searchKnownTaps for fuzzy queries.
   for (const tap of registry) {
-    if (tap.name === name) return tap;
+    if (sameText(tap.name, name)) return tap;
   }
   return null;
 }
@@ -36,8 +38,9 @@ export function findKnownTapSkill(
   name: string,
   namespace: string | null = null,
 ): KnownTapSkill | null {
+  // Case-insensitive exact lookup; use searchKnownTaps for fuzzy queries.
   for (const skill of tap.skills) {
-    if (skill.name === name && skill.namespace === namespace) return skill;
+    if (sameText(skill.name, name) && sameNullableText(skill.namespace, namespace)) return skill;
   }
   return null;
 }
@@ -58,6 +61,15 @@ function knownTapMatches(tap: KnownTap, query: string): boolean {
 function knownTapSkillMatches(skill: KnownTapSkill, query: string): boolean {
   const label = knownTapSkillLabel(skill).toLowerCase();
   return query === "" || skill.description.toLowerCase().includes(query) || label.includes(query);
+}
+
+function sameText(a: string, b: string): boolean {
+  return a.toLowerCase() === b.toLowerCase();
+}
+
+function sameNullableText(a: string | null, b: string | null): boolean {
+  if (a === null || b === null) return a === b;
+  return sameText(a, b);
 }
 
 function compareKnownTapHits(a: KnownTapHit, b: KnownTapHit): number {

--- a/src/known-taps/search.ts
+++ b/src/known-taps/search.ts
@@ -48,16 +48,16 @@ export function knownTapSkillLabel(skill: KnownTapSkill): string {
 }
 
 function knownTapMatches(tap: KnownTap, query: string): boolean {
-  return query === "" || tap.name.includes(query) || tap.description.toLowerCase().includes(query);
+  return (
+    query === "" ||
+    tap.name.toLowerCase().includes(query) ||
+    tap.description.toLowerCase().includes(query)
+  );
 }
 
 function knownTapSkillMatches(skill: KnownTapSkill, query: string): boolean {
-  return (
-    query === "" ||
-    skill.name.includes(query) ||
-    skill.description.toLowerCase().includes(query) ||
-    knownTapSkillLabel(skill).includes(query)
-  );
+  const label = knownTapSkillLabel(skill).toLowerCase();
+  return query === "" || skill.description.toLowerCase().includes(query) || label.includes(query);
 }
 
 function compareKnownTapHits(a: KnownTapHit, b: KnownTapHit): number {

--- a/src/known-taps/types.ts
+++ b/src/known-taps/types.ts
@@ -2,8 +2,6 @@
  * Types for the bundled known-tap registry (§16.2.1).
  */
 
-import type { TapConfig } from "../core/types.ts";
-
 export type KnownTapTrust = "official" | "curated";
 
 export interface KnownTapSkill {
@@ -26,15 +24,4 @@ export interface KnownTap {
 export interface KnownTapHit {
   readonly tap: KnownTap;
   readonly skill: KnownTapSkill;
-}
-
-export function tapConfigFromKnownTap(tap: KnownTap): TapConfig {
-  return {
-    name: tap.name,
-    kind: "git",
-    registered: true,
-    url: tap.url,
-    subpath: tap.subpath,
-    path: "",
-  };
 }

--- a/src/known-taps/types.ts
+++ b/src/known-taps/types.ts
@@ -1,0 +1,40 @@
+/**
+ * Types for the bundled known-tap registry (§16.2.1).
+ */
+
+import type { TapConfig } from "../core/types.ts";
+
+export type KnownTapTrust = "official" | "curated";
+
+export interface KnownTapSkill {
+  readonly name: string;
+  readonly namespace: string | null;
+  readonly description: string;
+  /** POSIX path to the skill directory, relative to the tap root. */
+  readonly path: string;
+}
+
+export interface KnownTap {
+  readonly name: string;
+  readonly url: string;
+  readonly subpath: string;
+  readonly description: string;
+  readonly trust: KnownTapTrust;
+  readonly skills: readonly KnownTapSkill[];
+}
+
+export interface KnownTapHit {
+  readonly tap: KnownTap;
+  readonly skill: KnownTapSkill;
+}
+
+export function tapConfigFromKnownTap(tap: KnownTap): TapConfig {
+  return {
+    name: tap.name,
+    kind: "git",
+    registered: true,
+    url: tap.url,
+    subpath: tap.subpath,
+    path: "",
+  };
+}

--- a/tests/known-taps/search.test.ts
+++ b/tests/known-taps/search.test.ts
@@ -72,7 +72,7 @@ describe("searchKnownTaps", () => {
     ]);
   });
 
-  test("name and label matching is case-insensitive", () => {
+  test("tap name matching is case-insensitive", () => {
     const mixedCaseRegistry: readonly KnownTap[] = [
       {
         name: "OpenAI",
@@ -94,6 +94,27 @@ describe("searchKnownTaps", () => {
     expect(searchKnownTaps("openai", mixedCaseRegistry).map((h) => h.skill.name)).toEqual([
       "Prompt-Eval",
     ]);
+  });
+
+  test("namespaced skill label matching is case-insensitive", () => {
+    const mixedCaseRegistry: readonly KnownTap[] = [
+      {
+        name: "OpenAI",
+        url: "https://github.com/openai/agent-skills.git",
+        subpath: "",
+        description: "API workflows",
+        trust: "official",
+        skills: [
+          {
+            name: "Prompt-Eval",
+            namespace: "Evals",
+            description: "Run checks",
+            path: "Evals/Prompt-Eval",
+          },
+        ],
+      },
+    ];
+
     expect(searchKnownTaps("evals/prompt", mixedCaseRegistry).map((h) => h.skill.name)).toEqual([
       "Prompt-Eval",
     ]);
@@ -105,17 +126,23 @@ describe("searchKnownTaps", () => {
 });
 
 describe("known tap lookup", () => {
-  test("findKnownTapByName returns exact matches only", () => {
-    expect(findKnownTapByName("openai", registry)?.url).toContain("openai");
-    expect(findKnownTapByName("OpenAI", registry)).toBeNull();
+  test("findKnownTapByName returns null when the registry is empty", () => {
+    expect(findKnownTapByName("anything", [])).toBeNull();
   });
 
-  test("findKnownTapSkill respects namespace", () => {
+  test("findKnownTapByName returns case-insensitive exact matches only", () => {
+    expect(findKnownTapByName("openai", registry)?.url).toContain("openai");
+    expect(findKnownTapByName("OpenAI", registry)?.url).toContain("openai");
+    expect(findKnownTapByName("open", registry)).toBeNull();
+  });
+
+  test("findKnownTapSkill uses case-insensitive exact name and namespace", () => {
     const tap = registry[0]!;
-    expect(findKnownTapSkill(tap, "schema-review", "database")?.path).toBe(
+    expect(findKnownTapSkill(tap, "Schema-Review", "Database")?.path).toBe(
       "skills/database/schema-review",
     );
     expect(findKnownTapSkill(tap, "schema-review")).toBeNull();
+    expect(findKnownTapSkill(tap, "schema", "database")).toBeNull();
   });
 
   test("tapConfigFromKnownTap creates a registered git tap config", () => {

--- a/tests/known-taps/search.test.ts
+++ b/tests/known-taps/search.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Tests for the bundled known-tap registry helpers (§16.2.1).
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  findKnownTapByName,
+  findKnownTapSkill,
+  knownTapSkillLabel,
+  searchKnownTaps,
+} from "../../src/known-taps/search.ts";
+import { type KnownTap, tapConfigFromKnownTap } from "../../src/known-taps/types.ts";
+
+const registry: readonly KnownTap[] = [
+  {
+    name: "supabase",
+    url: "https://github.com/supabase/agent-skills.git",
+    subpath: "skills",
+    description: "Database and auth workflows",
+    trust: "official",
+    skills: [
+      {
+        name: "schema-review",
+        namespace: "database",
+        description: "Review SQL migrations",
+        path: "skills/database/schema-review",
+      },
+      {
+        name: "edge-functions",
+        namespace: null,
+        description: "Deploy edge code",
+        path: "skills/edge-functions",
+      },
+    ],
+  },
+  {
+    name: "openai",
+    url: "https://github.com/openai/agent-skills.git",
+    subpath: "",
+    description: "Model and API workflows",
+    trust: "curated",
+    skills: [
+      {
+        name: "prompt-eval",
+        namespace: null,
+        description: "Evaluate prompts",
+        path: "prompt-eval",
+      },
+    ],
+  },
+];
+
+describe("searchKnownTaps", () => {
+  test("empty query returns every known skill sorted by tap and label", () => {
+    const labels = searchKnownTaps("", registry).map((h) => knownTapSkillLabel(h.skill));
+    expect(labels).toEqual(["prompt-eval", "database/schema-review", "edge-functions"]);
+  });
+
+  test("query matches tap metadata, skill metadata, and namespaced labels", () => {
+    expect(searchKnownTaps("auth", registry).map((h) => h.skill.name)).toEqual([
+      "schema-review",
+      "edge-functions",
+    ]);
+    expect(searchKnownTaps("sql", registry).map((h) => h.skill.name)).toEqual(["schema-review"]);
+    expect(searchKnownTaps("database/schema", registry).map((h) => h.skill.name)).toEqual([
+      "schema-review",
+    ]);
+  });
+
+  test("default registry is currently empty", () => {
+    expect(searchKnownTaps("anything")).toEqual([]);
+  });
+});
+
+describe("known tap lookup", () => {
+  test("findKnownTapByName returns exact matches only", () => {
+    expect(findKnownTapByName("openai", registry)?.url).toContain("openai");
+    expect(findKnownTapByName("OpenAI", registry)).toBeNull();
+  });
+
+  test("findKnownTapSkill respects namespace", () => {
+    const tap = registry[0]!;
+    expect(findKnownTapSkill(tap, "schema-review", "database")?.path).toBe(
+      "skills/database/schema-review",
+    );
+    expect(findKnownTapSkill(tap, "schema-review")).toBeNull();
+  });
+
+  test("tapConfigFromKnownTap creates a registered git tap config", () => {
+    expect(tapConfigFromKnownTap(registry[0]!)).toEqual({
+      name: "supabase",
+      kind: "git",
+      registered: true,
+      url: "https://github.com/supabase/agent-skills.git",
+      subpath: "skills",
+      path: "",
+    });
+  });
+});

--- a/tests/known-taps/search.test.ts
+++ b/tests/known-taps/search.test.ts
@@ -3,13 +3,14 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import { tapConfigFromKnownTap } from "../../src/known-taps/convert.ts";
 import {
   findKnownTapByName,
   findKnownTapSkill,
   knownTapSkillLabel,
   searchKnownTaps,
 } from "../../src/known-taps/search.ts";
-import { type KnownTap, tapConfigFromKnownTap } from "../../src/known-taps/types.ts";
+import type { KnownTap } from "../../src/known-taps/types.ts";
 
 const registry: readonly KnownTap[] = [
   {
@@ -57,6 +58,10 @@ describe("searchKnownTaps", () => {
   });
 
   test("query matches tap metadata, skill metadata, and namespaced labels", () => {
+    expect(searchKnownTaps("supa", registry).map((h) => h.skill.name)).toEqual([
+      "schema-review",
+      "edge-functions",
+    ]);
     expect(searchKnownTaps("auth", registry).map((h) => h.skill.name)).toEqual([
       "schema-review",
       "edge-functions",
@@ -64,6 +69,33 @@ describe("searchKnownTaps", () => {
     expect(searchKnownTaps("sql", registry).map((h) => h.skill.name)).toEqual(["schema-review"]);
     expect(searchKnownTaps("database/schema", registry).map((h) => h.skill.name)).toEqual([
       "schema-review",
+    ]);
+  });
+
+  test("name and label matching is case-insensitive", () => {
+    const mixedCaseRegistry: readonly KnownTap[] = [
+      {
+        name: "OpenAI",
+        url: "https://github.com/openai/agent-skills.git",
+        subpath: "",
+        description: "API workflows",
+        trust: "official",
+        skills: [
+          {
+            name: "Prompt-Eval",
+            namespace: "Evals",
+            description: "Run checks",
+            path: "Evals/Prompt-Eval",
+          },
+        ],
+      },
+    ];
+
+    expect(searchKnownTaps("openai", mixedCaseRegistry).map((h) => h.skill.name)).toEqual([
+      "Prompt-Eval",
+    ]);
+    expect(searchKnownTaps("evals/prompt", mixedCaseRegistry).map((h) => h.skill.name)).toEqual([
+      "Prompt-Eval",
     ]);
   });
 


### PR DESCRIPTION
## Summary
- Specify a bundled known-tap registry snapshot in the PRD, with explicit no-first-run-cloning semantics
- Add typed known-tap registry/search helpers for future search/install integrations
- Add unit coverage for registry search, lookup, labels, and tap-config conversion

## Notes
This PR intentionally does not change CLI output or install behavior yet. The registry is inert until later PRs explicitly wire it into search/install flows.

On the discovery design: we should ship a precomputed registry snapshot rather than clone many repos on first run. Git sparse/partial clone can reduce object transfer for a selected repo, but it still requires one network operation per repo and does not avoid needing an index source. The bundled snapshot keeps first-run behavior offline/fast, and normal git cloning only happens after the user chooses to tap a known repo.

## Verification
- bun run check