### PR TITLE
[LOG-4714] Make install refs case-insensitive

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -648,6 +648,13 @@ tap-ref     := any non-empty string not containing "/" or whitespace
 subpath     := any POSIX relative path not starting with "/"
 ```
 
+Tap-source identifiers are matched case-insensitively and canonicalized to
+lowercase before lookup. For example, `crew install Core/Python-Testing`
+resolves identically to `crew install core/python-testing`. This
+case-insensitivity applies only to tap-source identifiers (`tap-name`,
+`namespace-name`, and `skill-name`); path sources and git URLs keep their
+normal filesystem/source semantics.
+
 ### 8.5 Disambiguation precedence
 
 When the argument could match multiple forms, crew applies these rules in order:
@@ -673,6 +680,7 @@ shift which form applies.
 Given one or more skill references on the command line, `crew install` proceeds as follows. Every step is mandatory.
 
 1. **Parse each reference** per §8 into a structured source.
+   Tap-source names are canonicalized to lowercase during parsing.
 2. **Acquire the source contents** by attributing the install to a tap (§16):
    - Bare-name reference (`foo`) or qualified reference (`<tap>/foo`): use the named (or matching) registered/auto tap. Clone its repo if absent; never fetches per the network policy in §16.6.
    - Tap-name reference (`<tap-name>` with no slash) where `<tap-name>` matches a configured tap: install the entire tap (every skill it currently exposes).
@@ -1437,6 +1445,7 @@ Implementations and test suites refer to criteria by ID.
 | C-REF-18 | §8.2 | `@owner/repo` is parsed as a git source and expanded to `https://github.com/owner/repo.git` (identical handling to `gh:owner/repo`). |
 | C-REF-19 | §8.2 | `@owner/repo@v1.0.0` is parsed as a git source with ref `v1.0.0` (leading `@` is the shorthand, infix `@` is the ref separator). |
 | C-REF-20 | §8.2 | `@owner/repo//sub/path` is parsed as a git source with subpath `sub/path`. |
+| C-REF-21 | §8.4 | Tap-source identifiers are case-insensitive and canonicalized to lowercase before lookup; path sources and git URLs are not case-normalized. |
 
 #### C-SPEC: Skill spec validation (§9 step 4)
 

--- a/src/commands/install/index.ts
+++ b/src/commands/install/index.ts
@@ -123,6 +123,7 @@ function resolveCollisions(ctx: CommandContext, config: Config): string[] {
   const kindHint = readKindHint(ctx);
   for (const raw of ctx.positional) {
     const trimmed = raw.trim();
+    const canonical = trimmed.toLowerCase();
     if (!isBareName(trimmed)) {
       refs.push(raw);
       continue;
@@ -132,9 +133,9 @@ function resolveCollisions(ctx: CommandContext, config: Config): string[] {
       refs.push(raw);
       continue;
     }
-    const collision = detectCollision(trimmed, config, ctx.home);
+    const collision = detectCollision(canonical, config, ctx.home);
     if (collision && !ctx.flags.yes) {
-      refs.push(promptForCollision(ctx, collision, trimmed, raw));
+      refs.push(promptForCollision(ctx, collision, canonical, raw));
       continue;
     }
     if (collision) {
@@ -143,7 +144,7 @@ function resolveCollisions(ctx: CommandContext, config: Config): string[] {
     }
     // No tap-vs-other-tap-skill collision. Check for bare-name
     // ambiguity across skills and namespaces (§8.3).
-    refs.push(promptBareNameAmbiguity(ctx, config, trimmed, raw));
+    refs.push(promptBareNameAmbiguity(ctx, config, canonical, raw));
   }
   return refs;
 }

--- a/src/refs/parsers.ts
+++ b/src/refs/parsers.ts
@@ -15,7 +15,6 @@ import type { PathSource, TapSource } from "../core/types.ts";
 
 /** Matches a canonical Agent Skills name (also used for stored tap names). */
 export const NAME_PATTERN = /^[a-z][a-z0-9-]*$/;
-const TAP_REF_NAME_PATTERN = /^[a-z][a-z0-9-]*$/i;
 
 /** True if `ref` should be treated as a path source. */
 export function looksLikePath(ref: string): boolean {
@@ -65,22 +64,25 @@ export function parseTap(ref: string): TapSource {
         { ref },
       );
     }
+    const normalized: string[] = [];
     for (const p of parts) {
-      if (!TAP_REF_NAME_PATTERN.test(p)) {
+      const lower = p.toLowerCase();
+      if (!NAME_PATTERN.test(lower)) {
         throw new CrewError(
           "invalid_ref",
-          `\`${ref}\` isn't a valid tap reference — names must match [a-z][a-z0-9-]*, case-insensitively`,
+          `\`${ref}\` isn't a valid tap reference — names may only contain letters, digits, and hyphens`,
           { ref },
         );
       }
+      normalized.push(lower);
     }
     if (parts.length === 3) {
-      const [tap, namespace, name] = parts as [string, string, string];
+      const [tap, namespace, name] = normalized as [string, string, string];
       return {
         type: "tap",
-        tap: tap.toLowerCase(),
-        namespace: namespace.toLowerCase(),
-        name: name.toLowerCase(),
+        tap,
+        namespace,
+        name,
         ref: gitRef,
       };
     }
@@ -88,21 +90,22 @@ export function parseTap(ref: string): TapSource {
     // the resolver. We store the first segment in `tap` as the common
     // case; the resolver falls back to namespace interpretation if no
     // tap of that name exists.
-    const [first, second] = parts as [string, string];
+    const [first, second] = normalized as [string, string];
     return {
       type: "tap",
-      tap: first.toLowerCase(),
+      tap: first,
       namespace: null,
-      name: second.toLowerCase(),
+      name: second,
       ref: gitRef,
     };
   }
 
   // Bare name.
-  if (!TAP_REF_NAME_PATTERN.test(identifier)) {
+  const name = identifier.toLowerCase();
+  if (!NAME_PATTERN.test(name)) {
     throw new CrewError(
       "invalid_ref",
-      `\`${ref}\` isn't a valid skill name (must match [a-z][a-z0-9-]*, case-insensitively) or a known ref shape`,
+      `\`${ref}\` isn't a valid skill name (names may only contain letters, digits, and hyphens) or a known ref shape`,
       { ref },
     );
   }
@@ -110,7 +113,7 @@ export function parseTap(ref: string): TapSource {
     type: "tap",
     tap: null,
     namespace: null,
-    name: identifier.toLowerCase(),
+    name,
     ref: gitRef,
   };
 }

--- a/src/refs/parsers.ts
+++ b/src/refs/parsers.ts
@@ -13,8 +13,9 @@ import { isAbsolute, resolve } from "node:path";
 import { CrewError } from "../core/errors.ts";
 import type { PathSource, TapSource } from "../core/types.ts";
 
-/** Matches an Agent Skills name (also used for tap names). */
+/** Matches a canonical Agent Skills name (also used for stored tap names). */
 export const NAME_PATTERN = /^[a-z][a-z0-9-]*$/;
+const TAP_REF_NAME_PATTERN = /^[a-z][a-z0-9-]*$/i;
 
 /** True if `ref` should be treated as a path source. */
 export function looksLikePath(ref: string): boolean {
@@ -65,33 +66,51 @@ export function parseTap(ref: string): TapSource {
       );
     }
     for (const p of parts) {
-      if (!NAME_PATTERN.test(p)) {
+      if (!TAP_REF_NAME_PATTERN.test(p)) {
         throw new CrewError(
           "invalid_ref",
-          `\`${ref}\` isn't a valid tap reference — names must match [a-z][a-z0-9-]*`,
+          `\`${ref}\` isn't a valid tap reference — names must match [a-z][a-z0-9-]*, case-insensitively`,
           { ref },
         );
       }
     }
     if (parts.length === 3) {
       const [tap, namespace, name] = parts as [string, string, string];
-      return { type: "tap", tap, namespace, name, ref: gitRef };
+      return {
+        type: "tap",
+        tap: tap.toLowerCase(),
+        namespace: namespace.toLowerCase(),
+        name: name.toLowerCase(),
+        ref: gitRef,
+      };
     }
     // 2-segment: leave disambiguation (tap/skill vs namespace/skill) to
     // the resolver. We store the first segment in `tap` as the common
     // case; the resolver falls back to namespace interpretation if no
     // tap of that name exists.
     const [first, second] = parts as [string, string];
-    return { type: "tap", tap: first, namespace: null, name: second, ref: gitRef };
+    return {
+      type: "tap",
+      tap: first.toLowerCase(),
+      namespace: null,
+      name: second.toLowerCase(),
+      ref: gitRef,
+    };
   }
 
   // Bare name.
-  if (!NAME_PATTERN.test(identifier)) {
+  if (!TAP_REF_NAME_PATTERN.test(identifier)) {
     throw new CrewError(
       "invalid_ref",
-      `\`${ref}\` isn't a valid skill name (must match [a-z][a-z0-9-]*) or a known ref shape`,
+      `\`${ref}\` isn't a valid skill name (must match [a-z][a-z0-9-]*, case-insensitively) or a known ref shape`,
       { ref },
     );
   }
-  return { type: "tap", tap: null, namespace: null, name: identifier, ref: gitRef };
+  return {
+    type: "tap",
+    tap: null,
+    namespace: null,
+    name: identifier.toLowerCase(),
+    ref: gitRef,
+  };
 }

--- a/tests/e2e/namespaces.test.ts
+++ b/tests/e2e/namespaces.test.ts
@@ -112,6 +112,24 @@ describe("C-NS-03 3-segment install", () => {
     expect(state.installations.length).toBe(1);
     expect(state.installations[0]!.name).toBe("email-outreach");
   });
+
+  test("tap/ns/skill is case-insensitive", () => {
+    const home = makeCrewHome();
+    runCli(["tap", "remove", "core", "--force"], { home, streams: captureStreams().streams });
+    const repo = buildNamespacedTap("ns-3seg-case-", {
+      marketing: ["email-outreach"],
+    });
+    runCli(["tap", "add", `file://${repo}`, "acme"], {
+      home,
+      streams: captureStreams().streams,
+    });
+    const code = runCli(["install", "Acme/Marketing/Email-Outreach"], {
+      home,
+      streams: captureStreams().streams,
+    });
+    expect(code).toBe(0);
+    expect(readState(home).installations[0]!.name).toBe("email-outreach");
+  });
 });
 
 describe("C-NS-04 2-segment ns/skill", () => {

--- a/tests/e2e/tap-install.test.ts
+++ b/tests/e2e/tap-install.test.ts
@@ -81,6 +81,19 @@ describe("tap source install", () => {
     expect(existsSync(join(ccRoot, "alpha"))).toBe(true);
   });
 
+  test("bare skill install is case-insensitive", () => {
+    const home = makeCrewHome();
+    const repo = buildTapRepo();
+    runCli(["tap", "add", `file://${repo}`, "mytap"], {
+      home,
+      streams: captureStreams().streams,
+    });
+    runCli(["tap", "remove", "core", "--force"], { home, streams: captureStreams().streams });
+    const code = runCli(["install", "Alpha"], { home, streams: captureStreams().streams });
+    expect(code).toBe(0);
+    expect(existsSync(join(ccRoot, "alpha"))).toBe(true);
+  });
+
   test("qualified tap ref", () => {
     const home = makeCrewHome();
     const repo = buildTapRepo();
@@ -90,6 +103,18 @@ describe("tap source install", () => {
     });
     runCli(["tap", "remove", "core", "--force"], { home, streams: captureStreams().streams });
     const code = runCli(["install", "mytap/alpha"], { home, streams: captureStreams().streams });
+    expect(code).toBe(0);
+  });
+
+  test("qualified tap ref is case-insensitive", () => {
+    const home = makeCrewHome();
+    const repo = buildTapRepo();
+    runCli(["tap", "add", `file://${repo}`, "mytap"], {
+      home,
+      streams: captureStreams().streams,
+    });
+    runCli(["tap", "remove", "core", "--force"], { home, streams: captureStreams().streams });
+    const code = runCli(["install", "MyTap/Alpha"], { home, streams: captureStreams().streams });
     expect(code).toBe(0);
   });
 

--- a/tests/e2e/tap.test.ts
+++ b/tests/e2e/tap.test.ts
@@ -120,7 +120,7 @@ describe("crew tap", () => {
     // the shorthand's `looksLikeGitSource` guard.
     const home = makeCrewHome();
     const c = captureStreams();
-    const code = runCli(["tap", "NotAValidName"], { home, streams: c.streams });
+    const code = runCli(["tap", "not_a_valid_name"], { home, streams: c.streams });
     expect(code).toBe(4);
     expect(c.stderr()).toContain("crew help tap");
   });

--- a/tests/refs/parse.test.ts
+++ b/tests/refs/parse.test.ts
@@ -206,7 +206,7 @@ describe("parseRef: tap", () => {
     const r = parseRef("foo@bar");
     expect(r).toEqual({ type: "tap", tap: null, namespace: null, name: "foo", ref: "bar" });
   });
-  test("C-REF-21 tap refs are canonicalized to lowercase", () => {
+  test("C-REF-21 bare tap ref is canonicalized to lowercase", () => {
     expect(parseRef("BadName")).toEqual({
       type: "tap",
       tap: null,
@@ -215,7 +215,7 @@ describe("parseRef: tap", () => {
       ref: null,
     });
   });
-  test("C-REF-21 qualified tap refs are canonicalized to lowercase", () => {
+  test("C-REF-21 3-segment tap ref is canonicalized to lowercase", () => {
     expect(parseRef("Core/Tools/BadName@v1.0")).toEqual({
       type: "tap",
       tap: "core",

--- a/tests/refs/parse.test.ts
+++ b/tests/refs/parse.test.ts
@@ -206,11 +206,23 @@ describe("parseRef: tap", () => {
     const r = parseRef("foo@bar");
     expect(r).toEqual({ type: "tap", tap: null, namespace: null, name: "foo", ref: "bar" });
   });
-  test("invalid name fails", () => {
-    expect(() => parseRef("BadName")).toThrow();
+  test("C-REF-21 tap refs are canonicalized to lowercase", () => {
+    expect(parseRef("BadName")).toEqual({
+      type: "tap",
+      tap: null,
+      namespace: null,
+      name: "badname",
+      ref: null,
+    });
   });
-  test("invalid qualified name fails", () => {
-    expect(() => parseRef("tap/BadName")).toThrow();
+  test("C-REF-21 qualified tap refs are canonicalized to lowercase", () => {
+    expect(parseRef("Core/Tools/BadName@v1.0")).toEqual({
+      type: "tap",
+      tap: "core",
+      namespace: "tools",
+      name: "badname",
+      ref: "v1.0",
+    });
   });
   test("3-segment tap/namespace/skill parses unambiguously", () => {
     const r = parseRef("acme/marketing/copy-review");
@@ -236,7 +248,7 @@ describe("parseRef: tap", () => {
     expect(() => parseRef("a/b/c/d")).toThrow(/too many/);
   });
   test("3-segment with an invalid part fails", () => {
-    expect(() => parseRef("tap/Namespace/skill")).toThrow();
+    expect(() => parseRef("tap/bad_name/skill")).toThrow();
   });
   test("C-REF-17 empty string fails", () => {
     expect(() => parseRef("")).toThrow(CrewError);


### PR DESCRIPTION
## Summary
- Canonicalize tap-source identifiers to lowercase during parsing while leaving path sources and git URLs unchanged.
- Make bare, qualified, and namespaced install refs work regardless of user-entered case.
- Document the behavior in the PRD and add C-REF-21 coverage.

## Test plan
- bun test tests/refs/parse.test.ts
- bun test tests/e2e/tap-install.test.ts tests/e2e/namespaces.test.ts
- bun run check