### PR TITLE
[LOG-4713] Fix ambiguous tap install test prompt

### DIFF
--- a/tests/e2e/tap-install.test.ts
+++ b/tests/e2e/tap-install.test.ts
@@ -127,7 +127,7 @@ describe("tap source install", () => {
     const code = runCli(["install", "alpha"], {
       home,
       streams: c.streams,
-      prompt: () => "abort",
+      promptChoice: () => "abort",
     });
     expect(code).toBe(4);
     expect(c.stderr()).toContain("ambiguous across taps");

--- a/tests/e2e/tap-install.test.ts
+++ b/tests/e2e/tap-install.test.ts
@@ -123,8 +123,14 @@ describe("tap source install", () => {
       streams: captureStreams().streams,
     });
     runCli(["tap", "remove", "core", "--force"], { home, streams: captureStreams().streams });
-    const code = runCli(["install", "alpha"], { home, streams: captureStreams().streams });
+    const c = captureStreams();
+    const code = runCli(["install", "alpha"], {
+      home,
+      streams: c.streams,
+      prompt: () => "abort",
+    });
     expect(code).toBe(4);
+    expect(c.stderr()).toContain("ambiguous across taps");
   });
 
   test("bare dependency falls back to parent's tap", () => {


### PR DESCRIPTION
## Summary
- Make the ambiguous bare-name tap install test inject an abort prompt instead of inheriting the caller's TTY stdin.
- Assert the ambiguous-reference error text so the test proves it hit the intended failure path.

## Test plan
- bun test tests/e2e/tap-install.test.ts (test file passes; single-file run exits non-zero because global coverage is intentionally incomplete)
- bun run check