### PR TITLE
[LOG-4981] style(site): refresh visual system and grid fidget

### DIFF
--- a/site/app/globals.css
+++ b/site/app/globals.css
@@ -11,17 +11,20 @@ body {
 }
 
 body {
-  background:
-    linear-gradient(color-mix(in oklab, var(--saffron) 7%, transparent) 1px, transparent 1px),
-    linear-gradient(90deg, color-mix(in oklab, var(--saffron) 6%, transparent) 1px, transparent 1px),
-    var(--bg);
-  background-size: 18px 18px;
+  background: var(--bg);
   color: var(--ink);
   font-family: var(--font-sans);
   font-size: 16px;
   line-height: 1.55;
   -webkit-font-smoothing: antialiased;
   font-feature-settings: "ss01", "cv11";
+}
+
+body > nav,
+body > main,
+body > footer {
+  position: relative;
+  z-index: 2;
 }
 
 a {

--- a/site/app/globals.css
+++ b/site/app/globals.css
@@ -23,6 +23,7 @@ body {
 body > nav,
 body > main,
 body > footer {
+  /* Keep page content above the visual-only GridFidget canvas. */
   position: relative;
   z-index: 2;
 }

--- a/site/app/globals.css
+++ b/site/app/globals.css
@@ -11,7 +11,11 @@ body {
 }
 
 body {
-  background: var(--bg);
+  background:
+    linear-gradient(color-mix(in oklab, var(--saffron) 7%, transparent) 1px, transparent 1px),
+    linear-gradient(90deg, color-mix(in oklab, var(--saffron) 6%, transparent) 1px, transparent 1px),
+    var(--bg);
+  background-size: 18px 18px;
   color: var(--ink);
   font-family: var(--font-sans);
   font-size: 16px;

--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -1,17 +1,24 @@
 import { Analytics } from "@vercel/analytics/next";
 import type { Metadata } from "next";
-import { Inter, JetBrains_Mono } from "next/font/google";
+import { Archivo, Azeret_Mono, Instrument_Sans } from "next/font/google";
 import type { ReactNode } from "react";
 import "./globals.css";
 
-const inter = Inter({
+const archivo = Archivo({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  variable: "--font-display",
+  display: "swap",
+});
+
+const instrumentSans = Instrument_Sans({
   subsets: ["latin"],
   weight: ["400", "500", "600", "700"],
   variable: "--font-sans",
   display: "swap",
 });
 
-const jetbrainsMono = JetBrains_Mono({
+const azeretMono = Azeret_Mono({
   subsets: ["latin"],
   weight: ["400", "500", "600", "700"],
   variable: "--font-mono",
@@ -40,7 +47,10 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" className={`${inter.variable} ${jetbrainsMono.variable}`}>
+    <html
+      lang="en"
+      className={`${archivo.variable} ${instrumentSans.variable} ${azeretMono.variable}`}
+    >
       <body>
         {children}
         <Analytics />

--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -2,6 +2,7 @@ import { Analytics } from "@vercel/analytics/next";
 import type { Metadata } from "next";
 import { Archivo, Azeret_Mono, Instrument_Sans } from "next/font/google";
 import type { ReactNode } from "react";
+import { GridFidget } from "../components/primitives/GridFidget";
 import "./globals.css";
 
 const archivo = Archivo({
@@ -52,6 +53,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       className={`${archivo.variable} ${instrumentSans.variable} ${azeretMono.variable}`}
     >
       <body>
+        <GridFidget />
         {children}
         <Analytics />
       </body>

--- a/site/components/catalog/CommandButton.module.css
+++ b/site/components/catalog/CommandButton.module.css
@@ -16,7 +16,7 @@
 
 .secondaryButton {
   border: 1px solid var(--line-2);
-  background: #fff;
+  background: var(--surface);
   color: var(--ink);
 }
 
@@ -25,7 +25,7 @@
 }
 
 .iconButton.secondaryButton:hover {
-  background: #fff;
+  background: var(--surface);
 }
 
 .iconButton {
@@ -100,7 +100,7 @@
 .copiedButton.secondaryButton:hover,
 .failedButton.secondaryButton,
 .failedButton.secondaryButton:hover {
-  background: #fff;
+  background: var(--surface);
 }
 
 .disabledButton,
@@ -132,7 +132,7 @@
   padding: 9px 10px;
   border: 1px solid var(--line-2);
   border-radius: 6px;
-  background: #fff;
+  background: var(--surface);
   box-shadow: 0 10px 24px color-mix(in oklab, var(--ink) 14%, transparent);
   color: var(--mute);
   font: 11px var(--font-mono);

--- a/site/components/catalog/CommandButton.module.css
+++ b/site/components/catalog/CommandButton.module.css
@@ -2,7 +2,7 @@
   box-sizing: border-box;
   width: 100%;
   min-height: 34px;
-  border-radius: 5px;
+  border-radius: 2px;
   cursor: pointer;
   font: 600 12px var(--font-mono);
   padding: 0 10px;
@@ -36,7 +36,7 @@
   max-width: 28px;
   min-width: 28px;
   min-height: 28px;
-  border-radius: 50%;
+  border-radius: 2px;
   font-size: 17px;
   line-height: 1;
   overflow: hidden;
@@ -52,7 +52,7 @@
 .action:has(.iconButton:focus-visible) .iconButton,
 .actionCopied .iconButton {
   max-width: 160px;
-  border-radius: 999px;
+  border-radius: 2px;
   padding: 0 12px 0 0;
 }
 
@@ -131,7 +131,7 @@
   max-width: max-content;
   padding: 9px 10px;
   border: 1px solid var(--line-2);
-  border-radius: 6px;
+  border-radius: 2px;
   background: var(--surface);
   box-shadow: 0 10px 24px color-mix(in oklab, var(--ink) 14%, transparent);
   color: var(--mute);

--- a/site/components/catalog/SkillCatalog.module.css
+++ b/site/components/catalog/SkillCatalog.module.css
@@ -16,7 +16,7 @@
   width: 100%;
   border: 1px solid var(--line-2);
   border-radius: 5px;
-  background: #fff;
+  background: var(--surface);
   color: var(--ink);
   font: 500 15px var(--font-sans);
   padding: 12px 14px;

--- a/site/components/catalog/SkillCatalog.module.css
+++ b/site/components/catalog/SkillCatalog.module.css
@@ -15,7 +15,7 @@
 .search {
   width: 100%;
   border: 1px solid var(--line-2);
-  border-radius: 5px;
+  border-radius: 2px;
   background: var(--surface);
   color: var(--ink);
   font: 500 15px var(--font-sans);

--- a/site/components/catalog/SkillCatalogRows.module.css
+++ b/site/components/catalog/SkillCatalogRows.module.css
@@ -1,7 +1,7 @@
 .tap {
   scroll-margin-top: 88px;
   border: 1px solid var(--line);
-  border-radius: 8px;
+  border-radius: 2px;
   background: var(--surface);
   padding: 22px;
 }
@@ -34,7 +34,7 @@
 
 .badge {
   border: 1px solid var(--line);
-  border-radius: 4px;
+  border-radius: 999px;
   color: var(--accent-ink);
   font: 11px var(--font-mono);
   padding: 3px 7px;

--- a/site/components/catalog/SkillCatalogRows.module.css
+++ b/site/components/catalog/SkillCatalogRows.module.css
@@ -2,7 +2,7 @@
   scroll-margin-top: 88px;
   border: 1px solid var(--line);
   border-radius: 8px;
-  background: #fff;
+  background: var(--surface);
   padding: 22px;
 }
 

--- a/site/components/primitives/Button.module.css
+++ b/site/components/primitives/Button.module.css
@@ -13,7 +13,7 @@
 }
 
 .btn:hover {
-  background: #000;
+  background: color-mix(in oklab, var(--ink) 92%, var(--aubergine));
 }
 
 .ghost {

--- a/site/components/primitives/Button.module.css
+++ b/site/components/primitives/Button.module.css
@@ -2,7 +2,7 @@
   font-family: var(--font-mono);
   font-size: 13px;
   padding: 10px 16px;
-  border-radius: 5px;
+  border-radius: 2px;
   text-decoration: none;
   display: inline-flex;
   align-items: center;

--- a/site/components/primitives/Chip.module.css
+++ b/site/components/primitives/Chip.module.css
@@ -5,7 +5,7 @@
   gap: 8px;
   padding: 5px 10px;
   border: 1px solid var(--line);
-  border-radius: 4px;
+  border-radius: 999px;
   background: var(--surface);
   color: var(--ink);
   font-size: 13px;

--- a/site/components/primitives/Chip.module.css
+++ b/site/components/primitives/Chip.module.css
@@ -6,7 +6,7 @@
   padding: 5px 10px;
   border: 1px solid var(--line);
   border-radius: 4px;
-  background: #fff;
+  background: var(--surface);
   color: var(--ink);
   font-size: 13px;
 }

--- a/site/components/primitives/CodeBlock.module.css
+++ b/site/components/primitives/CodeBlock.module.css
@@ -4,7 +4,7 @@
   line-height: 1.65;
   background: var(--term-bg);
   color: var(--term-ink);
-  border-radius: 8px;
+  border-radius: 2px;
   padding: 20px 22px;
   overflow-x: auto;
   white-space: pre;

--- a/site/components/primitives/CodeBlock.module.css
+++ b/site/components/primitives/CodeBlock.module.css
@@ -8,12 +8,12 @@
   padding: 20px 22px;
   overflow-x: auto;
   white-space: pre;
-  border: 1px solid #000;
+  border: 1px solid var(--line-2);
   margin: 0;
 }
 
 .light {
-  background: #fff;
+  background: var(--surface);
   color: var(--ink);
   border: 1px solid var(--line);
 }
@@ -36,7 +36,7 @@
   color: var(--term-ok);
 }
 .light .ok {
-  color: oklch(0.5 0.12 150);
+  color: var(--ok);
 }
 
 .warn {
@@ -54,5 +54,5 @@
   color: var(--term-key);
 }
 .light .key {
-  color: oklch(0.5 0.12 250);
+  color: var(--key);
 }

--- a/site/components/primitives/CopyButton.module.css
+++ b/site/components/primitives/CopyButton.module.css
@@ -7,7 +7,7 @@
   padding: 0;
   background: color-mix(in oklab, var(--term-ink) 8%, transparent);
   border: 1px solid color-mix(in oklab, var(--term-ink) 15%, transparent);
-  border-radius: 6px;
+  border-radius: 2px;
   color: var(--term-mute);
   cursor: pointer;
   transition:

--- a/site/components/primitives/GridFidget.tsx
+++ b/site/components/primitives/GridFidget.tsx
@@ -1,27 +1,28 @@
 "use client";
 
 /*
- * Background grid fidget for the site presentation surface (§16.6).
+ * Background grid fidget for the site-only presentation surface.
+ * This visual layer does not implement a CLI PRD section.
  * The canvas is visual-only: it never intercepts input, and click waves
  * only trigger from background-like whitespace rather than foreground UI.
  */
 
 import { useEffect, useRef } from "react";
+import { CELL_SIZE, colorWithAlpha, snapToGrid } from "./grid-fidget/util";
 import type { GridOffset, Palette, Wave } from "./grid-fidget/waves";
 import { addWave, drawWaves } from "./grid-fidget/waves";
-
-const CELL_SIZE = 18;
 
 export function GridFidget() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
   useEffect(() => {
     const canvas = canvasRef.current;
-    if (!canvas || matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+    if (!canvas) return;
 
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
 
+    const allowMotion = !matchMedia("(prefers-reduced-motion: reduce)").matches;
     const palette = readPalette();
     const pointer = { x: -1, y: -1, active: false };
     const waves: Wave[] = [];
@@ -51,12 +52,14 @@ export function GridFidget() {
       ctx.clearRect(0, 0, width, height);
       const offset = gridOffset();
       drawGrid(ctx, width, height, palette, offset);
+      if (!allowMotion) return;
       if (pointer.active) drawHoverCell(ctx, pointer.x, pointer.y, palette, offset);
       drawWaves(ctx, waves, palette, now, offset);
       if (pointer.active || waves.length > 0) schedule();
     };
 
     const onPointerMove = (event: PointerEvent) => {
+      if (!allowMotion) return;
       pointer.x = event.clientX;
       pointer.y = event.clientY;
       pointer.active = true;
@@ -69,6 +72,7 @@ export function GridFidget() {
     };
 
     const onPointerDown = (event: PointerEvent) => {
+      if (!allowMotion) return;
       if (!shouldStartWave(event)) return;
       addWave(waves, event.clientX, event.clientY, width, height, performance.now());
       schedule();
@@ -92,15 +96,17 @@ export function GridFidget() {
   }, []);
 
   return (
-    <canvas
-      ref={canvasRef}
+    <div
+      aria-hidden="true"
       style={{
         inset: 0,
         position: "fixed",
         pointerEvents: "none",
         zIndex: 1,
       }}
-    />
+    >
+      <canvas ref={canvasRef} />
+    </div>
   );
 }
 
@@ -136,19 +142,19 @@ function drawGrid(
 ) {
   ctx.strokeStyle = colorWithAlpha(palette.saffron, 0.065);
   ctx.lineWidth = 1;
+  ctx.beginPath();
   for (let x = offset.x + 0.5; x <= width; x += CELL_SIZE) {
-    ctx.beginPath();
     ctx.moveTo(x, 0);
     ctx.lineTo(x, height);
-    ctx.stroke();
   }
+  ctx.stroke();
   ctx.strokeStyle = colorWithAlpha(palette.saffron, 0.075);
+  ctx.beginPath();
   for (let y = offset.y + 0.5; y <= height; y += CELL_SIZE) {
-    ctx.beginPath();
     ctx.moveTo(0, y);
     ctx.lineTo(width, y);
-    ctx.stroke();
   }
+  ctx.stroke();
 }
 
 function gridOffset(): GridOffset {
@@ -158,21 +164,14 @@ function gridOffset(): GridOffset {
   };
 }
 
-function snapToGrid(value: number, offset: number): number {
-  return Math.floor((value - offset) / CELL_SIZE) * CELL_SIZE + offset;
-}
-
 function shouldStartWave(event: PointerEvent): boolean {
   if (!(event.target instanceof Element)) return false;
   const target = document.elementFromPoint(event.clientX, event.clientY);
-  if (!target || target.closest("a,button,input,textarea,select,summary,[role='button']")) {
+  if (
+    !target ||
+    target.closest("a,button,input,textarea,select,summary,[role='button'],[data-no-fidget]")
+  ) {
     return false;
   }
   return !target.closest("pre,code,svg,img,canvas,video");
-}
-
-function colorWithAlpha(hex: string, alpha: number): string {
-  return `${hex}${Math.round(alpha * 255)
-    .toString(16)
-    .padStart(2, "0")}`;
 }

--- a/site/components/primitives/GridFidget.tsx
+++ b/site/components/primitives/GridFidget.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+/*
+ * Background grid fidget for the site presentation surface (§16.6).
+ * The canvas is visual-only: it never intercepts input, and click bursts
+ * only trigger from background-like whitespace rather than foreground UI.
+ */
+
+import { useEffect, useRef } from "react";
+
+const CELL_SIZE = 18;
+const MAX_PARTICLES = 120;
+
+type Particle = {
+  readonly born: number;
+  readonly size: number;
+  readonly spin: number;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  life: number;
+};
+
+type Palette = {
+  readonly aubergine: string;
+  readonly saffron: string;
+};
+
+export function GridFidget() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const palette = readPalette();
+    const pointer = { x: -1, y: -1, active: false };
+    const particles: Particle[] = [];
+    let animationFrame = 0;
+    let width = 0;
+    let height = 0;
+    let dpr = 1;
+
+    const resize = () => {
+      dpr = Math.min(window.devicePixelRatio || 1, 2);
+      width = window.innerWidth;
+      height = window.innerHeight;
+      canvas.width = Math.ceil(width * dpr);
+      canvas.height = Math.ceil(height * dpr);
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      schedule();
+    };
+
+    const schedule = () => {
+      if (animationFrame === 0) animationFrame = requestAnimationFrame(draw);
+    };
+
+    const draw = (now: number) => {
+      animationFrame = 0;
+      ctx.clearRect(0, 0, width, height);
+      if (pointer.active) drawHoverCell(ctx, pointer.x, pointer.y, palette);
+      drawParticles(ctx, particles, palette, now);
+      if (pointer.active || particles.length > 0) schedule();
+    };
+
+    const onPointerMove = (event: PointerEvent) => {
+      pointer.x = event.clientX;
+      pointer.y = event.clientY;
+      pointer.active = true;
+      schedule();
+    };
+
+    const onPointerLeave = () => {
+      pointer.active = false;
+      schedule();
+    };
+
+    const onPointerDown = (event: PointerEvent) => {
+      if (!isBackgroundClick(event.target)) return;
+      burstFromCell(particles, event.clientX, event.clientY, performance.now());
+      schedule();
+    };
+
+    resize();
+    window.addEventListener("resize", resize);
+    window.addEventListener("pointermove", onPointerMove, { passive: true });
+    window.addEventListener("pointerleave", onPointerLeave, { passive: true });
+    window.addEventListener("pointerdown", onPointerDown, { passive: true });
+
+    return () => {
+      cancelAnimationFrame(animationFrame);
+      window.removeEventListener("resize", resize);
+      window.removeEventListener("pointermove", onPointerMove);
+      window.removeEventListener("pointerleave", onPointerLeave);
+      window.removeEventListener("pointerdown", onPointerDown);
+    };
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      style={{
+        inset: 0,
+        position: "fixed",
+        pointerEvents: "none",
+        zIndex: 2,
+      }}
+    />
+  );
+}
+
+function readPalette(): Palette {
+  const styles = getComputedStyle(document.documentElement);
+  return {
+    aubergine: styles.getPropertyValue("--aubergine").trim(),
+    saffron: styles.getPropertyValue("--saffron").trim(),
+  };
+}
+
+function drawHoverCell(ctx: CanvasRenderingContext2D, x: number, y: number, palette: Palette) {
+  const cellX = Math.floor(x / CELL_SIZE) * CELL_SIZE;
+  const cellY = Math.floor(y / CELL_SIZE) * CELL_SIZE;
+  ctx.fillStyle = colorWithAlpha(palette.aubergine, 0.09);
+  ctx.fillRect(cellX + 1, cellY + 1, CELL_SIZE - 1, CELL_SIZE - 1);
+  ctx.strokeStyle = colorWithAlpha(palette.saffron, 0.38);
+  ctx.strokeRect(cellX + 0.5, cellY + 0.5, CELL_SIZE, CELL_SIZE);
+}
+
+function drawParticles(
+  ctx: CanvasRenderingContext2D,
+  particles: Particle[],
+  palette: Palette,
+  now: number,
+) {
+  for (let index = particles.length - 1; index >= 0; index -= 1) {
+    const particle = particles[index]!;
+    const age = now - particle.born;
+    if (age > particle.life) {
+      particles.splice(index, 1);
+      continue;
+    }
+    const progress = age / particle.life;
+    particle.x += particle.vx;
+    particle.y += particle.vy;
+    particle.vy += 0.045;
+    ctx.save();
+    ctx.translate(particle.x, particle.y);
+    ctx.rotate(progress * particle.spin);
+    ctx.fillStyle = colorWithAlpha(palette.aubergine, (1 - progress) * 0.26);
+    ctx.fillRect(-particle.size / 2, -particle.size / 2, particle.size, particle.size);
+    ctx.restore();
+  }
+}
+
+function burstFromCell(particles: Particle[], x: number, y: number, now: number) {
+  const baseX = Math.floor(x / CELL_SIZE) * CELL_SIZE + CELL_SIZE / 2;
+  const baseY = Math.floor(y / CELL_SIZE) * CELL_SIZE + CELL_SIZE / 2;
+  for (let index = 0; index < 18; index += 1) {
+    const angle = Math.random() * Math.PI * 2;
+    const speed = 0.7 + Math.random() * 1.6;
+    particles.push({
+      born: now,
+      life: 620 + Math.random() * 380,
+      size: 4 + Math.random() * 7,
+      spin: Math.random() * 4 - 2,
+      x: baseX,
+      y: baseY,
+      vx: Math.cos(angle) * speed,
+      vy: Math.sin(angle) * speed - 0.6,
+    });
+  }
+  if (particles.length > MAX_PARTICLES) particles.splice(0, particles.length - MAX_PARTICLES);
+}
+
+function isBackgroundClick(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  const foreground = target.closest(
+    "a,button,input,textarea,select,summary,details,pre,code,h1,h2,h3,h4,p,li,span,strong,em,small,svg,img,[role='button']",
+  );
+  if (foreground) return false;
+  if (target.matches("body,main,section")) return true;
+  return target instanceof HTMLElement && target.textContent?.trim() === "";
+}
+
+function colorWithAlpha(hex: string, alpha: number): string {
+  return `${hex}${Math.round(alpha * 255)
+    .toString(16)
+    .padStart(2, "0")}`;
+}

--- a/site/components/primitives/GridFidget.tsx
+++ b/site/components/primitives/GridFidget.tsx
@@ -2,30 +2,15 @@
 
 /*
  * Background grid fidget for the site presentation surface (§16.6).
- * The canvas is visual-only: it never intercepts input, and click bursts
+ * The canvas is visual-only: it never intercepts input, and click waves
  * only trigger from background-like whitespace rather than foreground UI.
  */
 
 import { useEffect, useRef } from "react";
+import type { GridOffset, Palette, Wave } from "./grid-fidget/waves";
+import { addWave, drawWaves } from "./grid-fidget/waves";
 
 const CELL_SIZE = 18;
-const MAX_PARTICLES = 120;
-
-type Particle = {
-  readonly born: number;
-  readonly size: number;
-  readonly spin: number;
-  x: number;
-  y: number;
-  vx: number;
-  vy: number;
-  life: number;
-};
-
-type Palette = {
-  readonly aubergine: string;
-  readonly saffron: string;
-};
 
 export function GridFidget() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -39,7 +24,7 @@ export function GridFidget() {
 
     const palette = readPalette();
     const pointer = { x: -1, y: -1, active: false };
-    const particles: Particle[] = [];
+    const waves: Wave[] = [];
     let animationFrame = 0;
     let width = 0;
     let height = 0;
@@ -64,9 +49,11 @@ export function GridFidget() {
     const draw = (now: number) => {
       animationFrame = 0;
       ctx.clearRect(0, 0, width, height);
-      if (pointer.active) drawHoverCell(ctx, pointer.x, pointer.y, palette);
-      drawParticles(ctx, particles, palette, now);
-      if (pointer.active || particles.length > 0) schedule();
+      const offset = gridOffset();
+      drawGrid(ctx, width, height, palette, offset);
+      if (pointer.active) drawHoverCell(ctx, pointer.x, pointer.y, palette, offset);
+      drawWaves(ctx, waves, palette, now, offset);
+      if (pointer.active || waves.length > 0) schedule();
     };
 
     const onPointerMove = (event: PointerEvent) => {
@@ -82,8 +69,8 @@ export function GridFidget() {
     };
 
     const onPointerDown = (event: PointerEvent) => {
-      if (!isBackgroundClick(event.target)) return;
-      burstFromCell(particles, event.clientX, event.clientY, performance.now());
+      if (!shouldStartWave(event)) return;
+      addWave(waves, event.clientX, event.clientY, width, height, performance.now());
       schedule();
     };
 
@@ -92,6 +79,7 @@ export function GridFidget() {
     window.addEventListener("pointermove", onPointerMove, { passive: true });
     window.addEventListener("pointerleave", onPointerLeave, { passive: true });
     window.addEventListener("pointerdown", onPointerDown, { passive: true });
+    window.addEventListener("scroll", schedule, { passive: true });
 
     return () => {
       cancelAnimationFrame(animationFrame);
@@ -99,6 +87,7 @@ export function GridFidget() {
       window.removeEventListener("pointermove", onPointerMove);
       window.removeEventListener("pointerleave", onPointerLeave);
       window.removeEventListener("pointerdown", onPointerDown);
+      window.removeEventListener("scroll", schedule);
     };
   }, []);
 
@@ -109,7 +98,7 @@ export function GridFidget() {
         inset: 0,
         position: "fixed",
         pointerEvents: "none",
-        zIndex: 2,
+        zIndex: 1,
       }}
     />
   );
@@ -123,69 +112,63 @@ function readPalette(): Palette {
   };
 }
 
-function drawHoverCell(ctx: CanvasRenderingContext2D, x: number, y: number, palette: Palette) {
-  const cellX = Math.floor(x / CELL_SIZE) * CELL_SIZE;
-  const cellY = Math.floor(y / CELL_SIZE) * CELL_SIZE;
+function drawHoverCell(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  palette: Palette,
+  offset: GridOffset,
+) {
+  const cellX = snapToGrid(x, offset.x);
+  const cellY = snapToGrid(y, offset.y);
   ctx.fillStyle = colorWithAlpha(palette.aubergine, 0.09);
   ctx.fillRect(cellX + 1, cellY + 1, CELL_SIZE - 1, CELL_SIZE - 1);
   ctx.strokeStyle = colorWithAlpha(palette.saffron, 0.38);
   ctx.strokeRect(cellX + 0.5, cellY + 0.5, CELL_SIZE, CELL_SIZE);
 }
 
-function drawParticles(
+function drawGrid(
   ctx: CanvasRenderingContext2D,
-  particles: Particle[],
+  width: number,
+  height: number,
   palette: Palette,
-  now: number,
+  offset: GridOffset,
 ) {
-  for (let index = particles.length - 1; index >= 0; index -= 1) {
-    const particle = particles[index]!;
-    const age = now - particle.born;
-    if (age > particle.life) {
-      particles.splice(index, 1);
-      continue;
-    }
-    const progress = age / particle.life;
-    particle.x += particle.vx;
-    particle.y += particle.vy;
-    particle.vy += 0.045;
-    ctx.save();
-    ctx.translate(particle.x, particle.y);
-    ctx.rotate(progress * particle.spin);
-    ctx.fillStyle = colorWithAlpha(palette.aubergine, (1 - progress) * 0.26);
-    ctx.fillRect(-particle.size / 2, -particle.size / 2, particle.size, particle.size);
-    ctx.restore();
+  ctx.strokeStyle = colorWithAlpha(palette.saffron, 0.065);
+  ctx.lineWidth = 1;
+  for (let x = offset.x + 0.5; x <= width; x += CELL_SIZE) {
+    ctx.beginPath();
+    ctx.moveTo(x, 0);
+    ctx.lineTo(x, height);
+    ctx.stroke();
+  }
+  ctx.strokeStyle = colorWithAlpha(palette.saffron, 0.075);
+  for (let y = offset.y + 0.5; y <= height; y += CELL_SIZE) {
+    ctx.beginPath();
+    ctx.moveTo(0, y);
+    ctx.lineTo(width, y);
+    ctx.stroke();
   }
 }
 
-function burstFromCell(particles: Particle[], x: number, y: number, now: number) {
-  const baseX = Math.floor(x / CELL_SIZE) * CELL_SIZE + CELL_SIZE / 2;
-  const baseY = Math.floor(y / CELL_SIZE) * CELL_SIZE + CELL_SIZE / 2;
-  for (let index = 0; index < 18; index += 1) {
-    const angle = Math.random() * Math.PI * 2;
-    const speed = 0.7 + Math.random() * 1.6;
-    particles.push({
-      born: now,
-      life: 620 + Math.random() * 380,
-      size: 4 + Math.random() * 7,
-      spin: Math.random() * 4 - 2,
-      x: baseX,
-      y: baseY,
-      vx: Math.cos(angle) * speed,
-      vy: Math.sin(angle) * speed - 0.6,
-    });
-  }
-  if (particles.length > MAX_PARTICLES) particles.splice(0, particles.length - MAX_PARTICLES);
+function gridOffset(): GridOffset {
+  return {
+    x: -(window.scrollX % CELL_SIZE),
+    y: -(window.scrollY % CELL_SIZE),
+  };
 }
 
-function isBackgroundClick(target: EventTarget | null): boolean {
-  if (!(target instanceof Element)) return false;
-  const foreground = target.closest(
-    "a,button,input,textarea,select,summary,details,pre,code,h1,h2,h3,h4,p,li,span,strong,em,small,svg,img,[role='button']",
-  );
-  if (foreground) return false;
-  if (target.matches("body,main,section")) return true;
-  return target instanceof HTMLElement && target.textContent?.trim() === "";
+function snapToGrid(value: number, offset: number): number {
+  return Math.floor((value - offset) / CELL_SIZE) * CELL_SIZE + offset;
+}
+
+function shouldStartWave(event: PointerEvent): boolean {
+  if (!(event.target instanceof Element)) return false;
+  const target = document.elementFromPoint(event.clientX, event.clientY);
+  if (!target || target.closest("a,button,input,textarea,select,summary,[role='button']")) {
+    return false;
+  }
+  return !target.closest("pre,code,svg,img,canvas,video");
 }
 
 function colorWithAlpha(hex: string, alpha: number): string {

--- a/site/components/primitives/Pill.module.css
+++ b/site/components/primitives/Pill.module.css
@@ -4,7 +4,7 @@
   padding: 6px 12px;
   border: 1px solid var(--line-2);
   border-radius: 999px;
-  background: #fff;
+  background: var(--surface);
   color: var(--ink-2);
   display: inline-flex;
   align-items: center;

--- a/site/components/primitives/SectionHead.module.css
+++ b/site/components/primitives/SectionHead.module.css
@@ -18,11 +18,11 @@
 }
 
 .title {
-  font-family: var(--font-sans);
-  font-weight: 600;
-  font-size: 40px;
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 42px;
   line-height: 1.05;
-  letter-spacing: -0.025em;
+  letter-spacing: -0.012em;
   margin: 0 0 16px;
   max-width: 620px;
   text-wrap: balance;

--- a/site/components/primitives/Terminal.module.css
+++ b/site/components/primitives/Terminal.module.css
@@ -1,11 +1,11 @@
 .card {
-  background: #fff;
+  background: var(--surface);
   border: 1px solid var(--line);
   border-radius: 8px;
   overflow: hidden;
   box-shadow:
-    0 1px 0 rgba(0, 0, 0, 0.02),
-    0 12px 40px -24px rgba(23, 22, 26, 0.25);
+    0 1px 0 color-mix(in oklab, var(--shadow) 4%, transparent),
+    0 12px 40px -24px color-mix(in oklab, var(--shadow) 28%, transparent);
 }
 
 .head {
@@ -30,7 +30,7 @@
   height: 10px;
   border-radius: 50%;
   display: inline-block;
-  background: #d8d2c4;
+  background: var(--chrome-dot);
 }
 
 .title {
@@ -46,4 +46,5 @@
   font-family: var(--font-mono);
   font-size: 14px;
   line-height: 1.7;
+  overflow-x: auto;
 }

--- a/site/components/primitives/Terminal.module.css
+++ b/site/components/primitives/Terminal.module.css
@@ -1,7 +1,7 @@
 .card {
   background: var(--surface);
   border: 1px solid var(--line);
-  border-radius: 8px;
+  border-radius: 2px;
   overflow: hidden;
   box-shadow:
     0 1px 0 color-mix(in oklab, var(--shadow) 4%, transparent),

--- a/site/components/primitives/grid-fidget/util.ts
+++ b/site/components/primitives/grid-fidget/util.ts
@@ -1,0 +1,70 @@
+/*
+ * Shared canvas helpers for the site-only background fidget.
+ * This visual layer does not implement a CLI PRD section.
+ */
+
+export const CELL_SIZE = 18;
+
+export function snapToGrid(value: number, offset: number): number {
+  return Math.floor((value - offset) / CELL_SIZE) * CELL_SIZE + offset;
+}
+
+export function colorWithAlpha(color: string, alpha: number): string {
+  const parsed = parseColor(color.trim());
+  if (!parsed) return color;
+  const nextAlpha = clamp(alpha) * parsed.alpha;
+  return `rgba(${parsed.r}, ${parsed.g}, ${parsed.b}, ${nextAlpha})`;
+}
+
+type Rgba = {
+  readonly alpha: number;
+  readonly b: number;
+  readonly g: number;
+  readonly r: number;
+};
+
+function parseColor(color: string): Rgba | null {
+  if (color.startsWith("#")) return parseHex(color);
+  if (color.toLowerCase().startsWith("rgb")) return parseRgb(color);
+  return null;
+}
+
+function parseHex(color: string): Rgba | null {
+  const hex = color.slice(1);
+  if (![3, 4, 6, 8].includes(hex.length) || /[^0-9a-f]/i.test(hex)) return null;
+  const expanded = hex.length <= 4 ? [...hex].map((part) => part + part).join("") : hex;
+  return {
+    r: Number.parseInt(expanded.slice(0, 2), 16),
+    g: Number.parseInt(expanded.slice(2, 4), 16),
+    b: Number.parseInt(expanded.slice(4, 6), 16),
+    alpha: expanded.length === 8 ? Number.parseInt(expanded.slice(6, 8), 16) / 255 : 1,
+  };
+}
+
+function parseRgb(color: string): Rgba | null {
+  const raw = color.match(/^rgba?\((.*)\)$/i)?.[1];
+  if (!raw) return null;
+  const normalized = raw.replace(/\s*\/\s*/, " / ");
+  const parts = normalized.includes(",") ? normalized.split(/\s*,\s*/) : normalized.split(/\s+/);
+  const slash = parts.indexOf("/");
+  const alpha = slash === -1 ? parts[3] : parts[slash + 1];
+  const [r, g, b] = parts;
+  if (r === undefined || g === undefined || b === undefined) return null;
+  return {
+    r: Number.parseFloat(r),
+    g: Number.parseFloat(g),
+    b: Number.parseFloat(b),
+    alpha: alpha === undefined ? 1 : parseAlpha(alpha),
+  };
+}
+
+function parseAlpha(value: string): number {
+  return value.endsWith("%")
+    ? clamp(Number.parseFloat(value) / 100)
+    : clamp(Number.parseFloat(value));
+}
+
+function clamp(value: number): number {
+  if (Number.isNaN(value)) return 1;
+  return Math.min(1, Math.max(0, value));
+}

--- a/site/components/primitives/grid-fidget/waves.ts
+++ b/site/components/primitives/grid-fidget/waves.ts
@@ -1,14 +1,16 @@
 /*
- * Wave drawing helpers for the site background fidget (§16.6).
- * These keep the canvas component small while preserving the grid physics.
+ * Wave drawing helpers for the site-only background fidget.
+ * This visual layer does not implement a CLI PRD section.
  */
 
-const CELL_SIZE = 18;
+import { CELL_SIZE, colorWithAlpha, snapToGrid } from "./util";
+
 const WAVE_BAND = CELL_SIZE * 2.7;
 const WAVE_SPEED = 0.72;
 const WAVE_SEGMENTS = 96;
 const MAX_WAVES = 64;
 const RING_OFFSETS = [-20, -10, 0, 10, 20];
+const RING_FADE_SPAN = Math.max(...RING_OFFSETS.map(Math.abs)) + 8;
 
 export type Wave = {
   readonly born: number;
@@ -73,7 +75,7 @@ function drawWaveRing(
   now: number,
 ) {
   for (const offset of RING_OFFSETS) {
-    const strength = 1 - Math.abs(offset) / 28;
+    const strength = 1 - Math.abs(offset) / RING_FADE_SPAN;
     ctx.beginPath();
     drawRingPath(ctx, wave, radius + offset, now);
     ctx.strokeStyle = colorWithAlpha(palette.aubergine, fade * strength * 0.18);
@@ -133,14 +135,4 @@ function drawWaveCell(
   ctx.fillRect(cellX + 1, cellY + 1 - lift, CELL_SIZE - 2, CELL_SIZE - 2);
   ctx.strokeStyle = colorWithAlpha(palette.saffron, alpha * 1.8);
   ctx.strokeRect(cellX + 0.5, cellY + 0.5 - lift, CELL_SIZE - 1, CELL_SIZE - 1);
-}
-
-function colorWithAlpha(hex: string, alpha: number): string {
-  return `${hex}${Math.round(alpha * 255)
-    .toString(16)
-    .padStart(2, "0")}`;
-}
-
-function snapToGrid(value: number, offset: number): number {
-  return Math.floor((value - offset) / CELL_SIZE) * CELL_SIZE + offset;
 }

--- a/site/components/primitives/grid-fidget/waves.ts
+++ b/site/components/primitives/grid-fidget/waves.ts
@@ -1,0 +1,146 @@
+/*
+ * Wave drawing helpers for the site background fidget (§16.6).
+ * These keep the canvas component small while preserving the grid physics.
+ */
+
+const CELL_SIZE = 18;
+const WAVE_BAND = CELL_SIZE * 2.7;
+const WAVE_SPEED = 0.72;
+const WAVE_SEGMENTS = 96;
+const MAX_WAVES = 64;
+const RING_OFFSETS = [-20, -10, 0, 10, 20];
+
+export type Wave = {
+  readonly born: number;
+  readonly maxRadius: number;
+  readonly x: number;
+  readonly y: number;
+};
+
+export type Palette = {
+  readonly aubergine: string;
+  readonly saffron: string;
+};
+
+export type GridOffset = {
+  readonly x: number;
+  readonly y: number;
+};
+
+export function drawWaves(
+  ctx: CanvasRenderingContext2D,
+  waves: Wave[],
+  palette: Palette,
+  now: number,
+  offset: GridOffset,
+) {
+  for (let index = waves.length - 1; index >= 0; index -= 1) {
+    const wave = waves[index]!;
+    const radius = (now - wave.born) * WAVE_SPEED;
+    if (radius > wave.maxRadius + WAVE_BAND) {
+      waves.splice(index, 1);
+      continue;
+    }
+    const fade = Math.max(0, 1 - radius / (wave.maxRadius + WAVE_BAND));
+    drawWaveRing(ctx, wave, radius, fade, palette, now);
+    drawWaveCells(ctx, wave, radius, fade, palette, offset);
+  }
+}
+
+export function addWave(
+  waves: Wave[],
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  now: number,
+) {
+  waves.push({
+    born: now,
+    maxRadius: Math.hypot(Math.max(x, width - x), Math.max(y, height - y)),
+    x,
+    y,
+  });
+  if (waves.length > MAX_WAVES) waves.splice(0, waves.length - MAX_WAVES);
+}
+
+function drawWaveRing(
+  ctx: CanvasRenderingContext2D,
+  wave: Wave,
+  radius: number,
+  fade: number,
+  palette: Palette,
+  now: number,
+) {
+  for (const offset of RING_OFFSETS) {
+    const strength = 1 - Math.abs(offset) / 28;
+    ctx.beginPath();
+    drawRingPath(ctx, wave, radius + offset, now);
+    ctx.strokeStyle = colorWithAlpha(palette.aubergine, fade * strength * 0.18);
+    ctx.lineWidth = offset === 0 ? 2.4 : 1.2;
+    ctx.stroke();
+  }
+}
+
+function drawRingPath(ctx: CanvasRenderingContext2D, wave: Wave, radius: number, now: number) {
+  for (let index = 0; index <= WAVE_SEGMENTS; index += 1) {
+    const angle = (index / WAVE_SEGMENTS) * Math.PI * 2;
+    const ripple = Math.sin(angle * 9 + now * 0.007) * 4 + Math.sin(angle * 5 - now * 0.004) * 3;
+    const ringRadius = Math.max(0, radius + ripple);
+    const x = wave.x + Math.cos(angle) * ringRadius;
+    const y = wave.y + Math.sin(angle) * ringRadius;
+    if (index === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  }
+}
+
+function drawWaveCells(
+  ctx: CanvasRenderingContext2D,
+  wave: Wave,
+  radius: number,
+  fade: number,
+  palette: Palette,
+  offset: GridOffset,
+) {
+  const fromX = snapToGrid(Math.max(0, wave.x - radius - WAVE_BAND), offset.x);
+  const toX = snapToGrid(wave.x + radius + WAVE_BAND + CELL_SIZE, offset.x);
+  const fromY = snapToGrid(Math.max(0, wave.y - radius - WAVE_BAND), offset.y);
+  const toY = snapToGrid(wave.y + radius + WAVE_BAND + CELL_SIZE, offset.y);
+
+  for (let cellY = fromY; cellY <= toY; cellY += CELL_SIZE) {
+    for (let cellX = fromX; cellX <= toX; cellX += CELL_SIZE) {
+      drawWaveCell(ctx, wave, radius, fade, palette, cellX, cellY);
+    }
+  }
+}
+
+function drawWaveCell(
+  ctx: CanvasRenderingContext2D,
+  wave: Wave,
+  radius: number,
+  fade: number,
+  palette: Palette,
+  cellX: number,
+  cellY: number,
+) {
+  const centerX = cellX + CELL_SIZE / 2;
+  const centerY = cellY + CELL_SIZE / 2;
+  const front = 1 - Math.abs(Math.hypot(centerX - wave.x, centerY - wave.y) - radius) / WAVE_BAND;
+  if (front <= 0) return;
+  const lift = Math.sin(front * Math.PI) * 3;
+  const alpha = front * fade * 0.18;
+  ctx.fillStyle = colorWithAlpha(palette.aubergine, alpha);
+  ctx.fillRect(cellX + 1, cellY + 1 - lift, CELL_SIZE - 2, CELL_SIZE - 2);
+  ctx.strokeStyle = colorWithAlpha(palette.saffron, alpha * 1.8);
+  ctx.strokeRect(cellX + 0.5, cellY + 0.5 - lift, CELL_SIZE - 1, CELL_SIZE - 1);
+}
+
+function colorWithAlpha(hex: string, alpha: number): string {
+  return `${hex}${Math.round(alpha * 255)
+    .toString(16)
+    .padStart(2, "0")}`;
+}
+
+function snapToGrid(value: number, offset: number): number {
+  return Math.floor((value - offset) / CELL_SIZE) * CELL_SIZE + offset;
+}

--- a/site/components/sections/AgentsStrip.module.css
+++ b/site/components/sections/AgentsStrip.module.css
@@ -24,7 +24,7 @@
   font-family: var(--font-mono);
   font-size: 13px;
   padding: 5px 2px;
-  border-radius: 3px;
+  border-radius: 2px;
 }
 
 .more:hover {

--- a/site/components/sections/BottomCTA.module.css
+++ b/site/components/sections/BottomCTA.module.css
@@ -9,9 +9,10 @@
 }
 
 .title {
+  font-family: var(--font-display);
   font-size: 48px;
-  font-weight: 600;
-  letter-spacing: -0.03em;
+  font-weight: 700;
+  letter-spacing: -0.014em;
   margin: 0 0 24px;
   line-height: 1.05;
 }

--- a/site/components/sections/BuildItYourself.module.css
+++ b/site/components/sections/BuildItYourself.module.css
@@ -4,7 +4,7 @@
   padding: 36px 28px 32px;
   background: var(--paper);
   border: 1px dashed var(--line-2);
-  border-radius: 10px;
+  border-radius: 2px;
   text-align: center;
 }
 
@@ -77,7 +77,7 @@
   font-family: var(--font-mono);
   font-size: 13px;
   padding: 10px 18px;
-  border-radius: 6px;
+  border-radius: 2px;
   border: 1px solid var(--line-2);
   background: var(--bg);
   color: var(--ink);

--- a/site/components/sections/Faq.module.css
+++ b/site/components/sections/Faq.module.css
@@ -14,7 +14,7 @@
   font-size: 0.88em;
   background: var(--paper);
   padding: 1px 6px;
-  border-radius: 3px;
+  border-radius: 4px;
 }
 
 .list details summary {

--- a/site/components/sections/Hero.module.css
+++ b/site/components/sections/Hero.module.css
@@ -68,6 +68,20 @@
   line-height: 1.5;
 }
 
+.lede code {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 0.78em;
+  line-height: 1.15;
+  color: var(--ink);
+  background: var(--paper);
+  border: 1px solid var(--line-2);
+  border-radius: 2px;
+  padding: 0.16em 0.42em 0.18em;
+  white-space: nowrap;
+  transform: translateY(-0.04em);
+}
+
 .ctaRow {
   display: flex;
   gap: 12px;

--- a/site/components/sections/Hero.module.css
+++ b/site/components/sections/Hero.module.css
@@ -10,12 +10,16 @@
   align-items: start;
 }
 
+.grid > * {
+  min-width: 0;
+}
+
 .title {
-  font-family: var(--font-sans);
-  font-weight: 600;
+  font-family: var(--font-display);
+  font-weight: 700;
   font-size: 76px;
   line-height: 1;
-  letter-spacing: -0.038em;
+  letter-spacing: -0.018em;
   margin: 0 0 28px;
   text-wrap: balance;
 }
@@ -44,7 +48,7 @@
   border: 1px solid var(--line-2);
   border-radius: 10px;
   padding: 0.14em 0.24em 0.18em 0.18em;
-  letter-spacing: -0.02em;
+  letter-spacing: 0;
   color: var(--ink);
   display: inline-block;
   /* translateY: nudge UP by 0.1em so the pill's vertical center lines

--- a/site/components/sections/HowItWorks.module.css
+++ b/site/components/sections/HowItWorks.module.css
@@ -42,7 +42,7 @@
 .diagram {
   background: var(--paper);
   border: 1px solid var(--line);
-  border-radius: 8px;
+  border-radius: 2px;
   padding: 28px;
   position: sticky;
   top: 80px;

--- a/site/components/sections/Install.module.css
+++ b/site/components/sections/Install.module.css
@@ -32,11 +32,11 @@
 }
 
 .title {
-  font-family: var(--font-sans);
-  font-weight: 600;
-  font-size: 40px;
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 42px;
   line-height: 1.05;
-  letter-spacing: -0.025em;
+  letter-spacing: -0.012em;
   margin: 0;
   color: var(--ink);
 }
@@ -81,7 +81,7 @@
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--ink-2);
-  background: #fff;
+  background: var(--surface);
   border: 1px solid var(--line-2);
   border-radius: 999px;
   padding: 7px 14px 7px 12px;

--- a/site/components/sections/Install.module.css
+++ b/site/components/sections/Install.module.css
@@ -104,6 +104,6 @@
   font-family: var(--font-mono);
   background: var(--paper);
   padding: 1px 6px;
-  border-radius: 3px;
+  border-radius: 4px;
   font-size: 0.9em;
 }

--- a/site/components/sections/Nav.module.css
+++ b/site/components/sections/Nav.module.css
@@ -10,7 +10,7 @@
 .inner {
   display: flex;
   align-items: center;
-  gap: 32px;
+  gap: 24px;
   height: var(--nav-h);
   padding: 0 var(--wrap-pad);
   max-width: var(--wrap-max);
@@ -28,7 +28,7 @@
 
 .links {
   display: flex;
-  gap: 24px;
+  gap: 20px;
   font-size: 14px;
   color: var(--ink-2);
   margin-left: 12px;
@@ -50,7 +50,7 @@
 
 .osPill {
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: 11px;
   padding: 5px 10px 5px 8px;
   border: 1px solid var(--line-2);
   border-radius: 999px;
@@ -59,7 +59,8 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  background: #fff;
+  background: var(--surface);
+  white-space: nowrap;
 }
 
 .osPill:hover {
@@ -73,16 +74,17 @@
 
 .cta {
   font-family: var(--font-mono);
-  font-size: 13px;
+  font-size: 12px;
   padding: 6px 12px;
   border: 1px solid var(--line-2);
   border-radius: 4px;
   text-decoration: none;
-  background: #fff;
+  background: var(--surface);
   color: var(--ink);
   display: inline-flex;
   align-items: center;
   gap: 8px;
+  white-space: nowrap;
 }
 
 .cta:hover {
@@ -96,6 +98,16 @@
 @media (max-width: 860px) {
   .links,
   .osPill {
+    display: none;
+  }
+
+  .inner {
+    gap: 14px;
+  }
+}
+
+@media (max-width: 520px) {
+  .cta {
     display: none;
   }
 }

--- a/site/components/sections/Nav.module.css
+++ b/site/components/sections/Nav.module.css
@@ -23,7 +23,7 @@
   color: var(--mute);
   padding: 3px 7px;
   border: 1px solid var(--line);
-  border-radius: 3px;
+  border-radius: 6px;
 }
 
 .links {
@@ -77,7 +77,7 @@
   font-size: 12px;
   padding: 6px 12px;
   border: 1px solid var(--line-2);
-  border-radius: 4px;
+  border-radius: 6px;
   text-decoration: none;
   background: var(--surface);
   color: var(--ink);

--- a/site/components/sections/Safety.module.css
+++ b/site/components/sections/Safety.module.css
@@ -17,7 +17,7 @@
   font-size: 11px;
   padding: 3px 7px;
   border: 1px solid var(--line-2);
-  border-radius: 3px;
+  border-radius: 2px;
   color: var(--ink);
   margin-bottom: 16px;
   display: inline-block;

--- a/site/components/sections/SkillRefs.module.css
+++ b/site/components/sections/SkillRefs.module.css
@@ -7,7 +7,7 @@
 .card {
   background: var(--surface);
   border: 1px solid var(--line);
-  border-radius: 8px;
+  border-radius: 2px;
   padding: 24px;
   display: flex;
   flex-direction: column;

--- a/site/components/sections/SkillRefs.module.css
+++ b/site/components/sections/SkillRefs.module.css
@@ -5,7 +5,7 @@
 }
 
 .card {
-  background: #fff;
+  background: var(--surface);
   border: 1px solid var(--line);
   border-radius: 8px;
   padding: 24px;

--- a/site/components/sections/Taps.module.css
+++ b/site/components/sections/Taps.module.css
@@ -15,7 +15,7 @@
   max-width: 820px;
   padding: 36px 28px 32px;
   border: 1px dashed var(--line-2);
-  border-radius: 10px;
+  border-radius: 2px;
   background: var(--paper);
   text-align: center;
 }

--- a/site/components/sections/ValueProp.module.css
+++ b/site/components/sections/ValueProp.module.css
@@ -76,7 +76,7 @@
   background: var(--surface);
   border: 1px solid var(--line);
   padding: 1px 6px;
-  border-radius: 3px;
+  border-radius: 4px;
 }
 
 .chips {

--- a/site/components/sections/ValueProp.module.css
+++ b/site/components/sections/ValueProp.module.css
@@ -31,11 +31,11 @@
 }
 
 .title {
-  font-family: var(--font-sans);
-  font-weight: 600;
+  font-family: var(--font-display);
+  font-weight: 700;
   font-size: 64px;
   line-height: 1.02;
-  letter-spacing: -0.035em;
+  letter-spacing: -0.016em;
   margin: 0;
   max-width: 980px;
   text-wrap: balance;
@@ -73,7 +73,7 @@
 
 .codePaper {
   font-family: var(--font-mono);
-  background: #fff;
+  background: var(--surface);
   border: 1px solid var(--line);
   padding: 1px 6px;
   border-radius: 3px;

--- a/site/styles/tokens.css
+++ b/site/styles/tokens.css
@@ -5,34 +5,44 @@
  */
 
 :root {
-  /* Ink & paper */
-  --bg: #faf8f5;
-  --ink: #17161a;
-  --ink-2: #3a3740;
-  --mute: #6e6a74;
-  --line: #e7e2d9;
-  --line-2: #d5cfc3;
-  --paper: #f2ede3;
+  /* Three-color system */
+  --white: #ffffff;
+  --off-black: #11100f;
+  --aubergine: #a30d2c;
+  --saffron: #b86f00;
+
+  --bg: var(--white);
+  --surface: var(--white);
+  --ink: var(--off-black);
+  --ink-2: color-mix(in oklab, var(--off-black) 88%, var(--saffron));
+  --mute: color-mix(in oklab, var(--off-black) 62%, var(--saffron));
+  --line: color-mix(in oklab, var(--saffron) 15%, var(--white));
+  --line-2: color-mix(in oklab, var(--saffron) 30%, var(--white));
+  --paper: color-mix(in oklab, var(--saffron) 6%, var(--white));
+  --shadow: var(--off-black);
+  --chrome-dot: color-mix(in oklab, var(--saffron) 36%, var(--white));
 
   /* Accent + semantic */
-  --accent: oklch(0.68 0.15 58);
-  --accent-ink: oklch(0.38 0.09 55);
-  --ok: oklch(0.6 0.12 150);
-  --warn: oklch(0.62 0.16 25);
+  --accent: var(--aubergine);
+  --accent-ink: var(--aubergine);
+  --key: var(--aubergine);
+  --ok: var(--aubergine);
+  --warn: var(--aubergine);
 
   /* Terminal palette */
-  --term-bg: #17161a;
-  --term-ink: #ece6d8;
-  --term-mute: #8a8478;
-  --term-ok: oklch(0.78 0.15 150);
-  --term-warn: oklch(0.78 0.17 60);
-  --term-accent: oklch(0.82 0.13 60);
-  --term-key: oklch(0.82 0.12 250);
-  --term-prompt: #d0c7b0;
+  --term-bg: var(--off-black);
+  --term-ink: var(--white);
+  --term-mute: color-mix(in oklab, var(--white) 58%, var(--saffron));
+  --term-ok: color-mix(in oklab, var(--aubergine) 44%, var(--white));
+  --term-warn: color-mix(in oklab, var(--aubergine) 44%, var(--white));
+  --term-accent: color-mix(in oklab, var(--aubergine) 44%, var(--white));
+  --term-key: color-mix(in oklab, var(--aubergine) 30%, var(--white));
+  --term-prompt: color-mix(in oklab, var(--white) 72%, var(--saffron));
 
   /* Typography */
-  --font-sans: "Inter", system-ui, sans-serif;
-  --font-mono: "JetBrains Mono", ui-monospace, monospace;
+  --font-display: "Archivo", system-ui, sans-serif;
+  --font-sans: "Instrument Sans", system-ui, sans-serif;
+  --font-mono: "Azeret Mono", ui-monospace, monospace;
 
   /* Layout */
   --wrap-max: 1160px;


### PR DESCRIPTION
Video comparing current site to new site:

https://github.com/user-attachments/assets/f6d1b988-0f00-40b0-b963-04220aa9490f

## Summary

The site now has a sharper, more distinctive visual system and a quieter white-first palette, with rounded treatment preserved where it reads as intentional copy or brand chrome.

The background grid is now an interactive fidget layer: hover tracks the current cell, background clicks send a soft wavy square ripple across the viewport, and the canvas handles its own grid drawing so the effect stays aligned while scrolling. Foreground content remains above the fidget layer, and real controls/media/code still do not trigger accidental waves.

Inline command text in the hero now reads as a compact code token instead of oversized monospace copy.

## Test Plan

- `bun run typecheck` in `site/`
- `bun run lint` in `site/`
- `bun run build` in `site/`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
