### PR TITLE
[LOG-4720] Suggest known taps for install misses

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -689,6 +689,7 @@ Given one or more skill references on the command line, `crew install` proceeds 
    - Git URL or shorthand (`@org/repo`, `gh:org/repo`, etc.): if any configured tap already points at the same URL+subpath, use it; otherwise create an auto tap (§16.5) and use it. The new tap is cloned and refreshed.
    - Path reference (`./foo`, `/abs/foo`): if any configured tap already points at the same path, use it; otherwise create a path-kind auto tap and use it.
    In all cases, the resolved `state.installations[i].source` is `{ tap: <tap-name>, path: <skill-relative-path-inside-tap> }`. The URL/path of the tap itself lives in `config.yaml`.
+   - If a tap-source reference cannot be resolved from configured taps, Homecrew consults the known-tap registry (§16.2.1) before returning `invalid_ref`. Exact known-tap matches are suggestions only: Homecrew MUST NOT clone, fetch, add a tap to config, or install anything from a known tap until the user explicitly runs `crew tap add <url>[//<subpath>] <name>` (or a future interactive flow confirms that same action). The error MUST include the tap-add command and the follow-up `crew install <tap>/<skill>` or `crew install <tap>` command.
 3. **Resolve refs to SHAs.** For git sources and tap sources, the ref (tag, branch, or `HEAD`) is resolved to a full commit SHA. This SHA is what's recorded in state and markers, even if the user specified a tag or branch.
 4. **Validate each candidate skill** against the Agent Skills specification:
    - `SKILL.md` exists at the expected location.
@@ -1734,6 +1735,7 @@ Implementations and test suites refer to criteria by ID.
 | C-TAP-21 | §16.5 | `crew install <local-path>` creates an auto tap with `kind: path`, `registered: false`, `path: <abs-path>`. `crew tap update` skips path-kind taps; `crew search` walks them when reachable. |
 | C-TAP-22 | §16.5 | Running `crew tap add <url>` against a URL that already backs an auto tap promotes it (`registered` flips to `true`) without re-cloning, and applies any user-supplied `<name>` argument. |
 | C-TAP-23 | §16.2.1 / §16.6 | `crew search <query>` surfaces matching known-tap registry entries that are not already configured as suggestions after configured-tap hits, without cloning, fetching, mutating config, or listing them for `crew search` with no query. JSON includes those suggestions in `known_hits`. |
+| C-TAP-24 | §9 / §16.2.1 | `crew install <tap-source>` that cannot resolve from configured taps surfaces exact known-tap registry matches in the `invalid_ref` error, including `crew tap add` and follow-up install commands, without cloning, fetching, mutating config, or installing from the known tap. JSON errors include `known_tap_suggestions`. |
 
 #### C-STATE: State and markers (§11)
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ commands that do what they say, across every agent you use.
    `crew tap add` once, and every skill inside is searchable and installable.
 3. **Install into every agent.** One `crew install` copies the skill into
    Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, Goose, and every
-   other supported agent on your machine.
+   other supported agent on your machine. If the name is only in a known tap,
+   Homecrew shows the tap to add first.
 4. **Dependencies, handled.** Skills can depend on other skills. Homecrew walks
    the graph and installs everything they need. A single "team baseline"
    meta-skill can pull in a dozen others in one command.
@@ -93,7 +94,7 @@ skill can list as a dependency. Three shapes:
 
 | Kind | Example | What it is |
 |---|---|---|
-| **Tap source** | `crew install founding-engineer` | A skill, namespace, or tap known to a configured tap. Bare names search every tap, including the default `core` tap. Qualify with `tap/skill`, `tap/namespace/skill`, or `namespace/skill`. Pin with `@v1.0`. |
+| **Tap source** | `crew install founding-engineer` | A skill, namespace, or tap known to a configured tap. Bare names search every tap, including the default `core` tap. Qualify with `tap/skill`, `tap/namespace/skill`, or `namespace/skill`. Pin with `@v1.0`. If a miss exactly matches a known-but-untapped source, Homecrew suggests the `crew tap add` command. |
 | **Git source** | `crew install @acme/skills@v1.2.0//engineers/founding` | Any reachable git URL. `@owner/repo` is GitHub shorthand; full `https://` and `git@` URLs work too. Append `@ref` to pin, `//subpath` to scope. |
 | **Local path** | `crew install ./my-skill` | A directory on your machine. Detected by a leading `./`, `../`, `/`, or `~`. |
 
@@ -151,7 +152,7 @@ for examples.
 
 | Command | What it does |
 |---|---|
-| `crew install <ref>…` | Install one or more skills into every detected agent. |
+| `crew install <ref>…` | Install one or more skills into every detected agent; on name misses, may suggest skills from trusted known taps you haven't added yet. |
 | `crew uninstall <name>…` | Remove installed skills from every agent they were installed into. |
 | `crew update [<name>…]` | Update all installed skills, or only those named. Pinned SHAs are skipped unless `--force`. |
 | `crew list` | List installed skills, grouped by scope, with sources and resolved SHAs. |

--- a/site/components/sections/Commands.data.tsx
+++ b/site/components/sections/Commands.data.tsx
@@ -12,7 +12,8 @@ export const GROUPS: readonly CommandGroup[] = [
       {
         name: "install",
         signature: <>crew install &lt;ref&gt;…</>,
-        description: "Install one or more skills into every detected agent.",
+        description:
+          "Install one or more skills into every detected agent; on misses, may suggest skills from trusted known taps you haven't added yet.",
       },
       {
         name: "uninstall",

--- a/src/commands/help/content/install.ts
+++ b/src/commands/help/content/install.ts
@@ -7,6 +7,7 @@ export const installHelp: CommandHelp = {
     "Install a skill and make it available in every agent coder on your machine.",
     "Homecrew installs the same skill into every supported agent coder you have — Claude Code, Codex, Cursor, Gemini, and more. One command, all your agents. You don't have to think about where the skill goes; Homecrew figures out the right place for each tool.",
     "You can install by name (from a collection you've already added), by GitHub URL, from any git repo, or from a local folder — see REFERENCE FORMS below for the full list of shapes you can pass.",
+    "If a name isn't in your configured taps but is known to Homecrew, install tells you which tap to add first.",
     "Point at a folder full of skills and you get all of them at once. New ones added later show up automatically when you run `crew update`.",
   ],
   flags: [
@@ -111,6 +112,7 @@ export const installHelp: CommandHelp = {
   ],
   notes: [
     "Pinning keeps a skill put. Anything with `@<tag>` or `@<sha>` is treated as pinned — `crew update` leaves it alone unless you ask for `--force`.",
+    "Known-tap suggestions are local hints. Homecrew won't clone or add the suggested tap until you run the shown `crew tap add` command.",
     "How Homecrew tells names apart: a plain word is a skill name. Paths start with `./`, `../`, `/`, or `~`. Git URLs start with `https://`, `git@`, `ssh://`, `file://`, `gh:`, `gl:`, `bb:`, or `@<owner>/<repo>`. Anything containing `//` is always treated as a git reference (that's the subfolder syntax).",
   ],
   seeAlso: ["uninstall", "update", "info", "search"],

--- a/src/commands/install/index.ts
+++ b/src/commands/install/index.ts
@@ -15,6 +15,7 @@ import type { KindHint } from "../../install/resolve-ref/index.ts";
 import type { CommandContext, CommandOutput } from "../types.ts";
 import { promptBareNameAmbiguity } from "./ambiguity-prompt.ts";
 import { promptForCollision } from "./collision-prompt.ts";
+import { withKnownTapInstallSuggestions } from "./known-tap-fallback/index.ts";
 import { renderInstall } from "./render/index.ts";
 
 /** Read --tap / --bundle / --skill, enforce mutual exclusivity. */
@@ -45,7 +46,7 @@ export function installCommand(ctx: CommandContext): CommandOutput {
   const kindHint = readKindHint(ctx);
   const config = readConfig(ctx.home);
   const refs = resolveCollisions(ctx, config);
-  const result = runInstall(config, {
+  const installOptions = {
     refs,
     scope: ctx.flags.scope,
     force: ctx.flags.force,
@@ -54,7 +55,14 @@ export function installCommand(ctx: CommandContext): CommandOutput {
     cwd: ctx.cwd,
     home: ctx.home,
     kindHint,
-  });
+  };
+  let result: ReturnType<typeof runInstall>;
+  try {
+    result = runInstall(config, installOptions);
+  } catch (err) {
+    if (!(err instanceof CrewError)) throw err;
+    throw withKnownTapInstallSuggestions(err, refs, config, ctx.cwd, kindHint);
+  }
 
   // Exit-code rules (PRD §9 step 9). Per-skill outcome is
   // "succeeded" iff the skill validated AND at least one agent

--- a/src/commands/install/known-tap-fallback/index.ts
+++ b/src/commands/install/known-tap-fallback/index.ts
@@ -1,0 +1,145 @@
+/**
+ * Known-tap install miss guidance (§9 / §16.2.1).
+ *
+ * `crew install <name>` only installs from configured taps. When that
+ * normal resolution misses, this module consults the bundled known-tap
+ * registry and enriches the `invalid_ref` error with explicit tap-add
+ * and install commands. It never clones, fetches, or mutates config.
+ */
+
+import { CrewError } from "../../../core/errors.ts";
+import type { Config, Source, TapSource } from "../../../core/types.ts";
+import type { KindHint } from "../../../install/resolve-ref/index.ts";
+import { knownTapIsConfigured } from "../../../known-taps/configured.ts";
+import { knownTapSource } from "../../../known-taps/format.ts";
+import { getKnownTaps } from "../../../known-taps/registry.ts";
+import type { KnownTap, KnownTapTrust } from "../../../known-taps/types.ts";
+import { parseRef } from "../../../refs/parse.ts";
+import { type KnownInstallSuggestion, knownMatchesForTap } from "./match.ts";
+
+interface KnownInstallSuggestionJson {
+  readonly tap: string;
+  readonly url: string;
+  readonly subpath: string;
+  readonly trust: KnownTapTrust;
+  readonly name: string | null;
+  readonly namespace: string | null;
+  readonly description: string;
+  readonly tap_add: string;
+  readonly install: string;
+}
+
+export function withKnownTapInstallSuggestions(
+  err: CrewError,
+  refs: readonly string[],
+  config: Config,
+  cwd: string,
+  kindHint: KindHint,
+): CrewError {
+  if (err.code !== "invalid_ref") {
+    return err;
+  }
+  const suggestions = knownInstallSuggestions(refs, config, cwd, kindHint);
+  if (suggestions.length === 0) {
+    return err;
+  }
+  return new CrewError("invalid_ref", renderKnownInstallError(err, suggestions), {
+    ...err.details,
+    known_tap_suggestions: suggestions.map(suggestionJson),
+  });
+}
+
+function parseMaybeTap(raw: string, cwd: string): TapSource | null {
+  let source: Source;
+  try {
+    source = parseRef(raw, cwd);
+  } catch {
+    return null;
+  }
+  return source.type === "tap" ? source : null;
+}
+
+function knownInstallSuggestions(
+  refs: readonly string[],
+  config: Config,
+  cwd: string,
+  kindHint: KindHint,
+): KnownInstallSuggestion[] {
+  const out: KnownInstallSuggestion[] = [];
+  const seen = new Set<string>();
+  for (const raw of refs) {
+    const source = parseMaybeTap(raw, cwd);
+    if (source === null) {
+      continue;
+    }
+    for (const suggestion of knownSuggestionsForSource(source, config, kindHint)) {
+      const key = `${suggestion.tap.name}/${suggestion.installRef}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      out.push(suggestion);
+    }
+  }
+  return out;
+}
+
+function knownSuggestionsForSource(
+  source: TapSource,
+  config: Config,
+  kindHint: KindHint,
+): KnownInstallSuggestion[] {
+  const out: KnownInstallSuggestion[] = [];
+  for (const tap of getKnownTaps()) {
+    if (!knownTapIsConfigured(tap, config.taps)) {
+      out.push(...filterKindHints(knownMatchesForTap(tap, source), kindHint));
+    }
+  }
+  return out;
+}
+
+function filterKindHints(
+  suggestions: readonly KnownInstallSuggestion[],
+  kindHint: KindHint,
+): KnownInstallSuggestion[] {
+  if (kindHint === null) {
+    return [...suggestions];
+  }
+  if (kindHint === "namespace") {
+    return [];
+  }
+  const wantSkill = kindHint === "skill";
+  return suggestions.filter((suggestion) => (suggestion.skill !== null) === wantSkill);
+}
+
+function renderKnownInstallError(
+  err: CrewError,
+  suggestions: readonly KnownInstallSuggestion[],
+): string {
+  const lines = [err.message, "", "Known taps may have what you want:"];
+  for (const suggestion of suggestions) {
+    lines.push("");
+    lines.push(`  ${suggestion.installRef} (${suggestion.tap.trust})`);
+    lines.push(`    tap with: ${tapAddCommand(suggestion.tap)}`);
+    lines.push(`    install with: crew install ${suggestion.installRef}`);
+  }
+  return lines.join("\n");
+}
+
+function suggestionJson(suggestion: KnownInstallSuggestion): KnownInstallSuggestionJson {
+  return {
+    tap: suggestion.tap.name,
+    url: suggestion.tap.url,
+    subpath: suggestion.tap.subpath,
+    trust: suggestion.tap.trust,
+    name: suggestion.skill?.name ?? null,
+    namespace: suggestion.skill?.namespace ?? null,
+    description: suggestion.skill?.description ?? suggestion.tap.description,
+    tap_add: tapAddCommand(suggestion.tap),
+    install: `crew install ${suggestion.installRef}`,
+  };
+}
+
+function tapAddCommand(tap: KnownTap): string {
+  return `crew tap add ${knownTapSource(tap)} ${tap.name}`;
+}

--- a/src/commands/install/known-tap-fallback/match.ts
+++ b/src/commands/install/known-tap-fallback/match.ts
@@ -1,0 +1,109 @@
+/**
+ * Exact known-tap install suggestion matching (§9 / §16.2.1).
+ */
+
+import type { TapSource } from "../../../core/types.ts";
+import { sameNullableText, sameText } from "../../../known-taps/text.ts";
+import type { KnownTap, KnownTapSkill } from "../../../known-taps/types.ts";
+
+export interface KnownInstallSuggestion {
+  readonly tap: KnownTap;
+  readonly skill: KnownTapSkill | null;
+  readonly installRef: string;
+}
+
+export function knownMatchesForTap(tap: KnownTap, source: TapSource): KnownInstallSuggestion[] {
+  if (source.tap === null) {
+    return bareMatches(tap, source);
+  }
+  if (source.namespace === null) {
+    return twoSegmentMatches(tap, source.tap, source.name, source.ref);
+  }
+  return threeSegmentMatches(tap, source.tap, source.namespace, source.name, source.ref);
+}
+
+function bareMatches(tap: KnownTap, source: TapSource): KnownInstallSuggestion[] {
+  const skillMatches: KnownInstallSuggestion[] = [];
+  for (const skill of tap.skills) {
+    if (sameText(skill.name, source.name)) {
+      skillMatches.push(skillSuggestion(tap, skill, source.ref));
+    }
+  }
+  if (skillMatches.length > 0) {
+    return skillMatches;
+  }
+  if (sameText(tap.name, source.name)) {
+    return [{ tap, skill: null, installRef: tap.name }];
+  }
+  return [];
+}
+
+function twoSegmentMatches(
+  tap: KnownTap,
+  sourceTap: string,
+  name: string,
+  ref: string | null,
+): KnownInstallSuggestion[] {
+  const out: KnownInstallSuggestion[] = [];
+  for (const skill of tap.skills) {
+    if (
+      matchesTapSkill(tap, skill, sourceTap, name) ||
+      matchesNamespaceSkill(skill, sourceTap, name)
+    ) {
+      out.push(skillSuggestion(tap, skill, ref));
+    }
+  }
+  return out;
+}
+
+function threeSegmentMatches(
+  tap: KnownTap,
+  sourceTap: string,
+  namespace: string,
+  name: string,
+  ref: string | null,
+): KnownInstallSuggestion[] {
+  const out: KnownInstallSuggestion[] = [];
+  for (const skill of tap.skills) {
+    if (matchesTapNamespaceSkill(tap, skill, sourceTap, namespace, name)) {
+      out.push(skillSuggestion(tap, skill, ref));
+    }
+  }
+  return out;
+}
+
+function skillSuggestion(
+  tap: KnownTap,
+  skill: KnownTapSkill,
+  ref: string | null,
+): KnownInstallSuggestion {
+  const label = skill.namespace === null ? skill.name : `${skill.namespace}/${skill.name}`;
+  return { tap, skill, installRef: `${tap.name}/${label}${ref === null ? "" : `@${ref}`}` };
+}
+
+function matchesTapSkill(
+  tap: KnownTap,
+  skill: KnownTapSkill,
+  sourceTap: string,
+  name: string,
+): boolean {
+  return sameText(tap.name, sourceTap) && sameText(skill.name, name);
+}
+
+function matchesNamespaceSkill(skill: KnownTapSkill, sourceTap: string, name: string): boolean {
+  return sameNullableText(skill.namespace, sourceTap) && sameText(skill.name, name);
+}
+
+function matchesTapNamespaceSkill(
+  tap: KnownTap,
+  skill: KnownTapSkill,
+  sourceTap: string,
+  namespace: string,
+  name: string,
+): boolean {
+  return (
+    sameText(tap.name, sourceTap) &&
+    sameNullableText(skill.namespace, namespace) &&
+    sameText(skill.name, name)
+  );
+}

--- a/src/commands/search/known.ts
+++ b/src/commands/search/known.ts
@@ -3,8 +3,9 @@
  */
 
 import type { TapConfig } from "../../core/types.ts";
+import { knownTapIsConfigured } from "../../known-taps/configured.ts";
+import { knownTapSource } from "../../known-taps/format.ts";
 import { searchKnownTaps } from "../../known-taps/search.ts";
-import type { KnownTap } from "../../known-taps/types.ts";
 import type { KnownSearchHit } from "./types.ts";
 
 export function collectKnownHits(
@@ -37,25 +38,4 @@ export function knownSkillRef(hit: KnownSearchHit): string {
   return `${hit.namespace}/${hit.name}`;
 }
 
-export function knownTapSource(hit: KnownSearchHit): string {
-  if (hit.subpath === "") return hit.url;
-  return `${hit.url}//${hit.subpath}`;
-}
-
-function knownTapIsConfigured(tap: KnownTap, configuredTaps: readonly TapConfig[]): boolean {
-  for (const configured of configuredTaps) {
-    if (sameText(configured.name, tap.name)) return true;
-    if (
-      configured.kind === "git" &&
-      sameText(configured.url, tap.url) &&
-      // Case-sensitive: subpaths are filesystem paths inside the repo.
-      configured.subpath === tap.subpath
-    )
-      return true;
-  }
-  return false;
-}
-
-function sameText(a: string, b: string): boolean {
-  return a.toLowerCase() === b.toLowerCase();
-}
+export { knownTapSource };

--- a/src/known-taps/configured.ts
+++ b/src/known-taps/configured.ts
@@ -1,0 +1,28 @@
+/**
+ * Known-tap configured-state helpers (§16.2.1 / §16.6).
+ */
+
+import type { TapConfig } from "../core/types.ts";
+import { sameText } from "./text.ts";
+import type { KnownTap } from "./types.ts";
+
+export function knownTapIsConfigured(tap: KnownTap, configuredTaps: readonly TapConfig[]): boolean {
+  for (const configured of configuredTaps) {
+    if (sameText(configured.name, tap.name)) {
+      return true;
+    }
+    if (sameGitSource(configured, tap)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function sameGitSource(configured: TapConfig, tap: KnownTap): boolean {
+  return (
+    configured.kind === "git" &&
+    sameText(configured.url, tap.url) &&
+    // Case-sensitive: subpaths are filesystem paths inside the repo.
+    configured.subpath === tap.subpath
+  );
+}

--- a/src/known-taps/format.ts
+++ b/src/known-taps/format.ts
@@ -1,0 +1,15 @@
+/**
+ * Known-tap display formatting helpers (§16.2.1).
+ */
+
+export interface KnownTapSourceParts {
+  readonly url: string;
+  readonly subpath: string;
+}
+
+export function knownTapSource(tap: KnownTapSourceParts): string {
+  if (tap.subpath === "") {
+    return tap.url;
+  }
+  return `${tap.url}//${tap.subpath}`;
+}

--- a/src/known-taps/search.ts
+++ b/src/known-taps/search.ts
@@ -3,6 +3,7 @@
  */
 
 import { getKnownTaps } from "./registry.ts";
+import { sameNullableText, sameText } from "./text.ts";
 import type { KnownTap, KnownTapHit, KnownTapSkill } from "./types.ts";
 
 export function searchKnownTaps(
@@ -61,15 +62,6 @@ function knownTapMatches(tap: KnownTap, query: string): boolean {
 function knownTapSkillMatches(skill: KnownTapSkill, query: string): boolean {
   const label = knownTapSkillLabel(skill).toLowerCase();
   return query === "" || skill.description.toLowerCase().includes(query) || label.includes(query);
-}
-
-function sameText(a: string, b: string): boolean {
-  return a.toLowerCase() === b.toLowerCase();
-}
-
-function sameNullableText(a: string | null, b: string | null): boolean {
-  if (a === null || b === null) return a === b;
-  return sameText(a, b);
 }
 
 function compareKnownTapHits(a: KnownTapHit, b: KnownTapHit): number {

--- a/src/known-taps/text.ts
+++ b/src/known-taps/text.ts
@@ -1,0 +1,14 @@
+/**
+ * Shared known-tap text comparison helpers (§16.2.1).
+ */
+
+export function sameText(a: string, b: string): boolean {
+  return a.toLowerCase() === b.toLowerCase();
+}
+
+export function sameNullableText(a: string | null, b: string | null): boolean {
+  if (a === null || b === null) {
+    return a === b;
+  }
+  return sameText(a, b);
+}

--- a/tests/e2e/install-known-tap-dedupe.test.ts
+++ b/tests/e2e/install-known-tap-dedupe.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Known-tap install suggestion dedupe tests (§9 / §16.2.1).
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { runCli } from "../../src/cli/main.ts";
+import { resetKnownTapsForTest, setKnownTapsForTest } from "../../src/known-taps/registry.ts";
+import type { KnownTap } from "../../src/known-taps/types.ts";
+import { captureStreams, makeCrewHome } from "../helpers/env.ts";
+
+const SAME_NAME_TAP: readonly KnownTap[] = [
+  {
+    name: "openai",
+    url: "https://github.com/example/openai-skills.git",
+    subpath: "",
+    description: "OpenAI workflows.",
+    trust: "curated",
+    skills: [
+      {
+        name: "prompt-eval",
+        namespace: null,
+        description: "Evaluate prompts.",
+        path: "prompt-eval",
+      },
+    ],
+  },
+  {
+    name: "supabase",
+    url: "https://github.com/example/supabase-skills.git",
+    subpath: "",
+    description: "Supabase workflows.",
+    trust: "curated",
+    skills: [
+      {
+        name: "supabase",
+        namespace: null,
+        description: "Work with Supabase projects.",
+        path: "supabase",
+      },
+    ],
+  },
+];
+
+afterEach(() => {
+  resetKnownTapsForTest();
+});
+
+describe("known-tap install suggestion dedupe", () => {
+  test("C-TAP-24 bare tap and skill name matches prefer the skill suggestion", () => {
+    const home = makeCrewHome();
+    setKnownTapsForTest(SAME_NAME_TAP);
+    const setupStreams = captureStreams();
+    runCli(["tap", "remove", "core", "--force"], { home, streams: setupStreams.streams });
+
+    const c = captureStreams();
+    const code = runCli(["install", "supabase"], { home, streams: c.streams });
+
+    expect(code).toBe(4);
+    expect(c.stderr()).toContain("install with: crew install supabase/supabase");
+    expect(c.stderr()).not.toContain("\n  supabase (curated)\n");
+  });
+});

--- a/tests/e2e/install-known-tap-flags.test.ts
+++ b/tests/e2e/install-known-tap-flags.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Known-tap install fallback disambiguation flag tests (§8.3 / §9).
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { runCli } from "../../src/cli/main.ts";
+import { resetKnownTapsForTest, setKnownTapsForTest } from "../../src/known-taps/registry.ts";
+import type { KnownTap } from "../../src/known-taps/types.ts";
+import { captureStreams, makeCrewHome } from "../helpers/env.ts";
+
+const KNOWN_TAPS: readonly KnownTap[] = [
+  {
+    name: "supabase",
+    url: "https://github.com/example/supabase-skills.git",
+    subpath: "skills",
+    description: "Supabase workflows.",
+    trust: "curated",
+    skills: [
+      {
+        name: "schema-review",
+        namespace: "database",
+        description: "Review SQL migrations and RLS policies.",
+        path: "database/schema-review",
+      },
+    ],
+  },
+];
+
+afterEach(() => {
+  resetKnownTapsForTest();
+});
+
+describe("known-tap install fallback with disambiguation flags", () => {
+  test("C-TAP-24 --tap does not suggest known skills", () => {
+    const c = runWithKnownTaps(["install", "--tap", "schema-review"]);
+    expect(c.code).toBe(4);
+    expect(c.stderr).toContain("`schema-review` is not a tap");
+    expect(c.stderr).not.toContain("Known taps may have what you want");
+  });
+
+  test("C-TAP-24 --skill does not suggest whole known taps", () => {
+    const c = runWithKnownTaps(["install", "--skill", "supabase"]);
+    expect(c.code).toBe(4);
+    expect(c.stderr).toContain("`supabase` is not a skill");
+    expect(c.stderr).not.toContain("Known taps may have what you want");
+  });
+
+  test("C-TAP-24 --bundle suppresses known skill and tap suggestions", () => {
+    const skill = runWithKnownTaps(["install", "--bundle", "schema-review"]);
+    expect(skill.code).toBe(4);
+    expect(skill.stderr).not.toContain("Known taps may have what you want");
+
+    const tap = runWithKnownTaps(["install", "--bundle", "supabase"]);
+    expect(tap.code).toBe(4);
+    expect(tap.stderr).not.toContain("Known taps may have what you want");
+  });
+});
+
+function runWithKnownTaps(args: readonly string[]): {
+  readonly code: number;
+  readonly stderr: string;
+} {
+  const home = makeCrewHome();
+  setKnownTapsForTest(KNOWN_TAPS);
+  const setupStreams = captureStreams();
+  runCli(["tap", "remove", "core", "--force"], { home, streams: setupStreams.streams });
+  const c = captureStreams();
+  const code = runCli(args, { home, streams: c.streams });
+  return { code, stderr: c.stderr() };
+}

--- a/tests/e2e/install-known-tap.test.ts
+++ b/tests/e2e/install-known-tap.test.ts
@@ -1,0 +1,195 @@
+/**
+ * `crew install` known-tap fallback tests (§9 / §16.2.1).
+ *
+ * These cases verify that install misses surface exact known-tap
+ * suggestions without cloning, fetching, mutating config, or installing
+ * from taps the user has not explicitly added.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { runCli } from "../../src/cli/main.ts";
+import { readConfig, writeConfig } from "../../src/config/load.ts";
+import { resetKnownTapsForTest, setKnownTapsForTest } from "../../src/known-taps/registry.ts";
+import type { KnownTap } from "../../src/known-taps/types.ts";
+import { captureStreams, makeCrewHome } from "../helpers/env.ts";
+
+const KNOWN_TAPS: readonly KnownTap[] = [
+  {
+    name: "supabase",
+    url: "https://github.com/example/supabase-skills.git",
+    subpath: "skills",
+    description: "Supabase workflows.",
+    trust: "curated",
+    skills: [
+      {
+        name: "schema-review",
+        namespace: "database",
+        description: "Review SQL migrations and RLS policies.",
+        path: "database/schema-review",
+      },
+      {
+        name: "auth-audit",
+        namespace: null,
+        description: "Audit auth flows.",
+        path: "auth-audit",
+      },
+    ],
+  },
+];
+
+afterEach(() => {
+  resetKnownTapsForTest();
+});
+
+describe("known-tap fallback for install misses", () => {
+  test("C-TAP-24 bare install miss suggests an exact known-tap skill", () => {
+    const home = homeWithKnownTaps();
+    const c = captureStreams();
+    const code = runCli(["install", "schema-review"], { home, streams: c.streams });
+    expect(code).toBe(4);
+    expect(c.stderr()).toContain("Known taps may have what you want");
+    expect(c.stderr()).toContain(
+      "tap with: crew tap add https://github.com/example/supabase-skills.git//skills supabase",
+    );
+    expect(c.stderr()).toContain("install with: crew install supabase/database/schema-review");
+    expect(readConfig(home).taps).toEqual([]);
+  });
+
+  test("C-TAP-24 JSON errors include known_tap_suggestions", () => {
+    const home = homeWithKnownTaps();
+    const c = captureStreams();
+    const code = runCli(["install", "--json", "database/schema-review"], {
+      home,
+      streams: c.streams,
+    });
+    expect(code).toBe(4);
+    const parsed = JSON.parse(c.stdout()) as {
+      error: { details: { known_tap_suggestions: unknown[] } };
+    };
+    expect(parsed.error.details.known_tap_suggestions).toEqual([
+      {
+        tap: "supabase",
+        url: "https://github.com/example/supabase-skills.git",
+        subpath: "skills",
+        trust: "curated",
+        name: "schema-review",
+        namespace: "database",
+        description: "Review SQL migrations and RLS policies.",
+        tap_add: "crew tap add https://github.com/example/supabase-skills.git//skills supabase",
+        install: "crew install supabase/database/schema-review",
+      },
+    ]);
+  });
+
+  test("C-TAP-24 qualified known-tap install misses suggest qualified install refs", () => {
+    const home = homeWithKnownTaps();
+    const tapSkill = captureStreams();
+    const tapSkillCode = runCli(["install", "supabase/schema-review"], {
+      home,
+      streams: tapSkill.streams,
+    });
+    expect(tapSkillCode).toBe(4);
+    expect(tapSkill.stderr()).toContain("crew install supabase/database/schema-review");
+
+    const threeSegment = captureStreams();
+    const threeSegmentCode = runCli(["install", "supabase/database/schema-review"], {
+      home,
+      streams: threeSegment.streams,
+    });
+    expect(threeSegmentCode).toBe(4);
+    expect(threeSegment.stderr()).toContain("crew install supabase/database/schema-review");
+  });
+
+  test("C-TAP-24 known tap-name misses suggest adding and installing the tap", () => {
+    const home = homeWithKnownTaps();
+    const c = captureStreams();
+    const code = runCli(["install", "--json", "supabase"], { home, streams: c.streams });
+    expect(code).toBe(4);
+    const parsed = JSON.parse(c.stdout()) as {
+      error: { details: { known_tap_suggestions: unknown[] } };
+    };
+    expect(parsed.error.details.known_tap_suggestions).toEqual([
+      {
+        tap: "supabase",
+        url: "https://github.com/example/supabase-skills.git",
+        subpath: "skills",
+        trust: "curated",
+        name: null,
+        namespace: null,
+        description: "Supabase workflows.",
+        tap_add: "crew tap add https://github.com/example/supabase-skills.git//skills supabase",
+        install: "crew install supabase",
+      },
+    ]);
+  });
+
+  test("C-TAP-24 install miss preserves tap refs in suggestions", () => {
+    const home = homeWithKnownTaps();
+    const c = captureStreams();
+    const code = runCli(["install", "auth-audit@v1"], { home, streams: c.streams });
+    expect(code).toBe(4);
+    expect(c.stderr()).toContain("install with: crew install supabase/auth-audit@v1");
+  });
+
+  test("C-TAP-24 configured known taps are not suggested by name or source", () => {
+    const byName = homeWithKnownTaps();
+    writeConfig(
+      { ...readConfig(byName), taps: [{ ...configuredKnownSource(), name: "supabase" }] },
+      byName,
+    );
+    const named = captureStreams();
+    runCli(["install", "schema-review"], { home: byName, streams: named.streams });
+    expect(named.stderr()).not.toContain("Known taps may have what you want");
+
+    const bySource = homeWithKnownTaps();
+    writeConfig(
+      { ...readConfig(bySource), taps: [{ ...configuredKnownSource(), name: "renamed" }] },
+      bySource,
+    );
+    const sourced = captureStreams();
+    runCli(["install", "schema-review"], { home: bySource, streams: sourced.streams });
+    expect(sourced.stderr()).not.toContain("Known taps may have what you want");
+  });
+
+  test("malformed install refs keep the original invalid_ref error", () => {
+    const home = homeWithKnownTaps();
+    const c = captureStreams();
+    const code = runCli(["install", "bad/name/with/too-many-parts"], {
+      home,
+      streams: c.streams,
+    });
+    expect(code).toBe(4);
+    expect(c.stderr()).not.toContain("Known taps may have what you want");
+  });
+
+  test("C-TAP-24 multi-ref install misses include matching known-tap suggestions", () => {
+    const home = homeWithKnownTaps();
+    const c = captureStreams();
+    const code = runCli(["install", "schema-review", "another-missing"], {
+      home,
+      streams: c.streams,
+    });
+    expect(code).toBe(4);
+    expect(c.stderr()).toContain("Known taps may have what you want");
+    expect(c.stderr()).toContain("install with: crew install supabase/database/schema-review");
+  });
+});
+
+function homeWithKnownTaps(): string {
+  const home = makeCrewHome();
+  setKnownTapsForTest(KNOWN_TAPS);
+  const setupStreams = captureStreams();
+  // Keep configured taps empty so suggestions can only come from the known registry fixture.
+  runCli(["tap", "remove", "core", "--force"], { home, streams: setupStreams.streams });
+  return home;
+}
+
+function configuredKnownSource() {
+  return {
+    kind: "git" as const,
+    registered: true,
+    url: "https://github.com/example/supabase-skills.git",
+    subpath: "skills",
+    path: "",
+  };
+}


### PR DESCRIPTION
## Summary
- enrich `crew install` invalid_ref misses with exact known-tap suggestions and JSON details
- document C-TAP-24 and update README/help/site copy
- add e2e coverage for bare, qualified, JSON, ref-preserving, and configured-source suppression cases

## Tests
- `bun run check`
- `cd site && bun run check`