### PR TITLE
[LOG-4941] Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.9.0] — 2026-05-26
+
+### Added
+- Antigravity CLI is now a supported agent. `crew` detects it automatically and resolves user-level skills to `~/.gemini/antigravity-cli/skills/`; project-level installs continue to use `<project>/.agents/skills/`.
+
+### Fixed
+- `crew update` no longer reports local path-sourced skills as updated on every run. The new content hash is persisted after each real change, so the next run compares against current bytes instead of stale state.
+- The install snippet on the crew website now dynamically renders the latest release version instead of a hardcoded string.
+
 ## [0.8.1] — 2026-05-11
 
 ### Added

--- a/PRD.md
+++ b/PRD.md
@@ -2,7 +2,7 @@
 
 **A package manager for Agent Skills.**
 
-Version: 0.8.1
+Version: 0.9.0
 Status: Specification, ready for implementation
 Platform: macOS (Apple Silicon and Intel)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crew",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "A package manager for Agent Skills",
   "author": "Logic App, Inc.",
   "license": "MIT",

--- a/site/public/latest-version.json
+++ b/site/public/latest-version.json
@@ -1,21 +1,21 @@
 {
-  "tag_name": "v0.8.1",
+  "tag_name": "v0.9.0",
   "assets": [
     {
       "name": "crew-macos-arm64",
-      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.8.1/crew-macos-arm64"
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.9.0/crew-macos-arm64"
     },
     {
       "name": "crew-macos-x64",
-      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.8.1/crew-macos-x64"
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.9.0/crew-macos-x64"
     },
     {
       "name": "SHA256SUMS",
-      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.8.1/SHA256SUMS"
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.9.0/SHA256SUMS"
     },
     {
       "name": "SHA256SUMS.sig",
-      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.8.1/SHA256SUMS.sig"
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.9.0/SHA256SUMS.sig"
     }
   ]
 }

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -5,5 +5,5 @@
  * without touching anything else. The value written to the `installed_by`
  * marker field and printed by `crew version` is derived from here.
  */
-export const CREW_VERSION = "0.8.1";
+export const CREW_VERSION = "0.9.0";
 export const CREW_INSTALLED_BY = `crew/${CREW_VERSION}`;


### PR DESCRIPTION
## What's new in 0.9.0

### Added

- **Antigravity CLI is now a supported agent.** `crew` detects Antigravity CLI automatically and installs skills to `~/.gemini/antigravity-cli/skills/` for user-level installs, or the shared `<project>/.agents/skills/` path for project-level installs.

### Fixed

- **`crew update` no longer re-reports local skills as changed on every run.** After applying an update to a local path-sourced skill, `crew` now persists the new content hash so subsequent runs correctly see the skill as up-to-date.
- **The install snippet on the crew website always shows the current release version.** The homepage example was previously hardcoded; it now reads the latest release tag dynamically so copy-pasted commands stay correct after every release.