### PR TITLE
[LOG-4724] Add Logic attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 Easily discover and share skills across your team. One command to install. The
 same skills on every laptop, in every coding agent. Updated automatically.
 
+Homecrew is an open-source project by [Logic, Inc](https://logic.inc).
+
 ```
 crew tap add @acme/skills
 crew install acme/team-baseline
@@ -47,6 +49,10 @@ registry.
 - **no hosted registry** · git is the backend
 - **no account** · nothing to sign up for
 - **no telemetry** · Homecrew never phones home
+
+Homecrew is an open-source project by [Logic, Inc](https://logic.inc). Logic is
+a platform for building and operating fleets of production agents reliably at
+scale.
 
 ## Install
 

--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -17,23 +17,23 @@ const jetbrainsMono = JetBrains_Mono({
   display: "swap",
 });
 
+const SITE_DESCRIPTION =
+  "Install personal skills, team taps, and git-hosted skill collections into every agent on your Mac. An open-source project by Logic, Inc.";
+
 export const metadata: Metadata = {
   metadataBase: new URL("https://crew.logic.inc"),
   title: "homecrew — package manager for agent skills",
-  description:
-    "Install, share, and update agent skills across Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, Goose, and more.",
+  description: SITE_DESCRIPTION,
   openGraph: {
     title: "homecrew — package manager for agent skills",
-    description:
-      "Install personal skills, team taps, and git-hosted skill collections into every agent on your Mac.",
+    description: SITE_DESCRIPTION,
     type: "website",
     url: "https://crew.logic.inc",
   },
   twitter: {
     card: "summary_large_image",
     title: "homecrew — package manager for agent skills",
-    description:
-      "Install personal skills, team taps, and git-hosted skill collections into every agent on your Mac.",
+    description: SITE_DESCRIPTION,
   },
 };
 

--- a/site/components/sections/Agents.tsx
+++ b/site/components/sections/Agents.tsx
@@ -31,7 +31,7 @@ export function Agents() {
         </div>
 
         <p className={styles.footnote}>
-          Don't see yours? Its adapter probably takes an afternoon to write —{" "}
+          Don't see yours? Its adapter probably takes a minute to write —{" "}
           <a href="https://github.com/with-logic/crew/blob/main/PRD.md#71-adapter-operations">
             §7.1
           </a>{" "}

--- a/site/components/sections/Faq.tsx
+++ b/site/components/sections/Faq.tsx
@@ -153,6 +153,16 @@ const QAS: readonly QA[] = [
     ),
   },
   {
+    id: "logic",
+    q: "Who builds Homecrew?",
+    a: (
+      <>
+        Homecrew is an open-source project by <a href="https://logic.inc">Logic, Inc</a>. Logic is a
+        platform for building and operating fleets of production agents reliably at scale.
+      </>
+    ),
+  },
+  {
     id: "platforms",
     q: "What about Linux? Windows?",
     a: "Future work. The v1 spec is macOS-only because launchd is the autoupdate mechanism and each agent adapter encodes platform-specific paths. Nothing in the core design is Mac-specific; it's a scope decision, not a technical one.",

--- a/site/components/sections/Footer.module.css
+++ b/site/components/sections/Footer.module.css
@@ -18,6 +18,18 @@
   max-width: 340px;
 }
 
+.lede a,
+.bot a {
+  color: inherit;
+  text-decoration-color: color-mix(in srgb, currentColor 35%, transparent);
+  text-underline-offset: 3px;
+}
+
+.lede a:hover,
+.bot a:hover {
+  color: var(--ink);
+}
+
 .h5 {
   font-family: var(--font-mono);
   font-size: 12px;

--- a/site/components/sections/Footer.tsx
+++ b/site/components/sections/Footer.tsx
@@ -47,7 +47,7 @@ export function Footer() {
             <Brand />
             <p className={styles.lede}>
               A macOS package manager for agent skills. Install once, share through git, keep every
-              agent current.
+              agent current. An open-source project by <a href="https://logic.inc">Logic, Inc</a>.
             </p>
           </div>
           {COLUMNS.map((c) => (
@@ -65,7 +65,9 @@ export function Footer() {
         </div>
         <div className={styles.bot}>
           <span>Homecrew · {CREW_VERSION_TAG} · macOS (arm64, x86_64)</span>
-          <span>© {new Date().getFullYear()} Logic App, Inc.</span>
+          <span>
+            © {new Date().getFullYear()} <a href="https://logic.inc">Logic App, Inc.</a>
+          </span>
           <span>$ crew help</span>
         </div>
       </Container>


### PR DESCRIPTION
## Summary
- identify Homecrew in the README as an open-source project by Logic, Inc.
- add restrained Logic attribution in the site footer, FAQ, and metadata description
- keep the copyright attribution linked to logic.inc

## Tests
- bun run check
- (site) bun run check