### PR TITLE
[LOG-4745] Release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [0.8.0] — 2026-05-11
+
+### Added
+- Bundled known-tap registry with 255 curated skills across 26 first-party taps (Anthropic, Apollo GraphQL, Azure, Cloudflare, ElevenLabs, Figma, Google Gemini, Hugging Face, OpenAI, PostHog, Stripe, Supabase, and more); no network access required on first run.
+- `crew install` now suggests known-tap `crew tap add` commands when a skill name is not found in any configured tap.
+- `crew search` appends known-but-untapped registry results (with tap-add commands) after configured-tap results for non-empty queries.
+- `crew untap <name>` top-level alias for `crew tap remove <name>`.
+- `crew skills` alias for `crew list`; `crew taps` alias for `crew tap list`.
+- `--recursive` flag for `crew tap add` and `crew install` to discover skills in non-standard, deeply nested tap layouts; discovery mode is persisted across search, update, and doctor repair.
+- Qualified skill selectors (`tap/skill`) now accepted by `crew uninstall`, `crew update`, and `crew info`.
+- Signed release checksums: every release ships `SHA256SUMS` + `SHA256SUMS.sig`; both the hosted installer and `crew self-update` verify the RSA/SHA-256 signature before trusting checksums.
+- Browsable skill catalog at `/skills` on the crew website, auto-generated from the curated registry.
+- CONTRIBUTING.md and SECURITY.md added to the repository.
+
+### Changed
+- CLI errors render as readable blocks with an explicit "Next step" instead of single-line messages; common tap, command, install-miss, and empty-search copy reworded for clarity.
+- `crew search` installed markers are now source-aware (tap + path), preventing false positives when taps share skill names.
+- Install refs are canonicalized to lowercase, making bare, qualified, and namespaced refs case-insensitive.
+- `SKILL.md` frontmatter `name` is now the authoritative skill name; source directory name no longer needs to match, and names may begin with a digit.
+- Hosted installer and `crew self-update` verify `SHA256SUMS` before replacing the binary on disk.
+
+### Fixed
+- Removing or replacing a tap no longer causes skills from the old tap to show as installed in `crew search` results.
+
 ## [0.7.0] — 2026-05-06
 
 ### Changed

--- a/PRD.md
+++ b/PRD.md
@@ -2,7 +2,7 @@
 
 **A package manager for Agent Skills.**
 
-Version: 0.7.0
+Version: 0.8.0
 Status: Specification, ready for implementation
 Platform: macOS (Apple Silicon and Intel)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crew",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "A package manager for Agent Skills",
   "author": "Logic App, Inc.",
   "license": "MIT",

--- a/site/public/latest-version.json
+++ b/site/public/latest-version.json
@@ -1,17 +1,21 @@
 {
-  "tag_name": "v0.7.0",
+  "tag_name": "v0.8.0",
   "assets": [
     {
       "name": "crew-macos-arm64",
-      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.7.0/crew-macos-arm64"
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.8.0/crew-macos-arm64"
     },
     {
       "name": "crew-macos-x64",
-      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.7.0/crew-macos-x64"
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.8.0/crew-macos-x64"
     },
     {
       "name": "SHA256SUMS",
-      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.7.0/SHA256SUMS"
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.8.0/SHA256SUMS"
+    },
+    {
+      "name": "SHA256SUMS.sig",
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.8.0/SHA256SUMS.sig"
     }
   ]
 }

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -5,5 +5,5 @@
  * without touching anything else. The value written to the `installed_by`
  * marker field and printed by `crew version` is derived from here.
  */
-export const CREW_VERSION = "0.7.0";
+export const CREW_VERSION = "0.8.0";
 export const CREW_INSTALLED_BY = `crew/${CREW_VERSION}`;


### PR DESCRIPTION
## What's new in 0.8.0

### Added

- **Known-tap registry** — crew now ships a curated, offline registry of 255 skills across 26 first-party taps (Anthropic, Apollo GraphQL, Azure, Cloudflare, ElevenLabs, Figma, Google Gemini, Hugging Face, OpenAI, PostHog, Stripe, Supabase, and more). No cloning happens on first run; the registry is bundled and instant.
- **Install suggestions for unknown skills** — when `crew install <name>` can't find a match in your configured taps, crew now checks the registry and suggests the exact `crew tap add` command to unlock it.
- **Search suggestions from the registry** — `crew search <query>` now appends known-but-untapped results below your configured tap results, with a ready-to-run tap command shown for each.
- **`crew untap <name>`** — top-level shorthand for `crew tap remove <name>`. Less typing, same result.
- **`crew skills` and `crew taps` aliases** — `crew skills` lists installed skills; `crew taps` lists configured taps. Both work everywhere `crew list` and `crew tap list` do.
- **Recursive tap discovery (`--recursive`)** — repos with non-standard, deeply nested skill directories can now be tapped with `crew tap add --recursive <url>` or installed directly with `crew install --recursive <url>`. The discovery mode is persisted so search, update, and doctor repair all use the same setting.
- **Qualified skill names everywhere** — `crew uninstall anthropic/pdf`, `crew update anthropic/pdf`, and `crew info anthropic/pdf` now work even when the skill was installed under its short name. The same selector resolution applies to `update` and `info`.
- **Signed release checksums** — every release now ships a `SHA256SUMS` file and an RSA/SHA-256 signature (`SHA256SUMS.sig`). Both the hosted installer and `crew self-update` verify the signature before trusting binary checksums.
- **Skill catalog page** — the crew website gains a browsable `/skills` page auto-generated from the curated registry, with one-click copy of `crew tap add` commands.
- **CONTRIBUTING.md and SECURITY.md** — public contribution guide and a private security-reporting channel (security@logic.inc) are now documented.

### Changed

- **Friendlier error output** — errors are now rendered as readable blocks with an explicit "Next step" instead of dense one-line messages. Common tap, command, install-miss, and empty-search messages have been reworded so the offending value and its remedy are easier to scan.
- **Source-aware installed markers in search** — `crew search` now computes installed status from the tap/path the skill came from, not just its name. Skills with the same name from different taps are correctly distinguished.
- **Case-insensitive install refs** — tap-source identifiers are now canonicalized to lowercase, so `crew install Anthropic/PDF` and `crew install anthropic/pdf` behave identically.
- **Relaxed skill name validation** — `SKILL.md` frontmatter `name` is now authoritative; the source directory name no longer needs to match. Skill names may also start with a digit (e.g. `3-statement-model`), bringing crew into alignment with how real-world skill authors publish.
- **Release binaries verified before install** — the hosted installer and `crew self-update` both download and verify `SHA256SUMS` before replacing the binary on disk.

### Fixed

- **Search installed markers no longer false-positive** — removing or replacing a tap no longer causes skills from the old tap to appear as installed in search results.