### PR TITLE
[LOG-4758] Use latest version in install snippet

### DIFF
--- a/site/components/sections/Install.tsx
+++ b/site/components/sections/Install.tsx
@@ -1,4 +1,5 @@
 import { SAAP_FULL_PROMPT } from "../../lib/prd";
+import { CREW_VERSION_TAG } from "../../lib/version";
 import { Acc, CodeBlock } from "../primitives/CodeBlock";
 import { Container } from "../primitives/Container";
 import { CopyButton } from "../primitives/CopyButton";
@@ -7,6 +8,7 @@ import { BuildItYourself } from "./BuildItYourself";
 import styles from "./Install.module.css";
 
 const INSTALL_COMMAND = "curl -fsSL https://crew.logic.inc/install.sh | sh";
+const CREW_VERSION = CREW_VERSION_TAG.replace(/^v/, "");
 
 export function Install() {
   return (
@@ -30,7 +32,7 @@ export function Install() {
             {"$ curl -fsSL "}
             <Acc>https://crew.logic.inc/install.sh</Acc>
             {" | sh\n$ crew version\ncrew "}
-            <Acc>0.3.1</Acc>
+            <Acc>{CREW_VERSION}</Acc>
             {" (darwin-arm64)"}
           </CodeBlock>
           <div className={styles.copy}>


### PR DESCRIPTION

<img width="1144" height="376" alt="image" src="https://github.com/user-attachments/assets/4e51f1ff-07ab-4e25-afce-82c49f238886" />

Fixing the hardcoded version string in the install example.

<img width="1178" height="391" alt="image" src="https://github.com/user-attachments/assets/b438366f-583a-4adf-ad28-5730960e065b" />


## Summary

- Replace the hardcoded homepage install snippet version with the latest release tag from `site/public/latest-version.json`.
- Strip the leading `v` for the terminal example so it matches `crew version` output.

## Test plan

- `cd site && bun run check`