### PR TITLE
[LOG-4734] Accept qualified installed skill names

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -780,6 +780,22 @@ Given one or more skill references on the command line, `crew install` proceeds 
 
 Exit code: 0 if every skill succeeded in at least one agent; 1 if any skill failed in every agent; 2 if nothing was attempted (empty install set after expansion when the user explicitly asked for something). Other exit codes per §15.
 
+### 9.1 `crew info`
+
+`crew info` accepts any install reference and, for installed skills, the same
+installed-skill selectors defined in §5.1. It reads `state.json` without taking
+the state lock. If the argument matches one or more installed state entries,
+`crew info` renders the installed view first: source, resolved version, installed
+agents, and local description when available. A tap-qualified selector such as
+`<tap>/<skill>` or `<tap>/<namespace>/<skill>` narrows the installed entries by
+`state.source.tap`, optional namespace path, and `state.name`.
+
+If the argument does not match installed state, `crew info` resolves it as an
+install reference and previews the valid skills available at that source. An
+`@ref` tail is not part of the installed-skill selector grammar; arguments such
+as `<tap>/<skill>@<ref>` therefore follow the reference-preview path rather than
+matching installed state.
+
 ## 10. Update and autoupdate
 
 ### 10.1 `crew update`
@@ -1738,6 +1754,12 @@ Implementations and test suites refer to criteria by ID.
 | C-UPD-20 | §10.1 | A tap whose fetch fails (network error, URL 404, etc.) produces a per-tap warning in the update summary but does NOT abort the run; other taps and per-skill updates continue to be processed. |
 | C-UPD-21 | §11.1 | `crew update` for a project-scope entry reinstalls at the entry's recorded `project_root`, NOT the user's current working directory. This holds whether update is run by the user from any shell, or by the autoupdate background agent from its launchd-assigned cwd. |
 | C-UPD-22 | §11.1 | A project-scope entry whose `project_root` no longer exists on disk is reported as `missing_project_root` and SKIPPED on update — the local install is preserved and no files are written. |
+
+#### C-INFO: Info (§9.1)
+
+| ID | Reference | Assertion |
+|---|---|---|
+| C-INFO-01 | §9.1 | `crew info <tap>/<skill>` resolves the argument against installed state first; if matching state entries exist, it renders the installed view rather than walking the tap source. |
 
 #### C-UNINST: Uninstall (§7.4)
 

--- a/PRD.md
+++ b/PRD.md
@@ -97,12 +97,12 @@ Every command below is mandatory. Exit codes are defined in §15.
 
 ```
 crew install <ref> [<ref>...]     Install one or more skills.
-crew uninstall <name> [<name>...] Remove installed skills from every agent.
-crew update [<name>...]           Update all installed skills, or only those named.
+crew uninstall <selector> [<selector>...] Remove installed skills from every agent.
+crew update [<selector>...]       Update all installed skills, or only those selected.
 crew list                         List installed skills.
 crew skills                       Alias for `crew list`.
 crew search <query>               Search across configured taps.
-crew info <ref-or-name>           Show details for an installed or searchable skill.
+crew info <ref-or-selector>       Show details for an installed or searchable skill.
 
 crew tap add [--recursive] <url-or-path> [<name>]
                                    Add a registry (name defaults to repo/path name).
@@ -128,6 +128,14 @@ crew help [<command>]              Show help.
 crew version                       Print version and exit.
 ```
 
+**Installed skill selectors.** Commands that operate on already-installed
+skills (`crew info`, `crew update`, and `crew uninstall`) accept either the
+stored skill name (`pdf`) or a tap-qualified selector (`<tap>/<skill>` or
+`<tap>/<namespace>/<skill>`) that identifies the installed state entry by
+`state.source.tap`, optional namespace path, and `state.name`.
+User-facing help may describe these values as skill names rather than
+selectors; the distinction is spec terminology, not product language.
+
 ### 5.2 Global flags
 
 Accepted on any command where they apply:
@@ -148,7 +156,7 @@ Accepted on any command where they apply:
 
 ### 5.3.1 Uninstall-time flags
 
-- `--prune` — after removing the named skills, recursively uninstall any
+- `--prune` — after removing the selected skills, recursively uninstall any
   remaining skill that was only installed as a transitive dependency
   (§7.4 step 5) and is no longer required by anything. Equivalent to
   running `crew uninstall` followed by an autoremove pass.
@@ -468,6 +476,14 @@ Install takes a staged skill directory in the store, a skill name, a scope, and 
 
 ### 7.4 Uninstall algorithm
 
+`crew uninstall` arguments are installed-skill selectors. A selector can be the
+stored skill name (`pdf`) or a tap-qualified skill reference
+(`<tap>/<skill>` or `<tap>/<namespace>/<skill>`) that identifies an installed
+state entry by `state.source.tap`, optional namespace path, and `state.name`.
+Tap-qualified selectors are accepted even though `state.json` stores the skill
+under its unqualified name. If no installed state entry matches the selector,
+the command reports `not_installed_here` for the selector the user typed.
+
 **Agent set.** The default is to remove the skill from every agent
 it's recorded against in state. `--agent <name>` (repeatable,
 §5.2) restricts removal to the named agents only — other agents
@@ -768,16 +784,20 @@ Exit code: 0 if every skill succeeded in at least one agent; 1 if any skill fail
 
 ### 10.1 `crew update`
 
-With no arguments, updates every installed skill. With arguments, updates only the named skills.
+With no arguments, updates every installed skill. With arguments, updates only
+the selected installed skills. A selector can be the stored skill name (`pdf`)
+or a tap-qualified installed skill reference (`<tap>/<skill>` or
+`<tap>/<namespace>/<skill>`), using the same installed-skill selector rules as
+`crew uninstall` (§7.4).
 
-1. Fetch upstream for the git-kind taps this run will actually touch. With no args, that is every configured git-kind tap. With `<name>...`, it is the subset of taps that host the named entries — plus any taps hosting entries pulled in by step 2's dependency closure. Path-kind taps are skipped silently. Per-tap failures produce a warning but do not abort the run.
+1. Fetch upstream for the git-kind taps this run will actually touch. With no args, that is every configured git-kind tap. With `<selector>...`, it is the subset of taps that host the selected entries — plus any taps hosting entries pulled in by step 2's dependency closure. Path-kind taps are skipped silently. Per-tap failures produce a warning but do not abort the run.
 2. Build the list of skills to consider:
    - `crew update` with no args → every entry in `state.json`.
-   - `crew update <name>...` → the named entries, **plus their transitive dependency closure**. Concretely: for each name, take its state entry's direct deps (from its SKILL.md `metadata.crew.dependencies`, resolved against `required_by` in state), then their deps, and so on. A dep that isn't in state — one that was never installed — is not added; Homecrew does not install new skills during update. Entries pulled in this way appear in the results alongside the named ones, marked `transitively_required_by: [<name>...]` in JSON output so callers can tell them apart. An unknown top-level name (`<name>` not in state) is an error per argument.
+   - `crew update <selector>...` → the selected entries, **plus their transitive dependency closure**. Concretely: for each selected entry, take its direct deps (from its SKILL.md `metadata.crew.dependencies`, resolved against `required_by` in state), then their deps, and so on. A dep that isn't in state — one that was never installed — is not added; Homecrew does not install new skills during update. Entries pulled in this way appear in the results alongside the selected entries, marked `transitively_required_by: [<name>...]` in JSON output so callers can tell them apart. An unknown top-level selector (no matching state entry) is an error per argument.
 2b. **Re-expand taps** per §10.1.1. For every git-kind tap with at
-   least one state entry attributed to it (filtered by the same name-
-   filter rule as step 2 — `crew update <name>` only touches taps that
-   host a named entry or one of its transitive deps), walk the tap one
+   least one state entry attributed to it (filtered by the same selector
+   rule as step 2 — `crew update <selector>` only touches taps that
+   host a selected entry or one of its transitive deps), walk the tap one
    level deep. Any newly-added child skill is added to the list of
    skills to consider as a fresh install; any child skill that has
    disappeared from the tap upstream is reported with `source_gone`
@@ -801,7 +821,7 @@ outcome and leaves the local install, its marker, and its state entry
 untouched. The skill keeps working at its last-resolved SHA. This is a
 soft outcome: exit code stays 0 for an update run whose only
 abnormalities are `source_gone`. Removal of an unwanted local skill is
-always explicit (`crew uninstall <name>`).
+always explicit (`crew uninstall <selector>`).
 
 This rule also applies when a whole source becomes unresolvable: a
 tap's clone URL 404s, or a git repo is gone. Those produce
@@ -1507,7 +1527,7 @@ Add a tap first, then install a suggested skill by qualified name.
 
 The only commands that actively fetch from upstream are:
 
-- `crew update` (§10.1 step 1). Without args: every configured git-kind tap. With `<name>...`: only the taps that back the named entries (after the dependency closure of §10.1 step 2 expands them). Taps hosting only unrelated skills are not touched.
+- `crew update` (§10.1 step 1). Without args: every configured git-kind tap. With `<selector>...`: only the taps that back the selected entries (after the dependency closure of §10.1 step 2 expands them). Taps hosting only unrelated skills are not touched.
 - `crew tap update` — every git-kind tap, or the named subset.
 - `crew tap add` — initial clone of the freshly-added git tap.
 - `crew install <git-url>` and `crew install <tap-name>` against an out-of-date tap — fetches that tap's URL.
@@ -1712,8 +1732,9 @@ Implementations and test suites refer to criteria by ID.
 | C-UPD-17 | §16.5 | An auto tap whose last associated state entry is uninstalled is garbage-collected: removed from `config.yaml`, its clone deleted. Registered taps are NOT garbage-collected by uninstall. |
 | C-UPD-18 | §10.1.1 | `crew update --dry-run` on a tap with pending additions lists those additions without installing anything. |
 | C-UPD-19 | §10.1 | `crew update` with no args fetches every configured tap (`git fetch` + fast-forward) before walking per-skill updates, so `crew search` reflects upstream changes without requiring the user to reinstall from the tap first. |
-| C-UPD-23 | §10.1 / §16.6 | `crew update <name>...` restricts fetching to taps that back the named entries (and any taps reached via the dependency closure of step 2). Taps hosting only unrelated skills are NOT fetched. |
-| C-UPD-24 | §10.1 | `crew update <name>...` includes each named entry's transitive dependency closure (as determined by `required_by` in state) in the update set. Entries pulled in that way are reported alongside the named ones, marked as transitively required in `--json` output. |
+| C-UPD-23 | §10.1 / §16.6 | `crew update <selector>...` restricts fetching to taps that back the selected entries (and any taps reached via the dependency closure of step 2). Taps hosting only unrelated skills are NOT fetched. |
+| C-UPD-24 | §10.1 | `crew update <selector>...` includes each selected entry's transitive dependency closure (as determined by `required_by` in state) in the update set. Entries pulled in that way are reported alongside the selected entries, marked as transitively required in `--json` output. |
+| C-UPD-25 | §10.1 | `crew update <tap>/<skill>` accepts a tap-qualified selector for an installed skill and updates the matching state entry. |
 | C-UPD-20 | §10.1 | A tap whose fetch fails (network error, URL 404, etc.) produces a per-tap warning in the update summary but does NOT abort the run; other taps and per-skill updates continue to be processed. |
 | C-UPD-21 | §11.1 | `crew update` for a project-scope entry reinstalls at the entry's recorded `project_root`, NOT the user's current working directory. This holds whether update is run by the user from any shell, or by the autoupdate background agent from its launchd-assigned cwd. |
 | C-UPD-22 | §11.1 | A project-scope entry whose `project_root` no longer exists on disk is reported as `missing_project_root` and SKIPPED on update — the local install is preserved and no files are written. |
@@ -1722,12 +1743,12 @@ Implementations and test suites refer to criteria by ID.
 
 | ID | Reference | Assertion |
 |---|---|---|
-| C-UNINST-01 | §7.4 | `crew uninstall <name>` removes the skill directory from every agent the skill was installed in. |
+| C-UNINST-01 | §7.4 | `crew uninstall <selector>` removes the skill directory from every agent the skill was installed in. |
 | C-UNINST-02 | §7.4 | Uninstall updates `state.json` to no longer list the skill. |
 | C-UNINST-03 | §7.4 | Uninstall does not touch sibling skill directories in the same agent. |
 | C-UNINST-04 | §7.4 | `crew uninstall` on a skill that is not installed produces `not_installed_here`, exit 6, without `--force`. |
-| C-UNINST-05 | §7.4 | `crew uninstall <name>` without `--prune` does NOT remove that skill's transitive dependencies, even if they are no longer required by anything else. |
-| C-UNINST-06 | §7.4 | `crew uninstall <name> --prune` removes the named skill, then recursively removes any remaining skill with `explicit: false` and an empty `required_by` at the same scope. |
+| C-UNINST-05 | §7.4 | `crew uninstall <selector>` without `--prune` does NOT remove that skill's transitive dependencies, even if they are no longer required by anything else. |
+| C-UNINST-06 | §7.4 | `crew uninstall <selector> --prune` removes the selected skill, then recursively removes any remaining skill with `explicit: false` and an empty `required_by` at the same scope. |
 | C-UNINST-07 | §7.4 | `--prune` never removes a skill with `explicit: true`, even if no other skill depends on it. |
 | C-UNINST-08 | §11.1 | After `crew uninstall`, every remaining state entry's `required_by` no longer names the uninstalled skill. |
 | C-UNINST-09 | §11.1 | A skill first installed as a dependency (`explicit: false`) and then later installed directly (`crew install <name>`) has `explicit: true` after the second install. |
@@ -1739,6 +1760,7 @@ Implementations and test suites refer to criteria by ID.
 | C-UNINST-15 | §11.1 | `crew uninstall --scope project <name>` removes the install at the entry's recorded `project_root`, NOT the user's current working directory. Run from any cwd, it finds and removes the correct files. |
 | C-UNINST-16 | §7.4 | When two agents share a `dest` (e.g. `codex` + `gemini-cli` both at `~/.agents/skills/<name>/`), `crew uninstall --agent codex <name>` removes `codex` from the marker's `agents` list but leaves the bytes on disk; `gemini-cli` continues to work. |
 | C-UNINST-17 | §7.4 | After `crew uninstall --agent codex <name>` in a path-shared install, the marker at `dest` contains every remaining owning adapter and no others. |
+| C-UNINST-18 | §7.4 | `crew uninstall <tap>/<skill>` accepts a tap-qualified selector for an installed skill and removes the matching state entry. |
 | C-SHARE-01 | §7.2, §7.3 | When `codex` and `gemini-cli` are both active, `crew install <name>` writes bytes to `~/.agents/skills/<name>/` exactly once, and the per-agent summary reports both adapter names as installed. |
 | C-SHARE-02 | §7.5 | The `agents` field in `.crew.json` is non-empty, alphabetically sorted, and lists every agent currently owning the install. |
 | C-SHARE-03 | §7.3 | Installing into a path already owned by agent X with agent Y active (and not X) results in a marker whose `agents` contains both X and Y, preserving X's ownership. |

--- a/README.md
+++ b/README.md
@@ -154,6 +154,9 @@ Every command accepts `--scope`, `--agent`, `--dry-run`, `--json`, `--quiet`,
 `--verbose`, `--yes`, and `--force` where they apply. Run `crew help <command>`
 for examples.
 
+When a command asks for an installed skill name, you can use the bare name
+(`pdf`) or a tap-qualified name (`anthropic/pdf`).
+
 **Managing skills**
 
 | Command | What it does |

--- a/site/components/sections/Commands.data.tsx
+++ b/site/components/sections/Commands.data.tsx
@@ -18,15 +18,15 @@ export const GROUPS: readonly CommandGroup[] = [
       {
         name: "uninstall",
         signature: <>crew uninstall &lt;name&gt;…</>,
-        description: "Remove installed skills from every agent they were installed into.",
+        description: "Remove installed skills from every agent. Bare and tap-qualified names work.",
       },
       {
         name: "update",
         signature: <>crew update [&lt;name&gt;…]</>,
         description: (
           <>
-            Update all installed skills, or only those named. Pinned SHAs are skipped unless{" "}
-            <span className={styles.flag}>--force</span>.
+            Update all installed skills, or only those named. Names can be bare or tap-qualified.
+            Pinned SHAs are skipped unless <span className={styles.flag}>--force</span>.
           </>
         ),
       },
@@ -43,7 +43,7 @@ export const GROUPS: readonly CommandGroup[] = [
       {
         name: "info",
         signature: <>crew info &lt;ref-or-name&gt;</>,
-        description: "Show details for an installed skill or one available in a tap.",
+        description: "Show installed details or preview a tap skill. Tap-qualified names work.",
       },
     ],
   },

--- a/src/commands/help/content/info.ts
+++ b/src/commands/help/content/info.ts
@@ -2,16 +2,20 @@ import type { CommandHelp } from "./types.ts";
 
 export const infoHelp: CommandHelp = {
   name: "info",
-  synopsis: "crew info <name-or-reference>",
+  synopsis: "crew info <ref-or-name>",
   summary: [
     "Get the details on a skill — installed or not.",
-    "If you already have it installed, you'll see what's going on locally: where it came from, which version you're on, and which agents it's in. If it's just a reference (a URL, a name in a collection you've added), Homecrew fetches the skill's metadata so you can look before you leap.",
+    "If you already have it installed, you'll see what's going on locally: where it came from, which version you're on, and which agents it's in. Installed skills can be named directly (`pdf`) or with a tap-qualified name (`anthropic/pdf`). If it's just a reference (a URL, a name in a collection you've added), Homecrew fetches the skill's metadata so you can look before you leap.",
     "Works with every reference shape `crew install` understands — see `crew help install` for the list.",
     "For non-standard nested repositories, add the source as a recursive tap first (`crew tap add --recursive ...`) and then run `crew info` against that tap.",
   ],
   flags: [{ flag: "--json", description: "Machine-readable output." }],
   examples: [
     { command: "crew info python-testing", description: "See the details on a skill you have." },
+    {
+      command: "crew info core/python-testing",
+      description: "See the installed skill using its tap-qualified name.",
+    },
     {
       command: "crew info gh:acme/skills//python/testing",
       description: "Preview a skill without installing it.",

--- a/src/commands/help/content/uninstall.ts
+++ b/src/commands/help/content/uninstall.ts
@@ -5,6 +5,7 @@ export const uninstallHelp: CommandHelp = {
   synopsis: "crew uninstall <name> [<name>...]",
   summary: [
     "Remove an installed skill from every agent on your machine.",
+    "You can name the installed skill directly (`pdf`) or use a tap-qualified name like `anthropic/pdf`.",
     "Homecrew only touches skills it installed — anything else in your agents' skills folders is left alone.",
     "If the skill pulled in dependencies, those stick around by default in case you want them. Pass `--prune` to also clean up anything that's now unused, like `apt autoremove`.",
   ],
@@ -32,6 +33,10 @@ export const uninstallHelp: CommandHelp = {
     {
       command: "crew uninstall python-testing",
       description: "Remove the skill from every agent it's in.",
+    },
+    {
+      command: "crew uninstall core/python-testing",
+      description: "Remove the installed skill using its tap-qualified name.",
     },
     {
       command: "crew uninstall --agent codex python-testing",

--- a/src/commands/help/content/update.ts
+++ b/src/commands/help/content/update.ts
@@ -5,7 +5,7 @@ export const updateHelp: CommandHelp = {
   synopsis: "crew update [<name>...]",
   summary: [
     "Catch your installed skills up to the latest versions.",
-    "Run this whenever you want to pull in improvements the authors have published since you installed. With no arguments, every skill you have is checked; pass one or more names to update just those.",
+    "Run this whenever you want to pull in improvements the authors have published since you installed. With no arguments, every skill you have is checked; pass one or more names (`pdf` or `anthropic/pdf`) to update just those.",
     "If you installed a whole collection of skills at once (e.g. `crew install @your-org/skills`), any new ones the team has added show up automatically. Skills you pinned to a specific version (`skill@v1.0.0`) are left alone unless you pass `--force`.",
     "If a skill has dependencies, updating it also updates the things it depends on — your setup stays consistent.",
   ],
@@ -21,6 +21,10 @@ export const updateHelp: CommandHelp = {
     {
       command: "crew update python-testing",
       description: "Just update this one skill (and anything it depends on).",
+    },
+    {
+      command: "crew update core/python-testing",
+      description: "Update a skill using its tap-qualified name.",
     },
     {
       command: "crew update --force my-pinned-skill",

--- a/src/commands/info/index.ts
+++ b/src/commands/info/index.ts
@@ -16,11 +16,12 @@ import { CrewError } from "../../core/errors.ts";
 import type { LoadedSkill, StateEntry, TapConfig } from "../../core/types.ts";
 import { type NonTapNameCandidate, resolveTapRef } from "../../install/resolve-ref/index.ts";
 import { attributeRef } from "../../install/tap-attribution.ts";
-import { NAME_PATTERN, parseRef } from "../../refs/parse.ts";
+import { parseRef } from "../../refs/parse.ts";
 import { hasSkillMd, loadSkill } from "../../skill/load.ts";
 import { acquireTap } from "../../sources/acquire/index.ts";
 import { expandSkills } from "../../sources/expand.ts";
 import { readState } from "../../state/load.ts";
+import { resolveStateSubject } from "../../state/subjects.ts";
 import type { CommandContext, CommandOutput } from "../types.ts";
 import type { InstalledInfo, SkillInfo } from "./render.ts";
 import { renderInstalled, renderSkills } from "./render.ts";
@@ -35,16 +36,15 @@ export function infoCommand(ctx: CommandContext): CommandOutput {
   const arg = ctx.positional[0]!;
 
   const state = readState(ctx.home);
-  const isBareName = NAME_PATTERN.test(arg);
-  const matches = isBareName ? state.installations.filter((e) => e.name === arg) : [];
-  if (matches.length > 0) {
-    const installed = buildInstalledInfo(matches, ctx.cwd);
+  const subject = resolveStateSubject(state, arg);
+  if (subject.entries.length > 0) {
+    const installed = buildInstalledInfo(subject.entries, ctx.cwd);
     return {
       exitCode: 0,
       human: renderInstalled(installed, ctx.style, ctx.width),
       json: {
         installed: installed.primary,
-        entries: matches,
+        entries: subject.entries,
         description: installed.description,
       },
     };

--- a/src/commands/uninstall/core.ts
+++ b/src/commands/uninstall/core.ts
@@ -12,6 +12,7 @@ import { agentByName } from "../../agents/registry.ts";
 import { uninstallSkillFromAgents } from "../../agents/uninstall.ts";
 import { CrewError } from "../../core/errors.ts";
 import type { StateEntry, StateFile } from "../../core/types.ts";
+import type { StateSubject } from "../../state/subjects.ts";
 import type { CommandContext } from "../types.ts";
 import { dropScopedEntryAndUpdateRequiredBy, reduceEntryAgents } from "./state.ts";
 
@@ -34,12 +35,17 @@ export interface UninstallRecord {
  */
 export function removeOne(
   state: StateFile,
-  name: string,
+  subject: string | StateSubject,
   ctx: CommandContext,
   pruned: boolean,
   agentFilter: readonly string[] | null,
 ): { updatedState: StateFile; rec: UninstallRecord } {
-  const entries = state.installations.filter((e) => e.name === name);
+  const name = typeof subject === "string" ? subject : subject.name;
+  const entries =
+    typeof subject === "string"
+      ? state.installations.filter((e) => e.name === name)
+      : subject.entries;
+  const errorName = typeof subject === "string" ? subject : subject.raw;
   const rec: UninstallRecord = {
     name,
     removedFrom: [],
@@ -51,8 +57,8 @@ export function removeOne(
     if (!(ctx.flags.force || pruned)) {
       throw new CrewError(
         "not_installed_here",
-        `\`${name}\` isn't in Homecrew's state — nothing to remove`,
-        { name },
+        `\`${errorName}\` isn't in Homecrew's state — nothing to remove`,
+        { name: errorName },
       );
     }
     return { updatedState: state, rec };

--- a/src/commands/uninstall/index.ts
+++ b/src/commands/uninstall/index.ts
@@ -28,6 +28,7 @@ import { tapPath } from "../../core/paths.ts";
 import type { Config, StateFile } from "../../core/types.ts";
 import { readState, writeState } from "../../state/load.ts";
 import { withStateLock } from "../../state/lock.ts";
+import { resolveStateSubjects } from "../../state/subjects.ts";
 import { rmrf } from "../../util/fs.ts";
 import type { CommandContext, CommandOutput } from "../types.ts";
 import { removeOne, type UninstallRecord } from "./core.ts";
@@ -49,8 +50,8 @@ export function uninstallCommand(ctx: CommandContext): CommandOutput {
 
   withStateLock(() => {
     let state = readState(ctx.home);
-    for (const name of ctx.positional) {
-      const { updatedState, rec } = removeOne(state, name, ctx, false, agentFilter);
+    for (const subject of resolveStateSubjects(state, ctx.positional)) {
+      const { updatedState, rec } = removeOne(state, subject, ctx, false, agentFilter);
       state = updatedState;
       records.push(rec);
       if (rec.failures.length > 0) exitCode = 1;

--- a/src/commands/uninstall/index.ts
+++ b/src/commands/uninstall/index.ts
@@ -28,7 +28,7 @@ import { tapPath } from "../../core/paths.ts";
 import type { Config, StateFile } from "../../core/types.ts";
 import { readState, writeState } from "../../state/load.ts";
 import { withStateLock } from "../../state/lock.ts";
-import { resolveStateSubjects } from "../../state/subjects.ts";
+import { resolveStateSubject } from "../../state/subjects.ts";
 import { rmrf } from "../../util/fs.ts";
 import type { CommandContext, CommandOutput } from "../types.ts";
 import { removeOne, type UninstallRecord } from "./core.ts";
@@ -50,7 +50,8 @@ export function uninstallCommand(ctx: CommandContext): CommandOutput {
 
   withStateLock(() => {
     let state = readState(ctx.home);
-    for (const subject of resolveStateSubjects(state, ctx.positional)) {
+    for (const raw of ctx.positional) {
+      const subject = resolveStateSubject(state, raw);
       const { updatedState, rec } = removeOne(state, subject, ctx, false, agentFilter);
       state = updatedState;
       records.push(rec);

--- a/src/commands/update/index.ts
+++ b/src/commands/update/index.ts
@@ -40,6 +40,7 @@ import { type UpdateRow, updateOneEntry } from "../../install/update-one.ts";
 import { garbageCollectStore } from "../../maintenance/gc.ts";
 import { readState, upsertEntry, writeState } from "../../state/load.ts";
 import { withStateLock } from "../../state/lock.ts";
+import { resolveStateSubjects } from "../../state/subjects.ts";
 import { nowIso } from "../../util/time.ts";
 import { refreshTaps, type TapRefreshRow } from "../tap/refresh.ts";
 import type { CommandContext, CommandOutput } from "../types.ts";
@@ -50,7 +51,7 @@ export function updateCommand(ctx: CommandContext): CommandOutput {
   const config = readConfig(ctx.home);
   const home = ctx.home ?? crewHome();
 
-  const names = ctx.positional;
+  const rawNames = ctx.positional;
 
   const rows: UpdateRow[] = [];
   const tapReexpandRows: TapReexpandRow[] = [];
@@ -62,7 +63,9 @@ export function updateCommand(ctx: CommandContext): CommandOutput {
 
     // Dep-closure expansion — may add more entries, but they all live in
     // state already (we never install new skills during update).
-    const { entries: initialSelected, transitiveSources } = chooseEntries(current, names);
+    const subjects = resolveStateSubjects(current, rawNames);
+    const { entries: initialSelected, transitiveSources } = chooseEntries(current, subjects);
+    const names = subjects.map((subject) => subject.name);
 
     // §10.1 step 1 (scoped): fetch only the taps that back the entries
     // this run will actually touch. Per-tap failures become warnings,
@@ -88,7 +91,10 @@ export function updateCommand(ctx: CommandContext): CommandOutput {
     // tap-re-expansion state. In practice the set is stable — tap
     // re-expansion can add skills, but those come in as explicit
     // top-level entries and aren't part of the dep closure.
-    const { entries: targetEntries } = chooseEntries(current, names);
+    const { entries: targetEntries } = chooseEntries(
+      current,
+      resolveStateSubjects(current, rawNames),
+    );
     for (const entry of targetEntries) {
       if (sourceGone.has(entry.name)) {
         rows.push(

--- a/src/commands/update/selection.ts
+++ b/src/commands/update/selection.ts
@@ -2,13 +2,14 @@
  * Entry selection helpers for `crew update` (§10.1).
  *
  * The command entry point orchestrates refresh/re-expand/update work;
- * this module owns the named-entry and dependency-closure selection
- * logic so the command file stays small.
+ * this module owns installed-subject and dependency-closure selection
+ * so the command file stays small.
  */
 
 import { CrewError } from "../../core/errors.ts";
 import type { Config, StateEntry, StateFile, TapConfig } from "../../core/types.ts";
 import type { UpdateRow } from "../../install/update-one.ts";
+import type { StateSubject } from "../../state/subjects.ts";
 
 /** Expanded update set + per-entry "who pulled you in" map. */
 export interface ChosenEntries {
@@ -29,7 +30,7 @@ export interface ChosenEntries {
  *
  * Non-empty `names`: the taps backing every entry in the expanded
  * update set (direct names + dep closure), plus the tap itself if the
- * user named it directly (`crew update <tap-name>`). Other taps
+ * user named it directly (`crew update <tap-name>`). Other taps are
  * untouched.
  */
 export function tapsToRefreshFor(
@@ -59,81 +60,97 @@ export function withTransitive(
 }
 
 /**
- * Select entries for the update run, expanding named entries with their
- * transitive dependency closure.
- *
- * Deps are derived from state alone: a skill `bar` is a dependency of
- * `foo` iff `bar.required_by` contains `"foo"` (§11.1). This works
- * without reading SKILL.md from disk.
+ * Select entries for the update run, expanding named entries with
+ * their transitive dependency closure.
  */
-export function chooseEntries(state: StateFile, names: readonly string[]): ChosenEntries {
-  if (names.length === 0) {
+export function chooseEntries(state: StateFile, subjects: readonly StateSubject[]): ChosenEntries {
+  if (subjects.length === 0) {
     return { entries: [...state.installations], transitiveSources: new Map() };
   }
-  for (const name of names) {
-    if (!state.installations.some((e) => e.name === name)) {
+  for (const subject of subjects) {
+    if (subject.entries.length === 0) {
       throw new CrewError(
         "unknown_skill",
-        `\`${name}\` isn't installed — run \`crew list\` to see what Homecrew is tracking`,
-        { name },
+        `\`${subject.raw}\` isn't installed — run \`crew list\` to see what Homecrew is tracking`,
+        { name: subject.raw },
       );
     }
   }
 
+  const names = subjects.map((subject) => subject.name);
   const topLevel = new Set(names);
-  const selectedNames = new Set<string>();
-  const ancestors = new Map<string, Set<string>>();
-  const queue: { name: string; rootedAt: string }[] = [];
-  for (const name of names) queue.push({ name, rootedAt: name });
+  const selectedNames = selectedWithDependencies(state, names);
+  const entries = orderedEntries(state, subjects, selectedNames, topLevel);
+  return { entries, transitiveSources: transitiveSourcesFor(state, names, topLevel) };
+}
 
+function selectedWithDependencies(state: StateFile, names: readonly string[]): ReadonlySet<string> {
+  const selectedNames = new Set<string>();
+  const queue = names.map((name) => ({ name }));
   while (queue.length > 0) {
-    const { name, rootedAt } = queue.shift()!;
+    const { name } = queue.shift()!;
     const firstVisit = !selectedNames.has(name);
     selectedNames.add(name);
+    if (!firstVisit) continue;
+    for (const candidate of state.installations) {
+      if (candidate.required_by.includes(name)) queue.push({ name: candidate.name });
+    }
+  }
+  return selectedNames;
+}
+
+function orderedEntries(
+  state: StateFile,
+  subjects: readonly StateSubject[],
+  selectedNames: ReadonlySet<string>,
+  topLevel: ReadonlySet<string>,
+): readonly StateEntry[] {
+  const entries: StateEntry[] = [];
+  const seen = new Set<string>();
+  const add = (entry: StateEntry) => {
+    const key = entryKey(entry);
+    if (seen.has(key)) return;
+    seen.add(key);
+    entries.push(entry);
+  };
+  for (const subject of subjects) {
+    for (const entry of subject.entries) add(entry);
+  }
+  for (const entry of state.installations) {
+    if (!selectedNames.has(entry.name) || topLevel.has(entry.name)) continue;
+    add(entry);
+  }
+  return entries;
+}
+
+function transitiveSourcesFor(
+  state: StateFile,
+  names: readonly string[],
+  topLevel: ReadonlySet<string>,
+): ReadonlyMap<string, readonly string[]> {
+  const ancestors = new Map<string, Set<string>>();
+  const visited = new Set<string>();
+  const queue = names.map((name) => ({ name, rootedAt: name }));
+  while (queue.length > 0) {
+    const { name, rootedAt } = queue.shift()!;
+    const firstVisit = !visited.has(name);
+    visited.add(name);
     if (!topLevel.has(name)) {
       if (!ancestors.has(name)) ancestors.set(name, new Set());
       ancestors.get(name)!.add(rootedAt);
     }
     if (!firstVisit) continue;
     for (const candidate of state.installations) {
-      if (candidate.required_by.includes(name)) queue.push({ name: candidate.name, rootedAt });
+      if (candidate.required_by.includes(name)) {
+        queue.push({ name: candidate.name, rootedAt });
+      }
     }
   }
-
-  return {
-    entries: selectedEntries(state.installations, names, selectedNames, topLevel),
-    transitiveSources: transitiveMap(ancestors),
-  };
-}
-
-function selectedEntries(
-  installations: readonly StateEntry[],
-  names: readonly string[],
-  selectedNames: ReadonlySet<string>,
-  topLevel: ReadonlySet<string>,
-): StateEntry[] {
-  const entries: StateEntry[] = [];
-  const seen = new Set<string>();
-  for (const n of names) {
-    for (const e of installations) {
-      if (e.name === n) pushEntry(entries, seen, e);
-    }
-  }
-  for (const e of installations) {
-    if (selectedNames.has(e.name) && !topLevel.has(e.name)) pushEntry(entries, seen, e);
-  }
-  return entries;
-}
-
-function pushEntry(entries: StateEntry[], seen: Set<string>, entry: StateEntry): void {
-  const key = `${entry.name}::${entry.scope}::${entry.project_root ?? ""}`;
-  if (seen.has(key)) return;
-  seen.add(key);
-  entries.push(entry);
-}
-
-function transitiveMap(ancestors: ReadonlyMap<string, ReadonlySet<string>>): Map<string, string[]> {
-  const out = new Map<string, string[]>();
+  const out = new Map<string, readonly string[]>();
   for (const [name, set] of ancestors) out.set(name, [...set].sort());
   return out;
+}
+
+function entryKey(entry: StateEntry): string {
+  return `${entry.name}::${entry.scope}::${entry.project_root ?? ""}`;
 }

--- a/src/commands/update/selection.ts
+++ b/src/commands/update/selection.ts
@@ -22,6 +22,11 @@ export interface ChosenEntries {
   readonly transitiveSources: ReadonlyMap<string, readonly string[]>;
 }
 
+interface DependencyClosure {
+  readonly selectedNames: ReadonlySet<string>;
+  readonly transitiveSources: ReadonlyMap<string, readonly string[]>;
+}
+
 /**
  * Compute the set of tap configs whose clones this run needs fresh.
  *
@@ -43,6 +48,9 @@ export function tapsToRefreshFor(
   for (const e of expandedSelection) {
     wantedTapNames.add(e.source.tap);
   }
+  // `names` are resolved skill names, not raw inputs. Qualified refs
+  // refresh through `expandedSelection`; this preserves bare tap-name
+  // updates.
   for (const n of names) {
     if (config.taps.some((t) => t.name === n)) wantedTapNames.add(n);
   }
@@ -79,26 +87,42 @@ export function chooseEntries(state: StateFile, subjects: readonly StateSubject[
 
   const names = subjects.map((subject) => subject.name);
   const topLevel = new Set(names);
-  const selectedNames = selectedWithDependencies(state, names);
-  const entries = orderedEntries(state, subjects, selectedNames, topLevel);
-  return { entries, transitiveSources: transitiveSourcesFor(state, names, topLevel) };
+  const closure = dependencyClosureFor(state, names, topLevel);
+  const entries = orderedEntries(state, subjects, closure.selectedNames, topLevel);
+  return { entries, transitiveSources: closure.transitiveSources };
 }
 
-function selectedWithDependencies(state: StateFile, names: readonly string[]): ReadonlySet<string> {
+function dependencyClosureFor(
+  state: StateFile,
+  names: readonly string[],
+  topLevel: ReadonlySet<string>,
+): DependencyClosure {
   const selectedNames = new Set<string>();
-  const queue = names.map((name) => ({ name }));
+  const ancestors = new Map<string, Set<string>>();
+  const visited = new Set<string>();
+  const queue = names.map((name) => ({ name, rootedAt: name }));
   while (queue.length > 0) {
-    const { name } = queue.shift()!;
-    const firstVisit = !selectedNames.has(name);
+    const { name, rootedAt } = queue.shift()!;
+    const firstVisit = !visited.has(name);
+    visited.add(name);
     selectedNames.add(name);
+    if (!topLevel.has(name)) {
+      if (!ancestors.has(name)) ancestors.set(name, new Set());
+      ancestors.get(name)!.add(rootedAt);
+    }
     if (!firstVisit) continue;
     for (const candidate of state.installations) {
-      if (candidate.required_by.includes(name)) queue.push({ name: candidate.name });
+      if (candidate.required_by.includes(name)) {
+        queue.push({ name: candidate.name, rootedAt });
+      }
     }
   }
-  return selectedNames;
+  const transitiveSources = new Map<string, readonly string[]>();
+  for (const [name, set] of ancestors) transitiveSources.set(name, [...set].sort());
+  return { selectedNames, transitiveSources };
 }
 
+/** Preserve the user's requested entries first, then append dependency entries in state order. */
 function orderedEntries(
   state: StateFile,
   subjects: readonly StateSubject[],
@@ -121,34 +145,6 @@ function orderedEntries(
     add(entry);
   }
   return entries;
-}
-
-function transitiveSourcesFor(
-  state: StateFile,
-  names: readonly string[],
-  topLevel: ReadonlySet<string>,
-): ReadonlyMap<string, readonly string[]> {
-  const ancestors = new Map<string, Set<string>>();
-  const visited = new Set<string>();
-  const queue = names.map((name) => ({ name, rootedAt: name }));
-  while (queue.length > 0) {
-    const { name, rootedAt } = queue.shift()!;
-    const firstVisit = !visited.has(name);
-    visited.add(name);
-    if (!topLevel.has(name)) {
-      if (!ancestors.has(name)) ancestors.set(name, new Set());
-      ancestors.get(name)!.add(rootedAt);
-    }
-    if (!firstVisit) continue;
-    for (const candidate of state.installations) {
-      if (candidate.required_by.includes(name)) {
-        queue.push({ name: candidate.name, rootedAt });
-      }
-    }
-  }
-  const out = new Map<string, readonly string[]>();
-  for (const [name, set] of ancestors) out.set(name, [...set].sort());
-  return out;
 }
 
 function entryKey(entry: StateEntry): string {

--- a/src/state/subjects.ts
+++ b/src/state/subjects.ts
@@ -1,0 +1,61 @@
+/**
+ * Installed skill selector resolution for state-oriented commands (§7.4, §10.1).
+ *
+ * Commands such as `info`, `update`, and `uninstall` operate on entries already
+ * present in `state.json`. They accept either the stored skill name (`pdf`) or a
+ * more specific tap-qualified selector (`anthropic/pdf`) that identifies the
+ * same installed entry.
+ */
+
+import type { StateEntry, StateFile, TapSource } from "../core/types.ts";
+import { parseRef } from "../refs/parse.ts";
+
+export interface StateSubject {
+  readonly raw: string;
+  readonly name: string;
+  readonly entries: readonly StateEntry[];
+}
+
+/** Resolve one command argument to installed state entries, if it names any. */
+export function resolveStateSubject(state: StateFile, raw: string): StateSubject {
+  const direct = state.installations.filter((entry) => entry.name === raw);
+  if (direct.length > 0) return { raw, name: raw, entries: direct };
+
+  const source = parseStateTapRef(raw);
+  if (source === null) return { raw, name: raw, entries: [] };
+
+  const entries = state.installations.filter((entry) => matchesTapSource(entry, source));
+  if (entries.length === 0) return { raw, name: raw, entries: [] };
+  return { raw, name: source.name, entries };
+}
+
+/** Resolve every argument independently, preserving input order. */
+export function resolveStateSubjects(
+  state: StateFile,
+  rawSubjects: readonly string[],
+): readonly StateSubject[] {
+  return rawSubjects.map((raw) => resolveStateSubject(state, raw));
+}
+
+function parseStateTapRef(raw: string): TapSource | null {
+  try {
+    const source = parseRef(raw);
+    if (source.type !== "tap") return null;
+    return source;
+  } catch {
+    return null;
+  }
+}
+
+function matchesTapSource(entry: StateEntry, source: TapSource): boolean {
+  if (entry.name !== source.name) return false;
+  if (source.tap !== null && entry.source.tap !== source.tap) return false;
+  if (source.namespace === null) return true;
+  return namespaceForEntry(entry) === source.namespace;
+}
+
+function namespaceForEntry(entry: StateEntry): string | null {
+  const parts = entry.source.path.split("/");
+  if (parts.length === 3 && parts[0] === "skills") return parts[1]!;
+  return null;
+}

--- a/src/state/subjects.ts
+++ b/src/state/subjects.ts
@@ -4,7 +4,8 @@
  * Commands such as `info`, `update`, and `uninstall` operate on entries already
  * present in `state.json`. They accept either the stored skill name (`pdf`) or a
  * more specific tap-qualified selector (`anthropic/pdf`) that identifies the
- * same installed entry.
+ * same installed entry. `name` is the resolved skill name when matched, and the
+ * raw input when unmatched so error messages can echo exactly what the user typed.
  */
 
 import type { StateEntry, StateFile, TapSource } from "../core/types.ts";
@@ -41,6 +42,7 @@ function parseStateTapRef(raw: string): TapSource | null {
   try {
     const source = parseRef(raw);
     if (source.type !== "tap") return null;
+    if (source.ref !== null) return null;
     return source;
   } catch {
     return null;
@@ -56,6 +58,7 @@ function matchesTapSource(entry: StateEntry, source: TapSource): boolean {
 
 function namespaceForEntry(entry: StateEntry): string | null {
   const parts = entry.source.path.split("/");
+  // §16 tap index paths use `skills/<namespace>/<name>` only for namespaced skills.
   if (parts.length === 3 && parts[0] === "skills") return parts[1]!;
   return null;
 }

--- a/tests/e2e/state-selectors.test.ts
+++ b/tests/e2e/state-selectors.test.ts
@@ -1,0 +1,106 @@
+/**
+ * State selector e2e tests for installed skill commands (§7.4, §10.1).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { claudeCodeAdapter } from "../../src/agents/claude-code.ts";
+import { codexAdapter } from "../../src/agents/codex.ts";
+import { runCli } from "../../src/cli/main.ts";
+import { readState } from "../../src/state/load.ts";
+import { captureStreams, makeCrewHome } from "../helpers/env.ts";
+import {
+  commitAll,
+  makeGitRepo,
+  makeSkill,
+  makeTempDir,
+  skillFrontmatter,
+} from "../helpers/fixtures.ts";
+
+let ccRoot: string;
+let restore: (() => void) | null = null;
+
+function setupTargets() {
+  ccRoot = makeTempDir("crew-cc-");
+  const coRoot = makeTempDir("crew-co-");
+  const originals = {
+    cc: { userPath: claudeCodeAdapter.userPath, detect: claudeCodeAdapter.detect },
+    co: { userPath: codexAdapter.userPath, detect: codexAdapter.detect },
+  };
+  (claudeCodeAdapter as { userPath: () => string }).userPath = () => ccRoot;
+  (claudeCodeAdapter as { detect: () => boolean }).detect = () => true;
+  (codexAdapter as { userPath: () => string }).userPath = () => coRoot;
+  (codexAdapter as { detect: () => boolean }).detect = () => true;
+  restore = () => {
+    (claudeCodeAdapter as { userPath: () => string }).userPath = originals.cc.userPath;
+    (claudeCodeAdapter as { detect: () => boolean }).detect = originals.cc.detect;
+    (codexAdapter as { userPath: () => string }).userPath = originals.co.userPath;
+    (codexAdapter as { detect: () => boolean }).detect = originals.co.detect;
+  };
+}
+
+function buildTapRepo(): string {
+  const repo = makeTempDir("crew-state-selector-");
+  makeGitRepo(repo);
+  makeSkill(repo, "alpha", skillFrontmatter({ name: "alpha" }));
+  commitAll(repo, "init");
+  return repo;
+}
+
+function installQualifiedSkill(home: string) {
+  const repo = buildTapRepo();
+  runCli(["tap", "add", `file://${repo}`, "mytap"], {
+    home,
+    streams: captureStreams().streams,
+  });
+  runCli(["tap", "remove", "core", "--force"], { home, streams: captureStreams().streams });
+  runCli(["install", "mytap/alpha"], { home, streams: captureStreams().streams });
+}
+
+beforeEach(() => setupTargets());
+afterEach(() => {
+  if (restore) {
+    restore();
+  }
+  restore = null;
+});
+
+describe("installed skill selectors", () => {
+  test("C-UNINST-18 uninstall accepts a qualified installed skill selector", () => {
+    const home = makeCrewHome();
+    installQualifiedSkill(home);
+
+    const code = runCli(["uninstall", "mytap/alpha"], {
+      home,
+      streams: captureStreams().streams,
+    });
+
+    expect(code).toBe(0);
+    expect(existsSync(join(ccRoot, "alpha"))).toBe(false);
+    expect(readState(home).installations).toHaveLength(0);
+  });
+
+  test("C-UPD-25 update accepts a qualified installed skill selector", () => {
+    const home = makeCrewHome();
+    installQualifiedSkill(home);
+    const capture = captureStreams();
+
+    const code = runCli(["update", "mytap/alpha"], { home, streams: capture.streams });
+
+    expect(code).toBe(0);
+    expect(capture.stdout()).toContain("alpha");
+  });
+
+  test("info accepts a qualified installed skill selector", () => {
+    const home = makeCrewHome();
+    installQualifiedSkill(home);
+    const capture = captureStreams();
+
+    const code = runCli(["info", "--json", "mytap/alpha"], { home, streams: capture.streams });
+
+    expect(code).toBe(0);
+    const parsed = JSON.parse(capture.stdout()) as { installed: { source: { tap: string } } };
+    expect(parsed.installed.source.tap).toBe("mytap");
+  });
+});

--- a/tests/e2e/state-selectors.test.ts
+++ b/tests/e2e/state-selectors.test.ts
@@ -16,6 +16,7 @@ import {
   makeSkill,
   makeTempDir,
   skillFrontmatter,
+  tagRepo,
 } from "../helpers/fixtures.ts";
 
 let ccRoot: string;
@@ -45,6 +46,7 @@ function buildTapRepo(): string {
   makeGitRepo(repo);
   makeSkill(repo, "alpha", skillFrontmatter({ name: "alpha" }));
   commitAll(repo, "init");
+  tagRepo(repo, "v1");
   return repo;
 }
 
@@ -54,6 +56,7 @@ function installQualifiedSkill(home: string) {
     home,
     streams: captureStreams().streams,
   });
+  // Keep the test tap as the only source for `alpha`; the default core tap is unrelated here.
   runCli(["tap", "remove", "core", "--force"], { home, streams: captureStreams().streams });
   runCli(["install", "mytap/alpha"], { home, streams: captureStreams().streams });
 }
@@ -92,7 +95,7 @@ describe("installed skill selectors", () => {
     expect(capture.stdout()).toContain("alpha");
   });
 
-  test("info accepts a qualified installed skill selector", () => {
+  test("C-INFO-01 info accepts a qualified installed skill name", () => {
     const home = makeCrewHome();
     installQualifiedSkill(home);
     const capture = captureStreams();
@@ -100,7 +103,56 @@ describe("installed skill selectors", () => {
     const code = runCli(["info", "--json", "mytap/alpha"], { home, streams: capture.streams });
 
     expect(code).toBe(0);
-    const parsed = JSON.parse(capture.stdout()) as { installed: { source: { tap: string } } };
+    const parsed = JSON.parse(capture.stdout()) as {
+      installed: { source: { tap: string } };
+      entries: readonly unknown[];
+    };
     expect(parsed.installed.source.tap).toBe("mytap");
+    expect(parsed.entries).toHaveLength(1);
+  });
+
+  test("uninstall does not treat a ref tail as part of an installed skill name", () => {
+    const home = makeCrewHome();
+    installQualifiedSkill(home);
+
+    const code = runCli(["uninstall", "mytap/alpha@v1"], {
+      home,
+      streams: captureStreams().streams,
+    });
+
+    expect(code).toBe(6);
+    expect(existsSync(join(ccRoot, "alpha"))).toBe(true);
+    expect(readState(home).installations).toHaveLength(1);
+  });
+
+  test("update does not treat a ref tail as part of an installed skill name", () => {
+    const home = makeCrewHome();
+    installQualifiedSkill(home);
+
+    const code = runCli(["update", "mytap/alpha@v1"], {
+      home,
+      streams: captureStreams().streams,
+    });
+
+    expect(code).toBe(4);
+  });
+
+  test("info with a ref tail previews the reference instead of installed state", () => {
+    const home = makeCrewHome();
+    installQualifiedSkill(home);
+    const capture = captureStreams();
+
+    const code = runCli(["info", "--json", "mytap/alpha@v1"], {
+      home,
+      streams: capture.streams,
+    });
+
+    expect(code).toBe(0);
+    const parsed = JSON.parse(capture.stdout()) as {
+      installed?: unknown;
+      skills: readonly { name: string }[];
+    };
+    expect(parsed.installed).toBeUndefined();
+    expect(parsed.skills.map((skill) => skill.name)).toEqual(["alpha"]);
   });
 });

--- a/tests/unit/state-subjects.test.ts
+++ b/tests/unit/state-subjects.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Installed state selector tests (§7.4, §10.1).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { chooseEntries } from "../../src/commands/update/selection.ts";
+import type { StateEntry, StateFile } from "../../src/core/types.ts";
+import { resolveStateSubject, resolveStateSubjects } from "../../src/state/subjects.ts";
+
+function stateEntry(
+  name: string,
+  tap: string,
+  path: string,
+  requiredBy: readonly string[] = [],
+): StateEntry {
+  return {
+    name,
+    source: { tap, path },
+    ref: null,
+    resolved_sha: null,
+    content_hash: "sha256:abc",
+    scope: "user",
+    installed_at: "2026-01-01T00:00:00.000Z",
+    agents: ["codex"],
+    pinned: false,
+    explicit: true,
+    required_by: requiredBy,
+  };
+}
+
+const state: StateFile = {
+  schema_version: 1,
+  installations: [
+    stateEntry("pdf", "anthropic", "skills/pdf"),
+    stateEntry("pdf", "other", "skills/pdf"),
+    stateEntry("forecast", "anthropic", "skills/finance/forecast"),
+  ],
+};
+
+describe("resolveStateSubject", () => {
+  test("bare names match installed state entries directly", () => {
+    const subject = resolveStateSubject(state, "pdf");
+    expect(subject.name).toBe("pdf");
+    expect(subject.entries.map((entry) => entry.source.tap)).toEqual(["anthropic", "other"]);
+  });
+
+  test("tap-qualified selectors narrow to the matching tap", () => {
+    const subject = resolveStateSubject(state, "anthropic/pdf");
+    expect(subject.name).toBe("pdf");
+    expect(subject.entries.map((entry) => entry.source.tap)).toEqual(["anthropic"]);
+  });
+
+  test("namespace-qualified selectors match the installed namespace path", () => {
+    const subject = resolveStateSubject(state, "anthropic/finance/forecast");
+    expect(subject.name).toBe("forecast");
+    expect(subject.entries).toHaveLength(1);
+  });
+
+  test("namespace-qualified selectors ignore non-namespaced installed entries", () => {
+    const subject = resolveStateSubject(
+      { schema_version: 1, installations: [stateEntry("forecast", "anthropic", "forecast")] },
+      "anthropic/finance/forecast",
+    );
+    expect(subject.entries).toHaveLength(0);
+  });
+
+  test("invalid or non-state references return an empty raw selector", () => {
+    expect(resolveStateSubject(state, "not a ref").entries).toHaveLength(0);
+    expect(resolveStateSubject(state, "./pdf").entries).toHaveLength(0);
+    expect(resolveStateSubject(state, "anthropic/missing").raw).toBe("anthropic/missing");
+  });
+
+  test("resolveStateSubjects preserves argument order", () => {
+    const subjects = resolveStateSubjects(state, ["anthropic/pdf", "anthropic/finance/forecast"]);
+    expect(subjects.map((subject) => subject.name)).toEqual(["pdf", "forecast"]);
+  });
+});
+
+describe("chooseEntries", () => {
+  test("unknown state selectors use the raw user input in the error", () => {
+    expect(() =>
+      chooseEntries(state, [{ raw: "anthropic/missing", name: "anthropic/missing", entries: [] }]),
+    ).toThrow("anthropic/missing");
+  });
+
+  test("selected entries include dependency closure in stable order", () => {
+    const root = stateEntry("foo", "core", "foo");
+    const dep = stateEntry("bar", "core", "bar", ["foo"]);
+    const nested = stateEntry("baz", "core", "baz", ["bar"]);
+    const selected = chooseEntries({ schema_version: 1, installations: [dep, root, nested] }, [
+      { raw: "foo", name: "foo", entries: [root] },
+    ]);
+    expect(selected.entries.map((entry) => entry.name)).toEqual(["foo", "bar", "baz"]);
+    expect(selected.transitiveSources.get("bar")).toEqual(["foo"]);
+    expect(selected.transitiveSources.get("baz")).toEqual(["foo"]);
+  });
+});

--- a/tests/unit/state-subjects.test.ts
+++ b/tests/unit/state-subjects.test.ts
@@ -50,6 +50,11 @@ describe("resolveStateSubject", () => {
     expect(subject.entries.map((entry) => entry.source.tap)).toEqual(["anthropic"]);
   });
 
+  test("tap-qualified selectors do not ignore ref tails", () => {
+    const subject = resolveStateSubject(state, "anthropic/pdf@v1");
+    expect(subject.entries).toHaveLength(0);
+  });
+
   test("namespace-qualified selectors match the installed namespace path", () => {
     const subject = resolveStateSubject(state, "anthropic/finance/forecast");
     expect(subject.name).toBe("forecast");
@@ -66,6 +71,7 @@ describe("resolveStateSubject", () => {
 
   test("invalid or non-state references return an empty raw selector", () => {
     expect(resolveStateSubject(state, "not a ref").entries).toHaveLength(0);
+    expect(resolveStateSubject(state, "foo bar").entries).toHaveLength(0);
     expect(resolveStateSubject(state, "./pdf").entries).toHaveLength(0);
     expect(resolveStateSubject(state, "anthropic/missing").raw).toBe("anthropic/missing");
   });


### PR DESCRIPTION
## Summary

- add installed-skill selector resolution so `crew uninstall anthropic/pdf` works for a skill installed as `pdf`
- extend the same state-oriented behavior to `crew update <tap>/<skill>` and `crew info <tap>/<skill>`
- update the PRD conformance language and CLI help examples

## Product language note

The PRD uses `selector` as precise spec terminology, but user-facing help intentionally uses `name`. To users, both `pdf` and `anthropic/pdf` are skill names; `selector` is colder and more technical.

## Verification

- `bun run check`
