### PR TITLE
[LOG-4730] Fix Claude mention PR resolution

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -83,10 +83,11 @@ jobs:
         id: pr
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
         run: |
           echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
-          gh pr view "$PR_NUMBER" \
+          gh pr view "$PR_NUMBER" --repo "$GH_REPO" \
             --json headRepository,headRefName \
             --jq '"repo=\(.headRepository.nameWithOwner)\nref=\(.headRefName)"' >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
- Fix the Claude mention workflow so the pre-checkout `Resolve PR head` step passes an explicit repository to `gh pr view`.
- Keep checkout behavior the same after resolving the PR head repo/ref.

## Why
`gh pr view "$PR_NUMBER"` was running before `actions/checkout`, so there was no `.git` directory for `gh` to infer repository context from. Passing `--repo "$GH_REPO"` makes the command work before checkout.

## Verification
- `bun run lint`
- From outside a git repository: `gh pr view 53 --repo with-logic/crew --json headRepository,headRefName --jq ...`

Linear: LOG-4730