### PR TITLE
[LOG-4917] support antigravity cli

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -410,6 +410,7 @@ Every adapter listed at [agentskills.io/clients](https://agentskills.io/clients)
 |---|---|---|---|
 | `agent-skills` | `~/.agents/skills/` | `<project>/.agents/skills/` | `~/.agents/` exists |
 | `amp` | `~/.config/amp/skills/` | `<project>/.agents/skills/` | `amp` on PATH or `~/.config/amp/` exists |
+| `antigravity-cli` | `~/.gemini/antigravity-cli/skills/` | `<project>/.agents/skills/` | `antigravity` on PATH or `~/.gemini/antigravity-cli/` exists |
 | `autohand` | `~/.autohand/skills/` | `<project>/.autohand/skills/` | `autohand` on PATH or `~/.autohand/` exists |
 | `claude-code` | `~/.claude/skills/` | `<project>/.claude/skills/` | `claude` on PATH or `~/.claude/` exists |
 | `codex` | `~/.agents/skills/` | `<project>/.agents/skills/` | `codex` on PATH or `~/.codex/` exists |
@@ -443,7 +444,7 @@ Adding a new adapter later requires updating this table, adding a file under `sr
 
 **Install path shape.** Each agent has a base directory for skills (user scope and project scope). A skill named `python-testing` is installed by writing its files under `<base>/python-testing/`. The install directory name equals the skill's declared `name`, which is lowercase alphanumerics and hyphens and may begin with a letter or digit.
 
-**Path sharing.** Most adapters resolve to the same filesystem path: `~/.agents/skills/` (user) and `<project>/.agents/skills/` (project) is the emerging cross-tool convention, read by Codex, Cursor, Command Code, Gemini CLI, GitHub Copilot, Goose, OpenCode, pi, and `agent-skills`. Homecrew writes bytes there once and reports the install to the user under each detected adapter's name, even though only one physical copy exists. The rule: **when a tool reads `~/.agents/skills/`, Homecrew's adapter points there** — one install serves every such tool at once. Adapters whose tools don't support the cross-tool path (Amp user-scope, Autohand, Claude Code, Factory, Junie, Kiro, Mistral Vibe, Nanobot, Roo Code) keep their tool-specific paths.
+**Path sharing.** Most adapters resolve to the same filesystem path: `~/.agents/skills/` (user) and `<project>/.agents/skills/` (project) is the emerging cross-tool convention, read by Codex, Cursor, Command Code, Gemini CLI, GitHub Copilot, Goose, OpenCode, pi, and `agent-skills`. Homecrew writes bytes there once and reports the install to the user under each detected adapter's name, even though only one physical copy exists. The rule: **when a tool reads `~/.agents/skills/`, Homecrew's adapter points there** — one install serves every such tool at once. Adapters whose tools don't support the cross-tool path (Amp user-scope, Antigravity CLI user-scope, Autohand, Claude Code, Factory, Junie, Kiro, Mistral Vibe, Nanobot, Roo Code) keep their tool-specific paths.
 
 The install algorithm (§7.3) dedupes writes by resolved path; the marker (§7.5) records which adapters own the install.
 

--- a/README.md
+++ b/README.md
@@ -344,7 +344,8 @@ Works with every Mac agent that speaks the spec. Any agent coder that reads
 the [Agent Skills spec](https://agentskills.io/specification) is a valid
 target. Homecrew auto-detects the ones you already have and quietly skips the rest.
 
-Amp · Autohand · Claude Code · Codex · Command Code · Cursor · Factory ·
+Amp · Antigravity CLI · Autohand · Claude Code · Codex · Command Code ·
+Cursor · Factory ·
 Gemini CLI · GitHub Copilot · Goose · Junie · Kiro · Mistral Vibe · Nanobot ·
 OpenCode · pi · Roo Code
 

--- a/site/components/sections/HowItWorks.tsx
+++ b/site/components/sections/HowItWorks.tsx
@@ -72,6 +72,7 @@ const DIAGRAM_ROWS: readonly {
   { name: "codex", path: "~/.agents/skills/", status: "detected" },
   { name: "cursor", path: "~/.agents/skills/", status: "detected" },
   { name: "gemini-cli", path: "~/.agents/skills/", status: "detected" },
+  { name: "antigravity-cli", path: "~/.gemini/antigravity-cli/skills/", status: "detected" },
 ];
 
 export function HowItWorks() {
@@ -99,7 +100,7 @@ export function HowItWorks() {
           </div>
 
           <aside className={styles.diagram}>
-            <div className={styles.dTitle}>Agent adapters · showing 4 of 17</div>
+            <div className={styles.dTitle}>Agent adapters · showing 5 of 18</div>
             {DIAGRAM_ROWS.map((r) => (
               <div key={r.name} className={styles.dRow}>
                 <span className={styles.dName}>{r.name}</span>

--- a/site/lib/agents.ts
+++ b/site/lib/agents.ts
@@ -11,6 +11,7 @@ export interface Agent {
 
 export const AGENTS: readonly Agent[] = [
   { name: "amp", display: "Amp" },
+  { name: "antigravity-cli", display: "Antigravity CLI" },
   { name: "autohand", display: "Autohand" },
   { name: "claude-code", display: "Claude Code" },
   { name: "codex", display: "Codex" },

--- a/src/agents/antigravity-cli.ts
+++ b/src/agents/antigravity-cli.ts
@@ -1,0 +1,29 @@
+/**
+ * Antigravity CLI adapter.
+ *
+ * Antigravity CLI stores user-scope skills under
+ * `~/.gemini/antigravity-cli/skills/` and project-scope skills under
+ * `<project>/.agents/skills/`.
+ */
+
+import { join } from "node:path";
+import { isDirectory } from "../util/fs.ts";
+import type { AgentAdapter } from "./adapter.ts";
+import { isOnPath, userHome } from "./path.ts";
+
+export const antigravityCliAdapter: AgentAdapter = {
+  name: "antigravity-cli",
+  detect(): boolean {
+    return (
+      isDirectory(join(userHome(), ".gemini", "antigravity-cli")) ||
+      isOnPath("antigravity") ||
+      isOnPath("antigravity-cli")
+    );
+  },
+  userPath(): string {
+    return join(userHome(), ".gemini", "antigravity-cli", "skills");
+  },
+  projectPath(cwd: string): string {
+    return join(cwd, ".agents", "skills");
+  },
+};

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -11,6 +11,7 @@
 import type { AgentAdapter } from "./adapter.ts";
 import { agentSkillsAdapter } from "./agent-skills.ts";
 import { ampAdapter } from "./amp.ts";
+import { antigravityCliAdapter } from "./antigravity-cli.ts";
 import { autohandAdapter } from "./autohand.ts";
 import { claudeCodeAdapter } from "./claude-code.ts";
 import { codexAdapter } from "./codex.ts";
@@ -32,6 +33,7 @@ import { rooCodeAdapter } from "./roo-code.ts";
 export const ALL_AGENTS: readonly AgentAdapter[] = [
   agentSkillsAdapter,
   ampAdapter,
+  antigravityCliAdapter,
   autohandAdapter,
   claudeCodeAdapter,
   codexAdapter,

--- a/tests/agents/adapters.test.ts
+++ b/tests/agents/adapters.test.ts
@@ -53,6 +53,12 @@ const EXPECTATIONS: readonly AdapterExpectation[] = [
     detectFixtures: [".config/amp"],
   },
   {
+    name: "antigravity-cli",
+    userSuffix: ".gemini/antigravity-cli/skills",
+    projectSuffix: ".agents/skills",
+    detectFixtures: [".gemini/antigravity-cli"],
+  },
+  {
     name: "autohand",
     userSuffix: ".autohand/skills",
     projectSuffix: ".autohand/skills",


### PR DESCRIPTION
## Summary
Homecrew previously could not detect Antigravity CLI as a supported agent, so skills installed through `crew` did not appear as a target for local antigravity workflows. Now `crew` can detect Antigravity CLI and resolve its user install location at `~/.gemini/antigravity-cli/skills/`, while keeping project-level installs on the shared `<project>/.agents/skills/` path.

## Changes
| Area | What changed |
| --- | --- |
| Agent adapter set | Added a dedicated `antigravity-cli` adapter with path and detection logic (`~/.gemini/antigravity-cli/` or `antigravity` on PATH). |
| Adapter wiring | Registered the adapter in runtime selection so install flows include Antigravity CLI when present. |
| User-facing documentation | Updated spec table, supported-agent list in README, and website flow diagram. |
| Test coverage | Added unit-test expectation for Antigravity CLI path detection and fixture handling. |

## Testing
- Tested locally in addition to codex generated tests in accordance with repo examples
