### PR TITLE
[LOG-4939] Parse .structured_output for claude --output-format json

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -199,19 +199,12 @@ if [ "$(echo "$response" | jq -r 'if type == "object" then (.is_error // false) 
   exit 1
 fi
 
-# With `--json-schema`, Claude's structured response comes back as a
-# tool call named `StructuredOutput` whose `input` is the schema-
-# conforming object. The top-level `result` field is empty text.
-# Walk the event stream and pick out the last tool_use input.
-inner="$(
-  echo "$response" | jq -c '
-    map(select(.type == "assistant")
-      | .message.content[]
-      | select(.name == "StructuredOutput")
-      | .input
-    ) | last
-  '
-)"
+# With `--json-schema` and `--output-format json`, claude returns a
+# single result envelope and parks the schema-conforming object at
+# top-level `.structured_output`. (Earlier versions of this script
+# walked a stream-json event log — that shape never matched under
+# --output-format json and produced a cryptic jq error.)
+inner="$(echo "$response" | jq -c '.structured_output')"
 if [ -z "$inner" ] || [ "$inner" = "null" ]; then
   echo "error: claude response missing structured output" >&2
   echo "--- raw response ---" >&2


### PR DESCRIPTION
## Summary

After #73 unblocked auth, `bun run release minor` failed at the parse step with:

```
jq: error (at <stdin>:1): Cannot index string with string "type"
error: script "release" exited with code 5
```

Root cause: the jq pipeline walked a stream-json event log
(`map(select(.type == "assistant") | .message.content[] | select(.name == "StructuredOutput") | .input)`),
but the script asks for `--output-format json`, which returns a single result envelope — not a stream of events. `map` on that object iterated its string values and tried to read `.type` from a string, hence the error.

## Fix

With `--output-format json --json-schema`, claude puts the schema-conforming object at top-level `.structured_output`. Replace the pipeline with `jq -c '.structured_output'` and update the comment to describe the actual shape. The downstream `[ -z "$inner" ] || [ "$inner" = "null" ]` guard still handles the missing-field case unchanged.

## Local test

Fast-forwarded local `main` onto this branch and ran the script in dry-run mode (which makes a real `claude -p` call and exercises the exact parse path that was broken), then reset `main` back to `origin/main`:

```sh
git checkout main
git merge --ff-only fix-release-script-jq-parse
bun run release minor --dry-run
git reset --hard origin/main
```

Output (trimmed):

```
==> Fetching origin/main
==> Releasing 0.8.1 -> 0.9.0 (minor)
==> Asking Claude to summarize changes since v0.8.1
==> [dry-run] Would create branch release/v0.9.0

--- PR body ---
## What's new in 0.9.0
### Added
- **Antigravity CLI support.** ...
### Fixed
- **`crew update` no longer re-reports local skills as changed on every run.** ...
- **Homepage install snippet always shows the current release.** ...

--- CHANGELOG section ---
## [0.9.0] — 2026-05-26
### Added
- Antigravity CLI is now a supported agent. ...
### Fixed
- `crew update` no longer reports local path-sourced skills as updated on every run ...
- The install snippet on the crew website now dynamically renders the latest release version ...

==> [dry-run] Done. No changes made.
```

Pre-fix, this run errored at the jq step (`Cannot index string with string "type"`). Post-fix, the structured response parses correctly and both the PR body and CHANGELOG render. No commit, branch, or PR is created in dry-run mode.

## Test plan

- [x] `bash -n scripts/release.sh` passes.
- [x] End-to-end dry-run produces a valid PR body + CHANGELOG section.
- [ ] (On merge) next real `bun run release <bump>` completes through the summary step.
