### PR TITLE
[LOG-4746] Release v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.8.1] — 2026-05-11
+
+### Added
+- **Compound Engineering known tap.** EveryInc's Compound Engineering Plugin (`compound-engineering`) is now in the curated registry, contributing 37 skills for spec writing, implementation, code review, debugging, and product workflows. The tap uses a non-standard subpath (`plugins/compound-engineering/skills`) and is pinned to a reviewed commit. It surfaces in `crew search` suggestions, `crew install` hints, and the skill catalog on the crew website.
+
 ## [0.8.0] — 2026-05-11
 
 ### Added

--- a/PRD.md
+++ b/PRD.md
@@ -2,7 +2,7 @@
 
 **A package manager for Agent Skills.**
 
-Version: 0.8.0
+Version: 0.8.1
 Status: Specification, ready for implementation
 Platform: macOS (Apple Silicon and Intel)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crew",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "A package manager for Agent Skills",
   "author": "Logic App, Inc.",
   "license": "MIT",

--- a/site/public/latest-version.json
+++ b/site/public/latest-version.json
@@ -1,21 +1,21 @@
 {
-  "tag_name": "v0.8.0",
+  "tag_name": "v0.8.1",
   "assets": [
     {
       "name": "crew-macos-arm64",
-      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.8.0/crew-macos-arm64"
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.8.1/crew-macos-arm64"
     },
     {
       "name": "crew-macos-x64",
-      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.8.0/crew-macos-x64"
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.8.1/crew-macos-x64"
     },
     {
       "name": "SHA256SUMS",
-      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.8.0/SHA256SUMS"
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.8.1/SHA256SUMS"
     },
     {
       "name": "SHA256SUMS.sig",
-      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.8.0/SHA256SUMS.sig"
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.8.1/SHA256SUMS.sig"
     }
   ]
 }

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -5,5 +5,5 @@
  * without touching anything else. The value written to the `installed_by`
  * marker field and printed by `crew version` is derived from here.
  */
-export const CREW_VERSION = "0.8.0";
+export const CREW_VERSION = "0.8.1";
 export const CREW_INSTALLED_BY = `crew/${CREW_VERSION}`;


### PR DESCRIPTION
## What's new in 0.8.1

### Added

- **Compound Engineering tap** — EveryInc's [Compound Engineering Plugin](https://github.com/EveryInc/compound-engineering-plugin) is now a curated known tap, adding 37 skills for spec writing, implementation planning, code review, debugging, and product workflows. Because the skills live in a non-standard subdirectory, the tap requires the `--recursive`-style subpath form — crew handles this automatically when you use the known-tap suggestion:
  ```sh
  crew tap add https://github.com/EveryInc/compound-engineering-plugin//plugins/compound-engineering/skills compound-engineering
  ```
  The tap also appears in `crew search` results and the skill catalog on the crew website.