### PR TITLE
[LOG-5085] feat: add Linux support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,8 @@ concurrency:
 
 jobs:
   check:
-    # Ubuntu is plenty for `bun run check` — launchctl is stubbed to a
-    # no-op on non-Darwin so the test suite runs green here without
-    # shelling out to a macOS-only binary. macOS runners are 10x the
-    # cost; we use them only in the release workflow.
+    # Ubuntu is plenty for `bun run check`; platform schedulers are
+    # stubbed in tests, and release builds cross-compile from Linux.
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,9 +103,8 @@ jobs:
   build-and-release:
     needs: resolve
     if: needs.resolve.outputs.should_release == 'true'
-    # Bun cross-compiles cleanly, so a Linux runner builds both macOS
-    # binaries and saves on GitHub minutes (Ubuntu is 10x cheaper than
-    # macOS).
+    # Bun cross-compiles cleanly, so a Linux runner builds every
+    # supported binary and saves on GitHub minutes.
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -163,9 +162,21 @@ jobs:
             --target=bun-darwin-x64 \
             src/index.ts --outfile dist/crew-macos-x64
 
+      - name: Build Linux arm64
+        run: |
+          bun build --compile --minify --sourcemap \
+            --target=bun-linux-arm64 \
+            src/index.ts --outfile dist/crew-linux-arm64
+
+      - name: Build Linux x64
+        run: |
+          bun build --compile --minify --sourcemap \
+            --target=bun-linux-x64 \
+            src/index.ts --outfile dist/crew-linux-x64
+
       - name: Generate checksums
         working-directory: dist
-        run: sha256sum crew-macos-arm64 crew-macos-x64 > SHA256SUMS
+        run: sha256sum crew-macos-arm64 crew-macos-x64 crew-linux-arm64 crew-linux-x64 > SHA256SUMS
 
       - name: Sign checksums
         working-directory: dist
@@ -197,6 +208,8 @@ jobs:
           files: |
             dist/crew-macos-arm64
             dist/crew-macos-x64
+            dist/crew-linux-arm64
+            dist/crew-linux-x64
             dist/SHA256SUMS
             dist/SHA256SUMS.sig
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,11 +77,12 @@ still describe the thing accurately.
 ### Runtime and shape
 
 - **Language**: TypeScript, strict mode (`tsconfig.json`).
-- **Runtime**: [Bun](https://bun.sh) only. We ship a single bundled
-  macOS executable produced by `bun build --compile`.
+- **Runtime**: [Bun](https://bun.sh) only. We ship bundled native
+  macOS and Linux executables produced by `bun build --compile`.
 - **Minimal host dependencies**: the `dist/crew` binary carries the Bun
-  runtime. The only host-level requirements are `git` and `launchctl`
-  (both mandated by PRD §17.1).
+  runtime. The host-level requirements are `git`, plus `launchctl` on
+  macOS or `systemctl --user` on Linux for autoupdate (mandated by
+  PRD §17.1).
 - **Libraries**: use well-established libraries for solved problems,
   hand-roll anything that's trivial or spec-prescribed. Current
   dependencies:
@@ -126,7 +127,7 @@ src/
 ├── git/                  # git exec seam + high-level repo ops
 ├── hash/                 # content hashing (§12.1)
 ├── maintenance/          # store garbage collection
-├── autoupdate/           # launchd plist + launchctl runner seam
+├── autoupdate/           # platform scheduler backends (launchd/systemd) + shared types/log
 ├── util/                 # fs, copy, json, time helpers
 ├── yaml/                 # minimal YAML parser + writer
 └── core/version.ts       # CREW_VERSION constant
@@ -209,11 +210,11 @@ are staged into a sibling directory whose name cannot collide with a
 real skill (leading dot), then `renameSync` onto `dest` after removing
 the old `dest`. A crash mid-install never leaves a half-copied install.
 
-**5. Testable subprocess boundary.** `src/git/exec.ts` and
-`src/autoupdate/launchd.ts` each expose a `setXRunner` seam. Real
-runner is the default; tests install a stub via `setGitRunner` /
-`setLaunchctlRunner` and call `resetXRunner` in `afterEach`. Prefer
-this pattern over global mocking.
+**5. Testable subprocess boundary.** `src/git/exec.ts`,
+`src/autoupdate/launchd.ts`, and `src/autoupdate/systemd.ts` each expose a
+`setXRunner` seam. Real runner is the default; tests install a stub via
+`setGitRunner` / `setLaunchctlRunner` / `setSystemctlRunner` and call
+`resetXRunner` in `afterEach`. Prefer this pattern over global mocking.
 
 **6. Errors are `CrewError(code, message, details)`.** `src/core/errors.ts`.
 Every error the user can see has a stable machine name (PRD §13) and a
@@ -251,13 +252,15 @@ is crew-owned; a source-authored marker would poison the install.
 - real `git` subprocesses against local `file://` repos;
 - the real YAML parser against real SKILL.md bytes.
 
-Mocks are confined to exactly two boundaries:
+Mocks are confined to exactly three boundaries:
 
 - `src/git/exec.ts` — for corner cases like "what if `git` returns
   exit code 42 with throwOnError=false"; real `git` is used for 95%
   of tests.
 - `src/autoupdate/launchd.ts` — because macOS CI environments don't
   have a user session launchd to talk to.
+- `src/autoupdate/systemd.ts` — because Linux CI environments don't
+  have a systemd `--user` session to talk to.
 
 **Adapter redirection.** Tests redirect `claudeCodeAdapter.userPath` /
 `.detect` / `.projectPath` at the top of the file via direct property

--- a/PRD.md
+++ b/PRD.md
@@ -4,7 +4,7 @@
 
 Version: 0.9.0
 Status: Specification, ready for implementation
-Platform: macOS (Apple Silicon and Intel)
+Platform: macOS (Apple Silicon and Intel), Linux (x86_64 and ARM64)
 
 This document specifies the behavior of Homecrew, a command-line tool whose executable is named `crew`, in enough detail that two independent implementations should produce interchangeable executables. Anything an end user can observe — commands, outputs, exit codes, file layouts, algorithms, error conditions — is defined here. Internal implementation choices (language, argument parser, hash library, HTTP client, how files are copied) are deliberately left to the implementer; see §17 "Implementation latitude" for the full list.
 
@@ -12,7 +12,7 @@ This document specifies the behavior of Homecrew, a command-line tool whose exec
 
 ## 1. Overview
 
-Homecrew manages Agent Skills — the standardized, markdown-based skill format specified at [agentskills.io](https://agentskills.io/specification) — across every agent coder on a macOS machine that supports them (Claude Code, Codex CLI, Gemini CLI, and others).
+Homecrew manages Agent Skills — the standardized, markdown-based skill format specified at [agentskills.io](https://agentskills.io/specification) — across every supported agent coder on a macOS or Linux machine (Claude Code, Codex CLI, Gemini CLI, and others).
 
 The value proposition is one command: `crew install python-testing` installs a skill into every agent tool on the machine, keeps it up to date, and lets users discover new skills from a shared registry or directly from any git repo.
 
@@ -28,11 +28,11 @@ Homecrew installs skills by copying files into each agent tool's expected direct
 - Direct install from any reachable git repository, with no registry setup required.
 - Install every skill found under a directory or git repo in one command.
 - Keep skills current manually (`crew update`) or via a background job (`crew autoupdate`).
-- Ship as a single macOS executable invokable as `crew` on `PATH`.
+- Ship as a single native executable invokable as `crew` on `PATH`.
 
 **Non-goals**
 
-- Cross-platform support. macOS only. Other platforms are future work.
+- Windows support. Windows is future work.
 - Symlinks. Homecrew always copies files.
 - Skill authoring tooling (creating and linting new skills) beyond minimal validation.
 - Executing skills. Homecrew installs files; agents run them.
@@ -116,8 +116,8 @@ crew agents                      List detected agents and their status.
 crew agents enable <name>        Force-enable an otherwise-undetected agent.
 crew agents disable <name>       Skip this agent on all install/update operations.
 
-crew autoupdate enable [--interval <dur>]   Install the launchd agent (default 4h).
-crew autoupdate disable                      Remove the launchd agent.
+crew autoupdate enable [--interval <dur>]   Install the platform scheduler (default 4h).
+crew autoupdate disable                      Remove the platform scheduler.
 crew autoupdate status                       Show whether active, last run, next run.
 
 crew self-update [--check] [--version <v>]  Upgrade the `crew` binary itself to the latest release.
@@ -319,7 +319,7 @@ With `--json`, help MUST emit a structured payload:
 │   └── <skill-name>@<short-sha>/
 ├── logs/
 │   └── autoupdate.log
-└── Homecrew.app/        # attribution bundle used by autoupdate (see §10.2)
+└── Homecrew.app/        # macOS attribution bundle used by autoupdate (see §10.2)
     └── Contents/
         └── Info.plist
 ```
@@ -404,7 +404,7 @@ Every adapter must provide:
 
 ### 7.2 Agents in v1
 
-Every adapter listed at [agentskills.io/clients](https://agentskills.io/clients) that (a) is installable on macOS as a local app or CLI and (b) reads skills from a filesystem location ships as a crew adapter. The full set:
+Every adapter listed at [agentskills.io/clients](https://agentskills.io/clients) that (a) is installable on a supported platform as a local app or CLI and (b) reads skills from a filesystem location ships as a crew adapter. The full set:
 
 | Adapter | User-scope skills dir | Project-scope skills dir | Detection |
 |---|---|---|---|
@@ -893,7 +893,7 @@ manually (`crew tap add`) or created automatically by a multi-skill
 install — they're stored identically in `config.yaml` and re-expanded
 identically here.
 
-**Autoupdate.** The background agent (§10.2) runs `crew update`, so
+**Autoupdate.** The background scheduler (§10.2) runs `crew update`, so
 tap re-expansion is automatic. The expected flow: a user runs
 `crew install @with-logic/skills` once (creating an auto-tap) and
 enables autoupdate; as the team adds skills, they appear in the
@@ -905,7 +905,32 @@ autoupdate would do.
 
 ### 10.2 `crew autoupdate`
 
-`crew autoupdate enable [--interval <duration>]` installs a launchd user agent that runs `crew update --quiet` on the given interval. Default interval is 4 hours. Accepted duration units: `s`, `m`, `h`, `d`.
+`crew autoupdate enable [--interval <duration>]` installs a per-user background scheduler that runs `crew update --quiet` on the given interval. Default interval is 4 hours. Accepted duration units: `s`, `m`, `h`, `d`. The interval quantity MUST be a positive integer; `0` with any unit is rejected with `usage_error`.
+
+The scheduler backend is platform-specific:
+
+- macOS uses `launchd`.
+- Linux uses a `systemd --user` timer. If `systemctl --user` is unavailable
+  or cannot load user units, `crew autoupdate enable` fails with
+  `autoupdate_failure`.
+
+Both backends MUST set `CREW_HOME` to the effective crew home used when
+`crew autoupdate enable` was run and MUST set `CREW_AUTOUPDATE_LOG=1`.
+This keeps scheduled updates pointing at the same state/config directory
+even when the user enabled autoupdate with a non-default `CREW_HOME`.
+
+When `CREW_AUTOUPDATE_LOG=1` is present, `crew update` MUST append one
+line to the autoupdate log before exiting:
+
+```text
+crew-autoupdate <ISO-8601 timestamp> exit=<integer exit code>
+```
+
+This line is the authoritative source for `crew autoupdate status`'s
+last-run timestamp and exit status. Backend stdout/stderr may also be
+appended to the same log when the platform scheduler supports it.
+
+#### macOS launchd backend
 
 **The launchd plist MUST be written to `~/Library/LaunchAgents/sh.crew.autoupdate.plist`** with the following minimum shape:
 
@@ -938,21 +963,6 @@ autoupdate would do.
 </plist>
 ```
 
-`CREW_HOME` MUST be set in the plist to the effective crew home used
-when `crew autoupdate enable` was run. This keeps scheduled updates
-pointing at the same state/config directory even when the user enabled
-autoupdate with a non-default `CREW_HOME`. `CREW_AUTOUPDATE_LOG=1` is
-an internal flag consumed by `crew update --quiet`: when present,
-`crew update` MUST append one line to the autoupdate log before exiting:
-
-```text
-crew-autoupdate <ISO-8601 timestamp> exit=<integer exit code>
-```
-
-This line is in addition to any command output or errors redirected by
-launchd. It is the authoritative source for `crew autoupdate status`'s
-last-run timestamp and exit status.
-
 **Attribution bundle.** On macOS Ventura and later, Login Items labels a
 launchd agent by the code-signing team of the executable unless the
 plist carries `AssociatedBundleIdentifiers` pointing at a resolvable
@@ -972,7 +982,53 @@ to the chosen interval.
 
 `crew autoupdate disable` unloads the agent (`launchctl bootout gui/<uid>/sh.crew.autoupdate` or `launchctl unload`), removes the plist, and sets `autoupdate.enabled` to `false`.
 
-`crew autoupdate status` reports: whether the agent is loaded, the configured interval, the timestamp of the last run (from the log), and the exit status of the last run.
+#### Linux systemd user backend
+
+The systemd service MUST be written to
+`~/.config/systemd/user/sh.crew.autoupdate.service` with the following
+minimum shape:
+
+```ini
+[Unit]
+Description=Homecrew Skill Autoupdate
+
+[Service]
+Type=oneshot
+Environment=CREW_HOME=<!-- effective crew home at enable time -->
+Environment=CREW_AUTOUPDATE_LOG=1
+ExecStart=<!-- absolute path to crew executable --> update --quiet
+StandardOutput=append:<!-- absolute path to ~/.crew/logs/autoupdate.log -->
+StandardError=append:<!-- same -->
+```
+
+The systemd timer MUST be written to
+`~/.config/systemd/user/sh.crew.autoupdate.timer` with the following
+minimum shape:
+
+```ini
+[Unit]
+Description=Run Homecrew Skill Autoupdate
+
+[Timer]
+OnBootSec=<!-- interval in seconds -->s
+OnUnitActiveSec=<!-- interval in seconds -->s
+Unit=sh.crew.autoupdate.service
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+After writing the service and timer, crew runs `systemctl --user
+daemon-reload` and then `systemctl --user enable --now
+sh.crew.autoupdate.timer`. `config.yaml`'s `autoupdate.enabled` is set
+to `true` and `autoupdate.interval_seconds` to the chosen interval.
+
+`crew autoupdate disable` runs `systemctl --user disable --now
+sh.crew.autoupdate.timer`, removes both unit files, runs `systemctl
+--user daemon-reload`, and sets `autoupdate.enabled` to `false`.
+
+`crew autoupdate status` reports: whether the platform scheduler is loaded, the configured interval, the timestamp of the last run (from the log), and the exit status of the last run. JSON output MUST include `scheduler_loaded`; `agent_loaded` MAY also be emitted as a deprecated compatibility alias for one release.
 
 ### 10.3 `crew self-update`
 
@@ -995,6 +1051,8 @@ Both endpoints emit the same JSON shape:
   "assets": [
     { "name": "crew-macos-arm64", "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.4.0/crew-macos-arm64" },
     { "name": "crew-macos-x64",   "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.4.0/crew-macos-x64" },
+    { "name": "crew-linux-arm64", "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.4.0/crew-linux-arm64" },
+    { "name": "crew-linux-x64",   "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.4.0/crew-linux-x64" },
     { "name": "SHA256SUMS",       "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.4.0/SHA256SUMS" },
     { "name": "SHA256SUMS.sig",   "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.4.0/SHA256SUMS.sig" }
   ]
@@ -1008,8 +1066,8 @@ binaries, the site just advertises the pointer).
 
 Every release starting with `v0.7.1` MUST publish both:
 
-- `SHA256SUMS` — SHA-256 hashes for `crew-macos-arm64` and
-  `crew-macos-x64`.
+- `SHA256SUMS` — SHA-256 hashes for `crew-macos-arm64`,
+  `crew-macos-x64`, `crew-linux-arm64`, and `crew-linux-x64`.
 - `SHA256SUMS.sig` — an RSA/SHA-256 signature over the exact
   `SHA256SUMS` bytes, verifiable with Homecrew's pinned release-signing
   public key.
@@ -1032,8 +1090,10 @@ the latest-release URL (used by tests and private forks).
    - Otherwise fetch the latest-release URL.
 2. If the resolved tag matches the running `CREW_VERSION` and `--force`
    is not set, print "already on the latest version" and exit 0.
-3. Resolve the asset matching the current CPU architecture
-   (`arm64` → `crew-macos-arm64`, `x86_64` → `crew-macos-x64`).
+3. Resolve the asset matching the current platform and CPU architecture:
+   macOS `arm64` → `crew-macos-arm64`; macOS `x86_64` →
+   `crew-macos-x64`; Linux `arm64` → `crew-linux-arm64`; Linux
+   `x86_64` → `crew-linux-x64`.
 4. Download the `SHA256SUMS` asset, the `SHA256SUMS.sig` asset (except for
    legacy `v0.7.0`), and the selected binary asset from the resolved release.
 5. Verify `SHA256SUMS.sig` against `SHA256SUMS` using Homecrew's pinned
@@ -1075,9 +1135,10 @@ the latest-release URL (used by tests and private forks).
 - `self_update_failed` (exit 8) — the replacement step failed (e.g. the
   binary path isn't writable). The old binary is left in place.
 
-**Non-macOS.** `crew self-update` on a non-macOS host produces
-`self_update_unavailable` with a message indicating Homecrew ships only for
-macOS. No release feed request is made.
+**Unsupported platforms.** `crew self-update` on an unsupported host
+produces `self_update_unavailable` with a message indicating Homecrew
+ships binaries for macOS and Linux only. No release feed request is
+made.
 
 ### 10.4 Update-available notice
 
@@ -1120,7 +1181,7 @@ skipped entirely — when any of the following hold:
 - `CREW_NO_UPDATE_CHECK=1` is set.
 - `CI` is set (standard GitHub Actions / generic CI convention).
 - `CREW_AUTOUPDATE_LOG=1` is set (the command is running under the
-  launchd autoupdater).
+  platform scheduler).
 - The command itself is `self-update` or `version`.
 
 ## 11. State
@@ -1174,8 +1235,8 @@ user's working directory at install time). Every subsequent command —
 `crew update`, `crew uninstall`, `crew doctor` — uses this path when
 resolving the adapter's project-scope base directory, NOT the user's
 current working directory. That way, `crew update` run from any
-directory (or by the autoupdate background agent from its
-launchd-assigned cwd) still updates each project-scope install at its
+directory (or by the autoupdate background scheduler from its
+scheduler-assigned cwd) still updates each project-scope install at its
 original location.
 
 A stale `project_root` (directory no longer exists, was moved,
@@ -1232,7 +1293,7 @@ off.
 4. Every agent listed in state still passes `detect()` (or is in `forced_agents`).
 5. No `store/` entry is orphaned (not referenced by any state entry).
 6. `config.yaml` parses.
-7. If autoupdate is enabled in config, the launchd agent is actually loaded.
+7. If autoupdate is enabled in config, the platform scheduler is actually loaded.
 8. For every project-scope entry, `project_root` exists on disk and a `.crew.json` marker lives under `<project_root>/<adapter-base>/<name>/`. A `project_root` that no longer exists produces a `missing_project_root` finding (warn, not error — the user may have simply moved the project, and the right fix is a `crew uninstall` from their new location).
 
 `--verify` includes check 3 (hash recomputation); without it, check 3 is skipped for speed.
@@ -1242,7 +1303,7 @@ off.
 - Orphaned state entries (no corresponding marker and agent missing): remove from state.
 - Orphaned markers (marker present, no state entry): re-add to state.
 - Orphan store entries: delete them.
-- Autoupdate drift (config says enabled but agent not loaded, or vice versa): reconcile to the config's value.
+- Autoupdate drift (config says enabled but the platform scheduler is not loaded, or vice versa): reconcile to the config's value.
 
 `--repair` never overwrites user-customized skills or touches anything outside `~/.crew/` and the agent skill directories it already manages.
 
@@ -1291,7 +1352,7 @@ Every error below has a stable machine-readable name (for `--json` output) and a
 | `no_agents` | 4 | No agent tools detected or all disabled. |
 | `config_invalid` | 4 | `config.yaml` did not parse. |
 | `state_locked` | 7 | Could not acquire `state.json.lock` within timeout. |
-| `launchd_failure` | 8 | Autoupdate enable/disable couldn't load/unload the agent. |
+| `autoupdate_failure` | 8 | Autoupdate enable/disable couldn't load/unload the platform scheduler. |
 | `self_update_unavailable` | 5 | `crew self-update` couldn't reach the release feed, the asset is missing for the current arch, or the named `--version` doesn't exist. |
 | `self_update_failed` | 8 | `crew self-update` fetched a new binary but couldn't replace the running one (e.g. the install prefix isn't writable). |
 
@@ -1330,7 +1391,7 @@ bar here is craft, not compliance.
 
 Homecrew mutates state from multiple entry points (interactive commands, autoupdate). To prevent races:
 
-1. Every command that writes `state.json` or installs into an agent acquires an advisory lock on `~/.crew/state.json.lock` (using `flock(2)` or an equivalent macOS file-lock primitive) before making changes. Read-only commands do not take the lock.
+1. Every command that writes `state.json` or installs into an agent acquires an advisory lock on `~/.crew/state.json.lock` (using `flock(2)` or an equivalent platform file-lock primitive) before making changes. Read-only commands do not take the lock.
 2. Lock timeout: 30 seconds. If not acquired, exit with `state_locked` (§13).
 3. The lock is held for the full duration of file-modifying operations and released on exit, including crashes (OS-level file locks release on fd close).
 4. Git clone/fetch against a single repo is serialized under the state lock. This is not the most parallel design but is simple and adequate for a desktop tool.
@@ -1346,7 +1407,7 @@ Homecrew mutates state from multiple entry points (interactive commands, autoupd
 | 5 | Network / source failure: could not reach git, ref does not exist, release feed unreachable. |
 | 6 | Safety-check abort: untracked directory, customized skill, bad marker. |
 | 7 | Could not acquire state lock. |
-| 8 | macOS integration failure: launchd agent could not be loaded/unloaded, or self-update couldn't replace the binary. |
+| 8 | Platform integration failure: autoupdate scheduler could not be loaded/unloaded, or self-update couldn't replace the binary. |
 
 ## 16. Taps
 
@@ -1560,7 +1621,7 @@ The only commands that actively fetch from upstream are:
 
 The following are deliberately **not** specified. Implementations may choose freely:
 
-- **Language and runtime.** Any language that can produce a single-file macOS executable.
+- **Language and runtime.** Any language that can produce single-file native executables for the supported platforms.
 - **Argument parser.** Any library or hand-rolled.
 - **YAML parser.** Any that handles the subset the Agent Skills spec uses.
 - **JSON serialization style.** Indented or compact, as long as output is valid JSON.
@@ -1573,7 +1634,8 @@ The following are deliberately **not** specified. Implementations may choose fre
 ### 17.1 Required external dependencies
 
 - `git` on `PATH` at runtime.
-- `launchctl` (present on all macOS).
+- `launchctl` on macOS (present on all supported macOS hosts).
+- `systemctl` with user-service support on Linux, only for `crew autoupdate`.
 
 ### 17.2 Performance expectations
 
@@ -1760,7 +1822,7 @@ Implementations and test suites refer to criteria by ID.
 | C-UPD-24 | §10.1 | `crew update <selector>...` includes each selected entry's transitive dependency closure (as determined by `required_by` in state) in the update set. Entries pulled in that way are reported alongside the selected entries, marked as transitively required in `--json` output. |
 | C-UPD-25 | §10.1 | `crew update <tap>/<skill>` accepts a tap-qualified selector for an installed skill and updates the matching state entry. |
 | C-UPD-20 | §10.1 | A tap whose fetch fails (network error, URL 404, etc.) produces a per-tap warning in the update summary but does NOT abort the run; other taps and per-skill updates continue to be processed. |
-| C-UPD-21 | §11.1 | `crew update` for a project-scope entry reinstalls at the entry's recorded `project_root`, NOT the user's current working directory. This holds whether update is run by the user from any shell, or by the autoupdate background agent from its launchd-assigned cwd. |
+| C-UPD-21 | §11.1 | `crew update` for a project-scope entry reinstalls at the entry's recorded `project_root`, NOT the user's current working directory. This holds whether update is run by the user from any shell, or by the autoupdate background scheduler from its scheduler-assigned cwd. |
 | C-UPD-22 | §11.1 | A project-scope entry whose `project_root` no longer exists on disk is reported as `missing_project_root` and SKIPPED on update — the local install is preserved and no files are written. |
 
 #### C-INFO: Info (§9.1)
@@ -1846,16 +1908,16 @@ Implementations and test suites refer to criteria by ID.
 
 | ID | Reference | Assertion |
 |---|---|---|
-| C-AUTO-01 | §10.2 | `crew autoupdate enable` writes a plist to `~/Library/LaunchAgents/sh.crew.autoupdate.plist`. |
-| C-AUTO-02 | §10.2 | The plist's `Label` is `sh.crew.autoupdate`, `ProgramArguments` invokes `crew update --quiet`, and `StartInterval` matches the configured interval. |
-| C-AUTO-03 | §10.2 | `crew autoupdate enable` loads the agent via `launchctl`. |
-| C-AUTO-04 | §10.2 | `crew autoupdate disable` unloads the agent and removes the plist. |
+| C-AUTO-01 | §10.2 | On macOS, `crew autoupdate enable` writes a plist to `~/Library/LaunchAgents/sh.crew.autoupdate.plist`. On Linux, it writes `sh.crew.autoupdate.service` and `sh.crew.autoupdate.timer` under `~/.config/systemd/user/`. |
+| C-AUTO-02 | §10.2 | The platform scheduler invokes `crew update --quiet`, sets `CREW_HOME` and `CREW_AUTOUPDATE_LOG`, and uses the configured interval. |
+| C-AUTO-03 | §10.2 | `crew autoupdate enable` loads the platform scheduler (`launchctl` on macOS, `systemctl --user enable --now` on Linux). |
+| C-AUTO-04 | §10.2 | `crew autoupdate disable` unloads the platform scheduler and removes its scheduler files. |
 | C-AUTO-05 | §10.2 | `crew autoupdate status` reports enabled/disabled state, configured interval, and last-run info. |
-| C-AUTO-06 | §10.2 | A failure to load the agent produces `launchd_failure`, exit 8, with a clear message. |
+| C-AUTO-06 | §10.2 | A failure to load the scheduler produces `autoupdate_failure`, exit 8, with a clear message. |
 | C-AUTO-07 | §10.2 | Default interval when none is specified is 14400 seconds (4 hours). |
-| C-AUTO-08 | §10.2 | Interval strings `30s`, `5m`, `2h`, `1d` are accepted. |
-| C-AUTO-09 | §10.2 | `crew autoupdate enable` writes an attribution bundle at `~/.crew/Homecrew.app/Contents/Info.plist` with `CFBundleIdentifier = sh.crew.autoupdater` and `CFBundleDisplayName = "Homecrew Skill Autoupdate"`. |
-| C-AUTO-10 | §10.2 | The plist carries an `AssociatedBundleIdentifiers` array containing `sh.crew.autoupdater`. |
+| C-AUTO-08 | §10.2 | Interval strings `30s`, `5m`, `2h`, `1d` are accepted; `0` with any unit is rejected with `usage_error`. |
+| C-AUTO-09 | §10.2 | On macOS, `crew autoupdate enable` writes an attribution bundle at `~/.crew/Homecrew.app/Contents/Info.plist` with `CFBundleIdentifier = sh.crew.autoupdater` and `CFBundleDisplayName = "Homecrew Skill Autoupdate"`. |
+| C-AUTO-10 | §10.2 | On macOS, the plist carries an `AssociatedBundleIdentifiers` array containing `sh.crew.autoupdater`. |
 
 #### C-SELF: Self-update (§10.3, §10.4)
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ scale.
 ## Install
 
 ```
-curl -fsSL https://crew.logic.inc/install.sh | sh
+curl -fsSL https://crew.logic.inc/install.sh | bash
 ```
 
 A single binary. Drops itself at `~/.local/bin/crew`, plus whatever skills you
@@ -70,8 +70,8 @@ in place. Set `CREW_INSTALL_PREFIX` to pick a different location.
 
 Uninstall with `rm -rf ~/.crew && rm ~/.local/bin/crew`.
 
-**Requires:** macOS 13+ (Apple Silicon or Intel), `git` on `PATH`. The
-installer also uses macOS-standard `curl`, `shasum`, and `openssl`.
+**Requires:** macOS 13+ or Linux (x86_64/ARM64), plus `git` on `PATH`. The
+installer also uses `bash`, `curl`, `openssl`, and either `shasum` or `sha256sum`.
 
 ## How it works
 
@@ -188,7 +188,7 @@ When a command asks for an installed skill name, you can use the bare name
 | `crew agents` | List detected agents and whether they're enabled, disabled, or forced. |
 | `crew agents enable <name>` | Force-enable an agent even if auto-detection misses it. |
 | `crew agents disable <name>` | Skip this agent on all install and update operations. |
-| `crew autoupdate enable [--interval]` | Install a launchd user agent that runs `crew update --quiet` on an interval (default 4h). |
+| `crew autoupdate enable [--interval]` | Install a platform scheduler that runs `crew update --quiet` on an interval (default 4h). |
 | `crew autoupdate status` | Whether active, last run, next run, configured interval. |
 
 **Housekeeping**
@@ -340,7 +340,7 @@ ones. Delete code aggressively. Write the boring version first.
 
 ## Agents
 
-Works with every Mac agent that speaks the spec. Any agent coder that reads
+Works with every supported local agent that speaks the spec. Any agent coder that reads
 the [Agent Skills spec](https://agentskills.io/specification) is a valid
 target. Homecrew auto-detects the ones you already have and quietly skips the rest.
 
@@ -368,8 +368,8 @@ workflows. A few things that are particular to Homecrew:
 - **Skill dependencies.** Skills can depend on other skills. Homecrew walks the
   graph and installs everything they need. A single `team-baseline` meta-skill
   can pull in a dozen others.
-- **Background autoupdate.** `crew autoupdate enable` sets up a launchd agent
-  that keeps every skill current.
+- **Background autoupdate.** `crew autoupdate enable` sets up launchd on macOS
+  or a systemd user timer on Linux to keep every skill current.
 - **Local-edit protection.** Homecrew hashes what it installs and refuses to
   clobber your edits on re-install — so you can tweak a skill in place and
   not lose your work the next time something updates.
@@ -424,10 +424,9 @@ exact SHA are skipped unless `--force`. Skills pinned to a tag are
 re-resolved: if the tag moved and `--force` is given, the new commit is
 installed. Everything else updates to whatever the ref resolves to now.
 
-**What about Linux? Windows?** Future work. The v1 spec is macOS-only because
-launchd is the autoupdate mechanism and each agent adapter encodes
-platform-specific paths. Nothing in the core design is Mac-specific; it's a
-scope decision, not a technical one.
+**What about Linux? Windows?** Linux is supported for x86_64 and ARM64 hosts.
+Windows is future work because agent paths, scheduler integration, and binary
+distribution need separate platform decisions.
 
 **Can a skill depend on another skill in a different tap?** Yes. Dependency
 references are full skill references — any form the CLI accepts.
@@ -446,8 +445,8 @@ want to use it, stop here.
 
 ### Requirements
 
-- [Bun](https://bun.sh) — the only runtime. Homecrew ships as a single bundled
-  Mach-O executable produced by `bun build --compile`.
+- [Bun](https://bun.sh) — the only runtime. Homecrew ships as single bundled
+  native executables produced by `bun build --compile`.
 - `git` on `PATH`.
 
 ### Setup
@@ -508,8 +507,9 @@ for anyone (human or AI) working in this repository. Highlights:
   section(s) it implements.
 - Named exports only. No default exports.
 - Tests use real filesystems under `os.tmpdir()` and real `git` subprocesses
-  against local `file://` repos. Mocks are confined to two boundaries:
-  `src/git/exec.ts` and `src/autoupdate/launchd.ts`.
+  against local `file://` repos. Mocks are confined to subprocess boundaries:
+  `src/git/exec.ts`, `src/autoupdate/launchd.ts`, and
+  `src/autoupdate/systemd.ts`.
 - Errors are `CrewError(code, message, details)` with a stable machine name
   (PRD §13) and a fixed exit code (PRD §15). Never `throw new Error(...)`
   for a user-visible failure.

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
   "files": {
     "includes": [

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -281,6 +281,14 @@ if [ -d site/public ]; then
       "browser_download_url": "https://github.com/with-logic/crew/releases/download/${next_tag}/crew-macos-x64"
     },
     {
+      "name": "crew-linux-arm64",
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/${next_tag}/crew-linux-arm64"
+    },
+    {
+      "name": "crew-linux-x64",
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/${next_tag}/crew-linux-x64"
+    },
+    {
       "name": "SHA256SUMS",
       "browser_download_url": "https://github.com/with-logic/crew/releases/download/${next_tag}/SHA256SUMS"
     },

--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -27,7 +27,7 @@ const azeretMono = Azeret_Mono({
 });
 
 const SITE_DESCRIPTION =
-  "Install personal skills, team taps, and git-hosted skill collections into every agent on your Mac. An open-source project by Logic, Inc.";
+  "Install personal skills, team taps, and git-hosted skill collections into every agent on macOS or Linux. An open-source project by Logic, Inc.";
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://crew.logic.inc"),

--- a/site/biome.json
+++ b/site/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "extends": ["../biome.json"],
   "files": {
     "includes": ["**/*.{ts,tsx,js,jsx,json,mjs}", "!.next", "!out", "!node_modules"]

--- a/site/components/primitives/GridFidget.tsx
+++ b/site/components/primitives/GridFidget.tsx
@@ -8,19 +8,23 @@
  */
 
 import { useEffect, useRef } from "react";
+import { configureCanvas } from "./grid-fidget/canvas";
 import { CELL_SIZE, colorWithAlpha, snapToGrid } from "./grid-fidget/util";
 import type { GridOffset, Palette, Wave } from "./grid-fidget/waves";
-import { addWave, drawWaves } from "./grid-fidget/waves";
+import { addWave, drawAndPruneWaves } from "./grid-fidget/waves";
 
 export function GridFidget() {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const gridRef = useRef<HTMLCanvasElement>(null);
+  const effectsRef = useRef<HTMLCanvasElement>(null);
 
   useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
+    const gridCanvas = gridRef.current;
+    const effectsCanvas = effectsRef.current;
+    if (!(gridCanvas && effectsCanvas)) return;
 
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return;
+    const gridCtx = gridCanvas.getContext("2d");
+    const effectsCtx = effectsCanvas.getContext("2d");
+    if (!(gridCtx && effectsCtx)) return;
 
     const allowMotion = !matchMedia("(prefers-reduced-motion: reduce)").matches;
     const palette = readPalette();
@@ -35,11 +39,9 @@ export function GridFidget() {
       dpr = Math.min(window.devicePixelRatio || 1, 2);
       width = window.innerWidth;
       height = window.innerHeight;
-      canvas.width = Math.ceil(width * dpr);
-      canvas.height = Math.ceil(height * dpr);
-      canvas.style.width = `${width}px`;
-      canvas.style.height = `${height}px`;
-      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      configureCanvas(gridCanvas, gridCtx, width, height, dpr);
+      configureCanvas(effectsCanvas, effectsCtx, width, height, dpr);
+      drawStaticGrid();
       schedule();
     };
 
@@ -49,13 +51,22 @@ export function GridFidget() {
 
     const draw = (now: number) => {
       animationFrame = 0;
-      ctx.clearRect(0, 0, width, height);
+      effectsCtx.clearRect(0, 0, width, height);
       const offset = gridOffset();
-      drawGrid(ctx, width, height, palette, offset);
       if (!allowMotion) return;
-      if (pointer.active) drawHoverCell(ctx, pointer.x, pointer.y, palette, offset);
-      drawWaves(ctx, waves, palette, now, offset);
-      if (pointer.active || waves.length > 0) schedule();
+      if (pointer.active) drawHoverCell(effectsCtx, pointer.x, pointer.y, palette, offset);
+      drawAndPruneWaves(effectsCtx, waves, palette, now, offset);
+      if (waves.length > 0) schedule();
+    };
+
+    const drawStaticGrid = () => {
+      gridCtx.clearRect(0, 0, width, height);
+      drawGrid(gridCtx, width, height, palette, gridOffset());
+    };
+
+    const onScroll = () => {
+      drawStaticGrid();
+      schedule();
     };
 
     const onPointerMove = (event: PointerEvent) => {
@@ -83,7 +94,7 @@ export function GridFidget() {
     window.addEventListener("pointermove", onPointerMove, { passive: true });
     window.addEventListener("pointerleave", onPointerLeave, { passive: true });
     window.addEventListener("pointerdown", onPointerDown, { passive: true });
-    window.addEventListener("scroll", schedule, { passive: true });
+    window.addEventListener("scroll", onScroll, { passive: true });
 
     return () => {
       cancelAnimationFrame(animationFrame);
@@ -91,7 +102,7 @@ export function GridFidget() {
       window.removeEventListener("pointermove", onPointerMove);
       window.removeEventListener("pointerleave", onPointerLeave);
       window.removeEventListener("pointerdown", onPointerDown);
-      window.removeEventListener("scroll", schedule);
+      window.removeEventListener("scroll", onScroll);
     };
   }, []);
 
@@ -105,7 +116,8 @@ export function GridFidget() {
         zIndex: 1,
       }}
     >
-      <canvas ref={canvasRef} />
+      <canvas ref={gridRef} />
+      <canvas ref={effectsRef} />
     </div>
   );
 }
@@ -127,6 +139,7 @@ function drawHoverCell(
 ) {
   const cellX = snapToGrid(x, offset.x);
   const cellY = snapToGrid(y, offset.y);
+  // Alpha values are hand-tuned for the quiet background texture.
   ctx.fillStyle = colorWithAlpha(palette.aubergine, 0.09);
   ctx.fillRect(cellX + 1, cellY + 1, CELL_SIZE - 1, CELL_SIZE - 1);
   ctx.strokeStyle = colorWithAlpha(palette.saffron, 0.38);
@@ -165,7 +178,6 @@ function gridOffset(): GridOffset {
 }
 
 function shouldStartWave(event: PointerEvent): boolean {
-  if (!(event.target instanceof Element)) return false;
   const target = document.elementFromPoint(event.clientX, event.clientY);
   if (
     !target ||

--- a/site/components/primitives/grid-fidget/canvas.ts
+++ b/site/components/primitives/grid-fidget/canvas.ts
@@ -1,0 +1,20 @@
+/*
+ * Canvas sizing helper for the site-only background fidget.
+ * This visual layer does not implement a CLI PRD section.
+ */
+
+export function configureCanvas(
+  canvas: HTMLCanvasElement,
+  ctx: CanvasRenderingContext2D,
+  width: number,
+  height: number,
+  dpr: number,
+) {
+  canvas.width = Math.ceil(width * dpr);
+  canvas.height = Math.ceil(height * dpr);
+  canvas.style.width = `${width}px`;
+  canvas.style.height = `${height}px`;
+  canvas.style.inset = "0";
+  canvas.style.position = "absolute";
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+}

--- a/site/components/primitives/grid-fidget/util.ts
+++ b/site/components/primitives/grid-fidget/util.ts
@@ -10,7 +10,9 @@ export function snapToGrid(value: number, offset: number): number {
 }
 
 export function colorWithAlpha(color: string, alpha: number): string {
-  const parsed = parseColor(color.trim());
+  const key = color;
+  const cached = COLOR_CACHE.get(key);
+  const parsed = cached === undefined ? parseAndCacheColor(key) : cached;
   if (!parsed) return color;
   const nextAlpha = clamp(alpha) * parsed.alpha;
   return `rgba(${parsed.r}, ${parsed.g}, ${parsed.b}, ${nextAlpha})`;
@@ -22,6 +24,14 @@ type Rgba = {
   readonly g: number;
   readonly r: number;
 };
+
+const COLOR_CACHE = new Map<string, Rgba | null>();
+
+function parseAndCacheColor(color: string): Rgba | null {
+  const parsed = parseColor(color);
+  COLOR_CACHE.set(color, parsed);
+  return parsed;
+}
 
 function parseColor(color: string): Rgba | null {
   if (color.startsWith("#")) return parseHex(color);

--- a/site/components/primitives/grid-fidget/waves.ts
+++ b/site/components/primitives/grid-fidget/waves.ts
@@ -29,7 +29,8 @@ export type GridOffset = {
   readonly y: number;
 };
 
-export function drawWaves(
+/** Draw active waves and remove expired waves from the passed array. */
+export function drawAndPruneWaves(
   ctx: CanvasRenderingContext2D,
   waves: Wave[],
   palette: Palette,
@@ -104,15 +105,74 @@ function drawWaveCells(
   palette: Palette,
   offset: GridOffset,
 ) {
-  const fromX = snapToGrid(Math.max(0, wave.x - radius - WAVE_BAND), offset.x);
-  const toX = snapToGrid(wave.x + radius + WAVE_BAND + CELL_SIZE, offset.x);
   const fromY = snapToGrid(Math.max(0, wave.y - radius - WAVE_BAND), offset.y);
   const toY = snapToGrid(wave.y + radius + WAVE_BAND + CELL_SIZE, offset.y);
+  const outerRadius = radius + WAVE_BAND;
+  const innerRadius = Math.max(0, radius - WAVE_BAND);
+  const outerSquared = outerRadius * outerRadius;
+  const innerSquared = innerRadius * innerRadius;
 
   for (let cellY = fromY; cellY <= toY; cellY += CELL_SIZE) {
-    for (let cellX = fromX; cellX <= toX; cellX += CELL_SIZE) {
-      drawWaveCell(ctx, wave, radius, fade, palette, cellX, cellY);
+    const centerY = cellY + CELL_SIZE / 2;
+    const dy = centerY - wave.y;
+    const dySquared = dy * dy;
+    if (dySquared > outerSquared) continue;
+    const outerDx = Math.sqrt(outerSquared - dySquared);
+    if (innerRadius > 0 && dySquared < innerSquared) {
+      const innerDx = Math.sqrt(innerSquared - dySquared);
+      drawWaveCellRange(
+        ctx,
+        wave,
+        radius,
+        fade,
+        palette,
+        offset,
+        cellY,
+        wave.x - outerDx,
+        wave.x - innerDx,
+      );
+      drawWaveCellRange(
+        ctx,
+        wave,
+        radius,
+        fade,
+        palette,
+        offset,
+        cellY,
+        wave.x + innerDx,
+        wave.x + outerDx,
+      );
+      continue;
     }
+    drawWaveCellRange(
+      ctx,
+      wave,
+      radius,
+      fade,
+      palette,
+      offset,
+      cellY,
+      wave.x - outerDx,
+      wave.x + outerDx,
+    );
+  }
+}
+
+function drawWaveCellRange(
+  ctx: CanvasRenderingContext2D,
+  wave: Wave,
+  radius: number,
+  fade: number,
+  palette: Palette,
+  offset: GridOffset,
+  cellY: number,
+  fromX: number,
+  toX: number,
+) {
+  const fromCellX = snapToGrid(Math.max(0, fromX - CELL_SIZE / 2), offset.x);
+  const toCellX = snapToGrid(toX + CELL_SIZE / 2, offset.x);
+  for (let cellX = fromCellX; cellX <= toCellX; cellX += CELL_SIZE) {
+    drawWaveCell(ctx, wave, radius, fade, palette, cellX, cellY);
   }
 }
 

--- a/site/components/sections/Agents.tsx
+++ b/site/components/sections/Agents.tsx
@@ -11,7 +11,7 @@ export function Agents() {
         <SectionHead
           number="12"
           label="Agents"
-          title="Works with every Mac agent that speaks the spec."
+          title="Works with every supported local agent that speaks the spec."
           description={
             <>
               Any agent coder that reads the{" "}

--- a/site/components/sections/Commands.data.tsx
+++ b/site/components/sections/Commands.data.tsx
@@ -127,12 +127,12 @@ export const GROUPS: readonly CommandGroup[] = [
             crew autoupdate enable <span className={styles.flag}>[--interval]</span>
           </>
         ),
-        description: "Install a launchd user agent that runs `crew update --quiet` every 4 hours.",
+        description: "Install a platform scheduler that runs `crew update --quiet` every 4 hours.",
       },
       {
         name: "autoupdate-disable",
         signature: <>crew autoupdate disable</>,
-        description: "Unload and remove the background update agent.",
+        description: "Unload and remove the background updater.",
       },
       {
         name: "autoupdate-status",

--- a/site/components/sections/Faq.tsx
+++ b/site/components/sections/Faq.tsx
@@ -36,7 +36,7 @@ const QAS: readonly QA[] = [
           </li>
           <li>
             <strong>Background autoupdate.</strong> <code>crew autoupdate enable</code> sets up a
-            launchd agent that keeps every skill current.
+            launchd agent on macOS or a systemd user timer on Linux.
           </li>
           <li>
             <strong>Local-edit protection.</strong> Homecrew hashes what it installs and refuses to
@@ -59,7 +59,7 @@ const QAS: readonly QA[] = [
         <p>
           Yes. Homecrew is still a package manager for your own skills. Install a skill once and it
           lands in every detected agent. Add your personal skills repo as a tap and your library
-          becomes searchable. Use a baseline skill to recreate your setup on a new Mac.
+          becomes searchable. Use a baseline skill to recreate your setup on a new machine.
         </p>
         <p>
           The team features are the same primitives scaled up: git sources, taps, dependency
@@ -81,8 +81,8 @@ const QAS: readonly QA[] = [
         </p>
         <p>
           Every <code>main</code>-merge automatically becomes installable team-wide. Pair it with{" "}
-          <code>crew autoupdate enable</code> and every Mac pulls approved skill updates on the next
-          interval.
+          <code>crew autoupdate enable</code> and every machine pulls approved skill updates on the
+          next interval.
         </p>
       </>
     ),
@@ -165,7 +165,7 @@ const QAS: readonly QA[] = [
   {
     id: "platforms",
     q: "What about Linux? Windows?",
-    a: "Future work. The v1 spec is macOS-only because launchd is the autoupdate mechanism and each agent adapter encodes platform-specific paths. Nothing in the core design is Mac-specific; it's a scope decision, not a technical one.",
+    a: "Linux is supported on x86_64 and ARM64 hosts. Windows is future work because agent paths, scheduler integration, and binary distribution need separate platform decisions.",
   },
 ];
 

--- a/site/components/sections/Footer.tsx
+++ b/site/components/sections/Footer.tsx
@@ -47,8 +47,9 @@ export function Footer() {
           <div>
             <Brand />
             <p className={styles.lede}>
-              A macOS package manager for agent skills. Install once, share through git, keep every
-              agent current. An open-source project by <a href="https://logic.inc">Logic, Inc</a>.
+              A package manager for agent skills on macOS and Linux. Install once, share through
+              git, keep every agent current. An open-source project by{" "}
+              <a href="https://logic.inc">Logic, Inc</a>.
             </p>
           </div>
           {COLUMNS.map((c) => (
@@ -65,7 +66,7 @@ export function Footer() {
           ))}
         </div>
         <div className={styles.bot}>
-          <span>Homecrew · {CREW_VERSION_TAG} · macOS (arm64, x86_64)</span>
+          <span>Homecrew · {CREW_VERSION_TAG} · macOS + Linux</span>
           <span>
             © {new Date().getFullYear()} <a href="https://logic.inc">Logic App, Inc.</a>
           </span>

--- a/site/components/sections/Install.tsx
+++ b/site/components/sections/Install.tsx
@@ -7,7 +7,7 @@ import { Section } from "../primitives/Section";
 import { BuildItYourself } from "./BuildItYourself";
 import styles from "./Install.module.css";
 
-const INSTALL_COMMAND = "curl -fsSL https://crew.logic.inc/install.sh | sh";
+const INSTALL_COMMAND = "curl -fsSL https://crew.logic.inc/install.sh | bash";
 const CREW_VERSION = CREW_VERSION_TAG.replace(/^v/, "");
 
 export function Install() {
@@ -31,9 +31,8 @@ export function Install() {
           <CodeBlock>
             {"$ curl -fsSL "}
             <Acc>https://crew.logic.inc/install.sh</Acc>
-            {" | sh\n$ crew version\ncrew "}
+            {" | bash\n$ crew version\ncrew "}
             <Acc>{CREW_VERSION}</Acc>
-            {" (darwin-arm64)"}
           </CodeBlock>
           <div className={styles.copy}>
             <CopyButton text={INSTALL_COMMAND} label="Copy install command" />
@@ -41,10 +40,7 @@ export function Install() {
         </div>
 
         <div className={styles.reqRow}>
-          <span className={styles.reqPill}>
-            <AppleGlyph />
-            Requires macOS 13+
-          </span>
+          <span className={styles.reqPill}>Requires macOS 13+ or Linux</span>
         </div>
 
         <p className={styles.footnote}>
@@ -57,20 +53,5 @@ export function Install() {
         <BuildItYourself prompt={SAAP_FULL_PROMPT} />
       </Container>
     </Section>
-  );
-}
-
-function AppleGlyph() {
-  return (
-    <svg
-      className={styles.apple}
-      width="14"
-      height="14"
-      viewBox="0 0 384 512"
-      fill="currentColor"
-      aria-hidden="true"
-    >
-      <path d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z" />
-    </svg>
   );
 }

--- a/site/components/sections/Taps.tsx
+++ b/site/components/sections/Taps.tsx
@@ -74,12 +74,12 @@ export function Taps() {
               {"\n\n"}
               <Prompt /> crew autoupdate enable
               {"\n"}
-              <Ok>✓</Ok> agent loaded · keeps skills current every 4h
+              <Ok>✓</Ok> updater loaded · keeps skills current every 4h
             </CodeBlock>
             <p className={styles.note}>
               A meta-skill is an ordinary skill whose body describes the team's conventions and
               whose <code>dependencies</code> list pulls in the rest. The same pattern works for a
-              solo baseline: one command to recreate your preferred agent setup on a new Mac.
+              solo baseline: one command to recreate your preferred agent setup on a new machine.
             </p>
           </div>
         </div>

--- a/site/lib/prd.ts
+++ b/site/lib/prd.ts
@@ -18,7 +18,7 @@ Rules:
 - The PRD is the contract. Build to spec.
 - Ask me which language and runtime to use before writing any code. Popular choices: TypeScript (Bun, Deno, Node), Go, Rust, Python, Swift. Pick with me; don't decide unilaterally.
 - After I choose, scaffold the project, implement the CLI, and write tests that map to the §18 conformance criteria.
-- Ship a single macOS-installable binary (or the language's closest equivalent).
+- Ship single native binaries for macOS and Linux (or the language's closest equivalent).
 - Match the PRD literally on commands, flags, file layouts, error codes, and marker schemas. Every command in §5.2 must exist with the documented behavior.
 
 ---

--- a/site/public/install.sh
+++ b/site/public/install.sh
@@ -3,17 +3,15 @@
 # crew installer.
 #
 # Usage:
-#   curl -fsSL https://crew.logic.inc/install.sh | sh
+#   curl -fsSL https://crew.logic.inc/install.sh | bash
 #
 # What it does:
-#   1. Detects your macOS CPU architecture (arm64 or x86_64).
+#   1. Detects your OS and CPU architecture.
 #   2. Downloads the latest crew release from GitHub.
 #   3. Verifies the signed release SHA256SUMS file, then verifies
 #      the binary against it.
 #   4. Installs to $CREW_INSTALL_PREFIX (default: ~/.local/bin).
-#   5. Clears the macOS quarantine attribute so Gatekeeper doesn't
-#      block the first run.
-#   6. Tells you how to put the install dir on your PATH if it isn't.
+#   5. Tells you how to put the install dir on your PATH if it isn't.
 #
 # Safe to re-run — upgrades in place.
 #
@@ -36,18 +34,26 @@ die()  { warn "$*"; exit 1; }
 
 # ---------- Prerequisites ------------------------------------------------
 
-[ "$(uname -s)" = "Darwin" ] || die "Homecrew is macOS-only for now. Linux and Windows are tracked but not yet shipping."
-
 command -v curl >/dev/null 2>&1 || die "\`curl\` is required but not on PATH."
-command -v shasum >/dev/null 2>&1 || die "\`shasum\` is required but not on PATH."
 command -v openssl >/dev/null 2>&1 || die "\`openssl\` is required but not on PATH."
 
+os="$(uname -s)"
 arch="$(uname -m)"
-case "$arch" in
-  arm64)  asset="crew-macos-arm64" ;;
-  x86_64) asset="crew-macos-x64"   ;;
-  *) die "unsupported architecture: $arch" ;;
+case "$os:$arch" in
+  Darwin:arm64)  asset="crew-macos-arm64" ;;
+  Darwin:x86_64) asset="crew-macos-x64" ;;
+  Linux:aarch64|Linux:arm64) asset="crew-linux-arm64" ;;
+  Linux:x86_64)  asset="crew-linux-x64" ;;
+  *) die "unsupported platform: $os/$arch" ;;
 esac
+
+if command -v shasum >/dev/null 2>&1; then
+  sha256() { shasum -a 256 "$1" | awk '{ print $1 }'; }
+elif command -v sha256sum >/dev/null 2>&1; then
+  sha256() { sha256sum "$1" | awk '{ print $1 }'; }
+else
+  die "\`shasum\` or \`sha256sum\` is required but neither is on PATH."
+fi
 
 # ---------- Resolve version and download URL ----------------------------
 
@@ -127,7 +133,7 @@ log "Verifying checksum"
 expected="$(awk -v asset="$asset" '$2 == asset { print $1; found = 1 } END { if (!found) exit 1 }' "$checksums")" || {
   die "checksum file did not contain an entry for $asset. Refusing to install."
 }
-actual="$(shasum -a 256 "$tmpfile" | awk '{ print $1 }')"
+actual="$(sha256 "$tmpfile")"
 if [ "$actual" != "$expected" ]; then
   die "checksum mismatch for $asset. Expected $expected but got $actual. Refusing to install."
 fi
@@ -135,10 +141,9 @@ ok "checksum verified"
 
 chmod +x "$tmpfile"
 
-# Clear macOS quarantine so Gatekeeper doesn't block the first run.
-# `xattr -dr com.apple.quarantine` is a no-op if the attribute isn't
-# set, so we don't need to check first.
-xattr -dr com.apple.quarantine "$tmpfile" 2>/dev/null || true
+if [ "$os" = "Darwin" ]; then
+  xattr -dr com.apple.quarantine "$tmpfile" 2>/dev/null || true # no-op if absent
+fi
 
 # ---------- Install to prefix -------------------------------------------
 

--- a/site/public/latest-version.json
+++ b/site/public/latest-version.json
@@ -10,6 +10,14 @@
       "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.9.0/crew-macos-x64"
     },
     {
+      "name": "crew-linux-arm64",
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.9.0/crew-linux-arm64"
+    },
+    {
+      "name": "crew-linux-x64",
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.9.0/crew-linux-x64"
+    },
+    {
       "name": "SHA256SUMS",
       "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.9.0/SHA256SUMS"
     },

--- a/src/autoupdate/launchd.ts
+++ b/src/autoupdate/launchd.ts
@@ -6,12 +6,12 @@
  * when available, falling back to `launchctl load` on older macOS.
  */
 
-import { readFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { CrewError } from "../core/errors.ts";
 import { crewHome, paths } from "../core/paths.ts";
 import { ensureDir, exists, rmrf, writeText } from "../util/fs.ts";
 import { BUNDLE_IDENTIFIER, writeAttributionBundle } from "./bundle.ts";
+import type { EnableInput } from "./types.ts";
 
 /**
  * Plist body per §10.2, plus an `AssociatedBundleIdentifiers` key so
@@ -57,12 +57,6 @@ function escapeXml(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-export interface EnableInput {
-  readonly crewBinaryPath: string;
-  readonly intervalSeconds: number;
-  readonly home?: string;
-}
-
 /** Write the attribution bundle + plist and (attempt to) load the agent. */
 export function enableAutoupdate(input: EnableInput): void {
   const home = input.home ?? crewHome();
@@ -79,7 +73,7 @@ export function enableAutoupdate(input: EnableInput): void {
   if (!runLaunchctl(["bootstrap", `gui/${process.getuid?.() ?? 0}`, p.autoupdatePlist])) {
     if (!runLaunchctl(["load", p.autoupdatePlist])) {
       throw new CrewError(
-        "launchd_failure",
+        "autoupdate_failure",
         "launchctl refused to load the autoupdate agent — check `log show --predicate 'subsystem == \"com.apple.xpc.launchd\"' --last 5m` for details",
       );
     }
@@ -132,30 +126,6 @@ export function setLaunchctlRunner(next: LaunchctlRunner): LaunchctlRunner {
 
 export function resetLaunchctlRunner(): void {
   launchctlRunner = defaultRunner;
-}
-
-/** Read the last line of the autoupdate log (if any). */
-export function readAutoupdateLogTail(home: string = crewHome()): {
-  last_run: string | null;
-  last_exit_status: number | null;
-  last_line: string | null;
-} {
-  const p = paths(home).autoupdateLog;
-  if (!exists(p)) {
-    return { last_run: null, last_exit_status: null, last_line: null };
-  }
-  const contents = readFileSync(p, "utf8");
-  const lines = contents.split("\n").filter((l) => l.length > 0);
-  if (lines.length === 0) {
-    return { last_run: null, last_exit_status: null, last_line: null };
-  }
-  const lastLine = lines[lines.length - 1]!;
-  const parsed = lastLine.match(/^crew-autoupdate (\S+) exit=(\d+)$/);
-  return {
-    last_run: parsed ? parsed[1]! : null,
-    last_exit_status: parsed ? Number.parseInt(parsed[2]!, 10) : null,
-    last_line: lastLine,
-  };
 }
 
 function runLaunchctl(args: string[]): boolean {

--- a/src/autoupdate/log.ts
+++ b/src/autoupdate/log.ts
@@ -1,0 +1,34 @@
+/**
+ * Autoupdate log parser (§10.2).
+ *
+ * Both launchd and systemd backends write the same line format, so status
+ * reads the log through this shared parser instead of a platform backend.
+ */
+
+import { readFileSync } from "node:fs";
+import { crewHome, paths } from "../core/paths.ts";
+import { exists } from "../util/fs.ts";
+
+/** Read the last line of the autoupdate log (if any). */
+export function readAutoupdateLogTail(home: string = crewHome()): {
+  last_run: string | null;
+  last_exit_status: number | null;
+  last_line: string | null;
+} {
+  const p = paths(home).autoupdateLog;
+  if (!exists(p)) {
+    return { last_run: null, last_exit_status: null, last_line: null };
+  }
+  const contents = readFileSync(p, "utf8");
+  const lines = contents.split("\n").filter((l) => l.length > 0);
+  if (lines.length === 0) {
+    return { last_run: null, last_exit_status: null, last_line: null };
+  }
+  const lastLine = lines[lines.length - 1]!;
+  const parsed = lastLine.match(/^crew-autoupdate (\S+) exit=(\d+)$/);
+  return {
+    last_run: parsed ? parsed[1]! : null,
+    last_exit_status: parsed ? Number.parseInt(parsed[2]!, 10) : null,
+    last_line: lastLine,
+  };
+}

--- a/src/autoupdate/scheduler.ts
+++ b/src/autoupdate/scheduler.ts
@@ -1,0 +1,64 @@
+/**
+ * Platform scheduler selector for autoupdate (§10.2).
+ *
+ * Commands use this module instead of depending directly on launchd or
+ * systemd. Tests can override the platform without mutating `process`.
+ */
+
+import { CrewError } from "../core/errors.ts";
+import { crewHome } from "../core/paths.ts";
+import * as launchd from "./launchd.ts";
+import { readAutoupdateLogTail } from "./log.ts";
+import * as systemd from "./systemd.ts";
+import type { EnableInput } from "./types.ts";
+
+type Scheduler = {
+  readonly enableAutoupdate: (input: EnableInput) => void;
+  readonly disableAutoupdate: (home?: string) => void;
+  readonly isAutoupdateLoaded: () => boolean;
+};
+
+let platformOverride: NodeJS.Platform | null = null;
+
+export function setAutoupdatePlatform(next: NodeJS.Platform): NodeJS.Platform | null {
+  const prev = platformOverride;
+  platformOverride = next;
+  return prev;
+}
+
+export function resetAutoupdatePlatform(): void {
+  platformOverride = null;
+}
+
+export function enableAutoupdate(input: EnableInput): void {
+  scheduler().enableAutoupdate(input);
+}
+
+export function disableAutoupdate(home: string = crewHome()): void {
+  scheduler().disableAutoupdate(home);
+}
+
+export function isAutoupdateLoaded(): boolean {
+  const selected = schedulerOrNull();
+  return selected ? selected.isAutoupdateLoaded() : false;
+}
+
+export { readAutoupdateLogTail };
+
+function scheduler(): Scheduler {
+  const selected = schedulerOrNull();
+  if (selected) return selected;
+  const platform = platformOverride ?? process.platform;
+  throw new CrewError(
+    "autoupdate_failure",
+    `autoupdate is not supported on ${platform}; Homecrew supports autoupdate on macOS and Linux`,
+    { platform },
+  );
+}
+
+function schedulerOrNull(): Scheduler | null {
+  const platform = platformOverride ?? process.platform;
+  if (platform === "darwin") return launchd;
+  if (platform === "linux") return systemd;
+  return null;
+}

--- a/src/autoupdate/systemd.ts
+++ b/src/autoupdate/systemd.ts
@@ -1,0 +1,179 @@
+/**
+ * systemd user timer management (§10.2).
+ *
+ * Writes `sh.crew.autoupdate.service` and `.timer` under the user's
+ * systemd unit directory, then enables the timer with `systemctl --user`.
+ */
+
+import { dirname } from "node:path";
+import { CrewError } from "../core/errors.ts";
+import { crewHome, paths } from "../core/paths.ts";
+import { atomicReplace, ensureDir, exists, rmrf, writeText } from "../util/fs.ts";
+import type { EnableInput } from "./types.ts";
+
+export interface SystemctlResult {
+  readonly ok: boolean;
+  readonly stderr: string;
+}
+
+/** systemd service unit per §10.2. */
+export function serviceUnit(crewBinaryPath: string, logPath: string, home: string): string {
+  return `[Unit]
+Description=Homecrew Skill Autoupdate
+
+[Service]
+Type=oneshot
+Environment=${quoteEnv("CREW_HOME", home)}
+Environment=CREW_AUTOUPDATE_LOG=1
+ExecStart=${quoteArg(crewBinaryPath)} update --quiet
+StandardOutput=${quoteArg(`append:${logPath}`)}
+StandardError=${quoteArg(`append:${logPath}`)}
+`;
+}
+
+/** systemd timer unit per §10.2. */
+export function timerUnit(intervalSeconds: number): string {
+  return `[Unit]
+Description=Run Homecrew Skill Autoupdate
+
+[Timer]
+OnBootSec=${intervalSeconds}s
+OnUnitActiveSec=${intervalSeconds}s
+Unit=sh.crew.autoupdate.service
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+`;
+}
+
+/** Write the unit files and enable the user timer. */
+export function enableAutoupdate(input: EnableInput): void {
+  const home = input.home ?? crewHome();
+  const p = paths(home);
+  ensureDir(p.logsDir);
+  ensureDir(dirname(p.autoupdateSystemdService));
+  writeUnitAtomic(
+    p.autoupdateSystemdService,
+    serviceUnit(input.crewBinaryPath, p.autoupdateLog, home),
+  );
+  writeUnitAtomic(p.autoupdateSystemdTimer, timerUnit(input.intervalSeconds));
+  const reload = runSystemctl(["daemon-reload"]);
+  if (!reload.ok) {
+    cleanupFailedEnable(home);
+    throw systemdFailure("reload systemd user units", reload.stderr);
+  }
+  const enable = runSystemctl(["enable", "--now", "sh.crew.autoupdate.timer"]);
+  if (!enable.ok) {
+    cleanupFailedEnable(home);
+    throw systemdFailure("enable the autoupdate timer", enable.stderr);
+  }
+}
+
+/**
+ * Disable the timer and remove unit files.
+ *
+ * If the post-removal daemon-reload fails, callers keep config enabled
+ * and surface the error; `doctor --repair` owns that drift recovery.
+ */
+export function disableAutoupdate(home: string = crewHome()): void {
+  const p = paths(home);
+  const hadUnits = exists(p.autoupdateSystemdService) || exists(p.autoupdateSystemdTimer);
+  if (!hadUnits) return;
+  const disable = runSystemctl(["disable", "--now", "sh.crew.autoupdate.timer"]);
+  if (!disable.ok) {
+    throw systemdFailure("disable the autoupdate timer", disable.stderr);
+  }
+  rmrf(p.autoupdateSystemdService);
+  rmrf(p.autoupdateSystemdTimer);
+  const reload = runSystemctl(["daemon-reload"]);
+  if (!reload.ok) {
+    throw systemdFailure("reload systemd user units", reload.stderr);
+  }
+}
+
+/** Is the timer currently active? */
+export function isAutoupdateLoaded(): boolean {
+  return runSystemctl(["is-active", "--quiet", "sh.crew.autoupdate.timer"]).ok;
+}
+
+export type SystemctlRunner = (args: string[]) => SystemctlResult;
+
+function defaultRunner(args: string[]): SystemctlResult {
+  try {
+    const proc = Bun.spawnSync({
+      cmd: ["systemctl", "--user", ...args],
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    return {
+      ok: (proc.exitCode ?? -1) === 0,
+      stderr: new TextDecoder().decode(proc.stderr).trim(),
+    };
+  } catch (err) {
+    // `Bun.spawnSync` throws only when the process boundary itself fails.
+    return { ok: false, stderr: (err as Error).message };
+  }
+}
+
+let systemctlRunner: SystemctlRunner = defaultRunner;
+
+export function setSystemctlRunner(next: SystemctlRunner): SystemctlRunner {
+  const prev = systemctlRunner;
+  systemctlRunner = next;
+  return prev;
+}
+
+export function resetSystemctlRunner(): void {
+  systemctlRunner = defaultRunner;
+}
+
+function quoteEnv(key: string, value: string): string {
+  return quoteArg(`${key}=${value}`);
+}
+
+/**
+ * Quote systemd command/env values for unit files.
+ *
+ * A conservative bare-word set stays unquoted. Quoted values double `%`
+ * so systemd does not treat user paths as specifiers, escape backslash
+ * and quote characters, and reject newlines because unit directives are
+ * line-oriented.
+ */
+function quoteArg(value: string): string {
+  if (/[\n\r]/.test(value)) {
+    throw new CrewError("autoupdate_failure", "systemd unit values cannot contain newlines");
+  }
+  if (/^[A-Za-z0-9_/@+=:,.-]+$/.test(value)) return value;
+  return `"${value.replace(/%/g, "%%").replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+function cleanupFailedEnable(home: string): void {
+  const p = paths(home);
+  rmrf(p.autoupdateSystemdService);
+  rmrf(p.autoupdateSystemdTimer);
+  runSystemctl(["daemon-reload"]);
+}
+
+function writeUnitAtomic(path: string, contents: string): void {
+  const tmp = `${path}.tmp`;
+  writeText(tmp, contents);
+  atomicReplace(tmp, path);
+}
+
+function systemdFailure(action: string, stderr: string): CrewError {
+  const detail = boundedStderr(stderr);
+  const suffix = detail ? ` systemctl stderr: ${detail}` : "";
+  const message = `systemctl --user couldn't ${action}; make sure systemd user services are available. Check \`systemctl --user status sh.crew.autoupdate.timer\` and \`journalctl --user -u sh.crew.autoupdate.service\` for details. On headless sessions, you may need \`loginctl enable-linger\`.${suffix}`;
+  if (!detail) return new CrewError("autoupdate_failure", message);
+  return new CrewError("autoupdate_failure", message, { stderr: detail });
+}
+
+function boundedStderr(stderr: string): string {
+  const trimmed = stderr.trim();
+  return trimmed.length > 600 ? `${trimmed.slice(0, 600)}...` : trimmed;
+}
+
+function runSystemctl(args: string[]): SystemctlResult {
+  return systemctlRunner(args);
+}

--- a/src/autoupdate/types.ts
+++ b/src/autoupdate/types.ts
@@ -1,0 +1,12 @@
+/**
+ * Shared autoupdate scheduler types (§10.2).
+ *
+ * Both platform backends consume the same enable input so the dispatcher
+ * and concrete schedulers cannot drift independently.
+ */
+
+export interface EnableInput {
+  readonly crewBinaryPath: string;
+  readonly intervalSeconds: number;
+  readonly home?: string;
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -11,6 +11,7 @@ import { CrewError } from "../core/errors.ts";
 import { crewHome } from "../core/paths.ts";
 import { maybeEmitUpdateNotice } from "../self-update/notice.ts";
 import { colorEnabled, makeStyler, type Styler, terminalWidth } from "../util/term.ts";
+import { nowIso } from "../util/time.ts";
 import { parseArgs } from "./args.ts";
 import { dispatch } from "./dispatch.ts";
 import { defaultStreams, type OutputStreams, writeError, writeSuccess } from "./output.ts";
@@ -45,11 +46,23 @@ export interface RunCliOptions {
   readonly stderrIsTty?: boolean;
 }
 
-/** Run the CLI with the given argv. Returns an exit code. */
+/**
+ * Run the CLI with the given argv. Returns an exit code.
+ */
 export function runCli(argv: readonly string[], options: RunCliOptions = {}): number {
   const streams = options.streams ?? defaultStreams;
   const cwd = options.cwd ?? process.cwd();
   const home = options.home ?? crewHome();
+  return runCliWithHome(argv, options, streams, cwd, home);
+}
+
+function runCliWithHome(
+  argv: readonly string[],
+  options: RunCliOptions,
+  streams: OutputStreams,
+  cwd: string,
+  home: string,
+): number {
   // When the caller supplied a streams override (tests, pipes), force
   // plain-text output regardless of whether the real stdout is a TTY —
   // color codes in captured buffers are almost never what you want.
@@ -105,6 +118,11 @@ export function runCli(argv: readonly string[], options: RunCliOptions = {}): nu
       );
       exitCode = 4;
     }
+  }
+  // §10.2: scheduled updates append one status line before exit. Keeping
+  // this at the CLI boundary covers both normal `update` exits and crashes.
+  if (parsed.command === "update" && process.env["CREW_AUTOUPDATE_LOG"] === "1") {
+    streams.stderr(`crew-autoupdate ${nowIso()} exit=${exitCode}\n`);
   }
 
   // §10.4 update-available notice. Runs on every command path (success

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -131,8 +131,8 @@ const REMEDIES: Partial<Record<CrewErrorName, string>> = {
     "Homecrew couldn't parse `~/.crew/config.yaml`. Fix the YAML or delete the file to get defaults back.",
   state_locked:
     "Another `crew` process is holding the lock. Wait a few seconds and try again; if it's really stuck, run `crew doctor --repair`.",
-  launchd_failure:
-    "`launchctl` couldn't load or unload the autoupdate agent. `crew autoupdate status` shows details; `crew autoupdate disable` then `crew autoupdate enable` is a safe reset.",
+  autoupdate_failure:
+    "The platform scheduler couldn't load or unload the background updater. `crew autoupdate status` shows details; `crew autoupdate disable` then `crew autoupdate enable` is a safe reset.",
   self_update_unavailable:
     "Homecrew couldn't reach the release feed, or the requested version doesn't exist. Check your network, then try `crew self-update --check`.",
   self_update_failed:

--- a/src/commands/autoupdate.ts
+++ b/src/commands/autoupdate.ts
@@ -12,7 +12,7 @@ import {
   enableAutoupdate,
   isAutoupdateLoaded,
   readAutoupdateLogTail,
-} from "../autoupdate/launchd.ts";
+} from "../autoupdate/scheduler.ts";
 import { DEFAULT_AUTOUPDATE_INTERVAL_SECONDS } from "../config/defaults.ts";
 import { readConfig, writeConfig } from "../config/load.ts";
 import { CrewError } from "../core/errors.ts";
@@ -96,6 +96,8 @@ function status(ctx: CommandContext): CommandOutput {
     json: {
       enabled: config.autoupdate.enabled,
       interval_seconds: config.autoupdate.interval_seconds,
+      scheduler_loaded: loaded,
+      // Deprecated compatibility alias for pre-Linux status consumers.
       agent_loaded: loaded,
       last_run: tail.last_run,
       last_exit_status: tail.last_exit_status,
@@ -120,7 +122,7 @@ function renderStatus(
   }
   const headline = loaded
     ? `${style.symbol("ok")} ${style.bold("Autoupdate is on")}`
-    : `${style.symbol("warn")} ${style.bold("Autoupdate is on, but the background agent isn't loaded")}`;
+    : `${style.symbol("warn")} ${style.bold("Autoupdate is on, but the background updater isn't loaded")}`;
   lines.push(headline);
   lines.push("");
   const rows: [string, string][] = [];
@@ -173,6 +175,9 @@ export function parseDuration(raw: string): number {
     );
   }
   const n = Number.parseInt(m[1]!, 10);
+  if (n === 0) {
+    throw new CrewError("usage_error", "duration must be positive", { raw });
+  }
   const unit = m[2] as "s" | "m" | "h" | "d";
   const scale = { s: 1, m: 60, h: 3600, d: 86400 }[unit];
   return n * scale;

--- a/src/commands/doctor/checks.ts
+++ b/src/commands/doctor/checks.ts
@@ -9,7 +9,7 @@
 
 import { existsSync } from "node:fs";
 import { ALL_AGENTS } from "../../agents/registry.ts";
-import { isAutoupdateLoaded } from "../../autoupdate/launchd.ts";
+import { isAutoupdateLoaded } from "../../autoupdate/scheduler.ts";
 import { paths } from "../../core/paths.ts";
 import type { Config, StateEntry } from "../../core/types.ts";
 import { hashDirectory } from "../../hash/content.ts";
@@ -160,14 +160,14 @@ export function checkAutoupdateDrift(config: Config): Finding[] {
     findings.push({
       level: "warn",
       code: "autoupdate_not_loaded",
-      message: "config says autoupdate enabled but launchd agent is not loaded",
+      message: "config says autoupdate enabled but the platform scheduler is not loaded",
     });
   }
   if (!config.autoupdate.enabled && loaded) {
     findings.push({
       level: "warn",
       code: "autoupdate_unexpectedly_loaded",
-      message: "autoupdate agent is loaded but config says disabled",
+      message: "config says autoupdate disabled but the platform scheduler is still loaded",
     });
   }
   return findings;

--- a/src/commands/doctor/render.ts
+++ b/src/commands/doctor/render.ts
@@ -18,8 +18,8 @@ const CODE_LABELS: Record<string, string> = {
   orphan_store_entry: "a cached skill is no longer referenced",
   agent_missing: "an agent in your state isn't detected anymore",
   missing_project_root: "a project folder is missing",
-  autoupdate_not_loaded: "autoupdate is enabled but the background agent isn't loaded",
-  autoupdate_unexpectedly_loaded: "autoupdate is off but the background agent is still loaded",
+  autoupdate_not_loaded: "autoupdate is enabled but the background updater isn't loaded",
+  autoupdate_unexpectedly_loaded: "autoupdate is off but the background updater is still loaded",
   config_invalid: "~/.crew/config.yaml couldn't be parsed",
 };
 

--- a/src/commands/help/content/autoupdate.ts
+++ b/src/commands/help/content/autoupdate.ts
@@ -6,7 +6,7 @@ export const autoupdateHelp: CommandHelp = {
   summary: [
     "Keep your skills up to date automatically, in the background.",
     "Turn it on and Homecrew checks for updates on a schedule — your team's new skills appear, existing ones roll forward. No more forgetting to run `crew update`.",
-    "On macOS, you'll see it in System Settings → General → Login Items as `Homecrew Skill Autoupdate`.",
+    "On macOS, Homecrew uses launchd. On Linux, it uses a systemd user timer.",
   ],
   flags: [
     {

--- a/src/commands/update/index.ts
+++ b/src/commands/update/index.ts
@@ -42,7 +42,6 @@ import { garbageCollectStore } from "../../maintenance/gc.ts";
 import { readState, upsertEntry, writeState } from "../../state/load.ts";
 import { withStateLock } from "../../state/lock.ts";
 import { resolveStateSubjects } from "../../state/subjects.ts";
-import { nowIso } from "../../util/time.ts";
 import { refreshTaps, type TapRefreshRow } from "../tap/refresh.ts";
 import type { CommandContext, CommandOutput } from "../types.ts";
 import { renderUpdate } from "./render.ts";
@@ -132,15 +131,10 @@ export function updateCommand(ctx: CommandContext): CommandOutput {
 
   const exitCode = hardFailure ? 1 : 0;
   const human = renderUpdate({ rows, tapReexpandRows, tapRows }, ctx.style);
-  const stderr =
-    process.env["CREW_AUTOUPDATE_LOG"] === "1"
-      ? [`crew-autoupdate ${nowIso()} exit=${exitCode}`]
-      : [];
 
   return {
     exitCode,
     human,
-    stderr,
     json: { rows, tap_reexpand_rows: tapReexpandRows, tap_rows: tapRows },
   };
 }

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -25,7 +25,7 @@ export type CrewErrorName =
   | "no_agents"
   | "config_invalid"
   | "state_locked"
-  | "launchd_failure"
+  | "autoupdate_failure"
   | "self_update_unavailable"
   | "self_update_failed"
   | "usage_error"
@@ -53,7 +53,7 @@ export const EXIT_CODES: Record<CrewErrorName, number> = {
   no_agents: 4,
   config_invalid: 4,
   state_locked: 7,
-  launchd_failure: 8,
+  autoupdate_failure: 8,
   self_update_unavailable: 5,
   self_update_failed: 8,
   usage_error: 4,

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -1,7 +1,7 @@
 /**
  * Homecrew's canonical filesystem layout.
  *
- * §6 lays out the directory tree crew owns under `~/.crew/`. Every path in
+ * §6 and §10.2 lay out the directories crew owns or writes. Every path in
  * that tree is produced here so we never hardcode a layout decision in two
  * places. The paths are computed relative to a configurable `home` so tests
  * can redirect crew's state dir via the `CREW_HOME` environment variable.
@@ -32,6 +32,19 @@ export function launchAgentsDir(): string {
   return join(homedir(), "Library", "LaunchAgents");
 }
 
+/**
+ * Resolve the user's systemd unit directory. Normally
+ * `~/.config/systemd/user`, but tests can redirect via
+ * `CREW_SYSTEMD_USER_DIR`.
+ */
+export function systemdUserDir(): string {
+  const override = process.env["CREW_SYSTEMD_USER_DIR"];
+  if (override && override.length > 0) {
+    return override;
+  }
+  return join(homedir(), ".config", "systemd", "user");
+}
+
 /** Every well-known path crew produces. */
 export interface CrewPaths {
   readonly home: string;
@@ -46,6 +59,9 @@ export interface CrewPaths {
   readonly autoupdateLog: string;
   readonly launchAgentsDir: string;
   readonly autoupdatePlist: string;
+  readonly systemdUserDir: string;
+  readonly autoupdateSystemdService: string;
+  readonly autoupdateSystemdTimer: string;
   readonly versionCheckFile: string;
 }
 
@@ -64,6 +80,9 @@ export function paths(home: string = crewHome()): CrewPaths {
     autoupdateLog: join(home, "logs", "autoupdate.log"),
     launchAgentsDir: launchAgentsDir(),
     autoupdatePlist: join(launchAgentsDir(), "sh.crew.autoupdate.plist"),
+    systemdUserDir: systemdUserDir(),
+    autoupdateSystemdService: join(systemdUserDir(), "sh.crew.autoupdate.service"),
+    autoupdateSystemdTimer: join(systemdUserDir(), "sh.crew.autoupdate.timer"),
     versionCheckFile: join(home, "version-check.json"),
   };
 }

--- a/src/install/flow.ts
+++ b/src/install/flow.ts
@@ -98,7 +98,6 @@ export function runInstall(config: Config, options: InstallOptions): InstallFlow
     const summary = performInstall(toInstall, agents, options.scope, cwd, currentState, {
       force: options.force,
       dryRun: true,
-      home,
       requiredBy,
       allResolved: resolvedAll,
     });
@@ -116,7 +115,6 @@ export function runInstall(config: Config, options: InstallOptions): InstallFlow
     const result = performInstall(toInstall, agents, options.scope, cwd, freshState, {
       force: options.force,
       dryRun: false,
-      home,
       requiredBy,
       allResolved: resolvedAll,
     });

--- a/src/install/perform.ts
+++ b/src/install/perform.ts
@@ -22,7 +22,6 @@
 import { type AgentAdapter, baseFor } from "../agents/adapter.ts";
 import { type InstallOutcome, installSkillIntoAgents } from "../agents/install.ts";
 import type { CrewError } from "../core/errors.ts";
-import { crewHome } from "../core/paths.ts";
 import type { ResolvedSkill, Scope, StateEntry, StateFile } from "../core/types.ts";
 import type { RequiredByMap } from "../install/resolve/index.ts";
 import { upsertEntry } from "../state/load.ts";
@@ -59,7 +58,6 @@ export function performInstall(
   options: {
     readonly force: boolean;
     readonly dryRun: boolean;
-    readonly home?: string;
     readonly requiredBy: RequiredByMap;
     /**
      * The full resolve set (including skills that were already
@@ -71,8 +69,6 @@ export function performInstall(
     readonly allResolved?: readonly ResolvedSkill[];
   },
 ): InstallSummary {
-  const home = options.home ?? crewHome();
-  void home;
   const records: InstallRecord[] = [];
   let state = startingState;
 

--- a/src/self-update/checksum.ts
+++ b/src/self-update/checksum.ts
@@ -1,15 +1,16 @@
 /**
  * Release checksum verification for binary self-update (§10.3).
  *
- * `crew self-update` verifies the downloaded macOS binary against the
+ * `crew self-update` verifies the downloaded platform binary against the
  * release's SHA256SUMS asset before making it executable or replacing
  * the running binary.
  */
 
 import { createHash } from "node:crypto";
-import { readFileSync } from "node:fs";
+import { readFileSync, rmSync } from "node:fs";
+import { dirname } from "node:path";
 import { CrewError } from "../core/errors.ts";
-import { downloadAssetToTemp } from "./download.ts";
+import { CHECKSUMS_MAX_BYTES, downloadAssetToTemp } from "./download.ts";
 
 export const CHECKSUMS_ASSET_NAME = "SHA256SUMS";
 
@@ -26,7 +27,12 @@ export function checksumAssetUrl(assets: Readonly<Record<string, string>>, tag: 
 }
 
 export function downloadChecksums(url: string, timeoutSeconds: number): string {
-  return readFileSync(downloadAssetToTemp(url, timeoutSeconds), "utf8");
+  const path = downloadAssetToTemp(url, timeoutSeconds, CHECKSUMS_MAX_BYTES);
+  try {
+    return readFileSync(path, "utf8");
+  } finally {
+    rmSync(dirname(path), { recursive: true, force: true });
+  }
 }
 
 export function verifyAssetChecksum(path: string, assetName: string, checksumsText: string): void {

--- a/src/self-update/download.ts
+++ b/src/self-update/download.ts
@@ -1,7 +1,7 @@
 /**
  * Release-asset download + binary swap (§10.3 steps 3–5).
  *
- * Downloads the right asset for the current CPU architecture to a
+ * Downloads the right asset for the current platform and CPU architecture to a
  * temp file, marks it executable, clears the macOS quarantine xattr,
  * and atomically renames it over `process.execPath`. The running
  * process keeps executing on the old inode; the new binary takes
@@ -11,25 +11,39 @@
  * the command path can stay synchronous.
  */
 
-import { chmodSync, mkdtempSync } from "node:fs";
+import { chmodSync, mkdtempSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { CrewError } from "../core/errors.ts";
 import { atomicReplace } from "../util/fs.ts";
 
-/** Asset name for the current CPU arch, or throws if unsupported. */
-export function assetNameForArch(arch: string = process.arch): string {
-  if (arch === "arm64") return "crew-macos-arm64";
-  if (arch === "x64") return "crew-macos-x64";
+export const RELEASE_ASSET_MAX_BYTES = 128 * 1024 * 1024;
+export const CHECKSUMS_MAX_BYTES = 1024 * 1024;
+export const CHECKSUM_SIGNATURE_MAX_BYTES = 64 * 1024;
+
+/** Asset name for the current platform + CPU arch, or throws if unsupported. */
+export function releaseAssetName(
+  arch: NodeJS.Architecture = process.arch,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  if (platform === "darwin" && arch === "arm64") return "crew-macos-arm64";
+  if (platform === "darwin" && arch === "x64") return "crew-macos-x64";
+  if (platform === "linux" && arch === "arm64") return "crew-linux-arm64";
+  if (platform === "linux" && arch === "x64") return "crew-linux-x64";
   throw new CrewError(
     "self_update_unavailable",
-    `no release asset for this CPU (${arch}). Homecrew ships macOS arm64 and x64 builds.`,
-    { arch },
+    `no release asset for this platform (${platform}/${arch}). Homecrew ships macOS and Linux arm64 and x64 builds.`,
+    { arch, platform },
   );
 }
 
 /** Network seam: save bytes from a URL into `destPath`. */
-export type AssetDownloader = (url: string, destPath: string, timeoutSeconds: number) => void;
+export type AssetDownloader = (
+  url: string,
+  destPath: string,
+  timeoutSeconds: number,
+  maxBytes: number,
+) => void;
 
 let downloader: AssetDownloader = defaultDownloader;
 
@@ -62,16 +76,30 @@ export function resetXattrClearer(): void {
  * Download the bytes at `url` into a new temp file and return its path.
  * Raises `self_update_unavailable` on any network failure.
  */
-export function downloadAssetToTemp(url: string, timeoutSeconds: number): string {
+export function downloadAssetToTemp(
+  url: string,
+  timeoutSeconds: number,
+  maxBytes: number = RELEASE_ASSET_MAX_BYTES,
+): string {
   const dir = mkdtempSync(join(tmpdir(), "crew-self-update-"));
   const path = join(dir, "crew");
   try {
-    downloader(url, path, timeoutSeconds);
+    downloader(url, path, timeoutSeconds, maxBytes);
   } catch (err) {
+    rmSync(dir, { recursive: true, force: true });
     throw new CrewError(
       "self_update_unavailable",
       `couldn't download release asset from ${url}: ${(err as Error).message}`,
       { url, cause: (err as Error).message },
+    );
+  }
+  const size = statSync(path).size;
+  if (size > maxBytes) {
+    rmSync(dir, { recursive: true, force: true });
+    throw new CrewError(
+      "self_update_unavailable",
+      `downloaded file from ${url} exceeded the ${maxBytes} byte limit`,
+      { url, size, maxBytes },
     );
   }
   return path;
@@ -97,13 +125,20 @@ export function installBinary(tempPath: string, dest: string): void {
   }
 }
 
-function defaultDownloader(url: string, destPath: string, timeoutSeconds: number): void {
+function defaultDownloader(
+  url: string,
+  destPath: string,
+  timeoutSeconds: number,
+  maxBytes: number,
+): void {
   const proc = Bun.spawnSync({
     cmd: [
       "curl",
       "-fsSL",
       "--max-time",
       String(timeoutSeconds),
+      "--max-filesize",
+      String(maxBytes),
       "-H",
       "User-Agent: crew-self-update",
       "-o",

--- a/src/self-update/github.ts
+++ b/src/self-update/github.ts
@@ -31,7 +31,7 @@ import { CrewError } from "../core/errors.ts";
 export interface ReleaseInfo {
   /** The version tag, e.g. "v0.4.0". */
   readonly tag: string;
-  /** Assets keyed by name (e.g. "crew-macos-arm64" → download URL). */
+  /** Assets keyed by name (e.g. "crew-linux-x64" → download URL). */
   readonly assets: Readonly<Record<string, string>>;
 }
 

--- a/src/self-update/signature.ts
+++ b/src/self-update/signature.ts
@@ -6,9 +6,10 @@
  */
 
 import { createVerify } from "node:crypto";
-import { readFileSync } from "node:fs";
+import { readFileSync, rmSync } from "node:fs";
+import { dirname } from "node:path";
 import { CrewError } from "../core/errors.ts";
-import { downloadAssetToTemp } from "./download.ts";
+import { CHECKSUM_SIGNATURE_MAX_BYTES, downloadAssetToTemp } from "./download.ts";
 import { RELEASE_SIGNING_PUBLIC_KEY } from "./signing-key.ts";
 
 export const CHECKSUMS_SIGNATURE_ASSET_NAME = "SHA256SUMS.sig";
@@ -41,7 +42,12 @@ export function checksumSignatureAssetUrl(
 }
 
 export function downloadChecksumSignature(url: string, timeoutSeconds: number): Buffer {
-  return readFileSync(downloadAssetToTemp(url, timeoutSeconds));
+  const path = downloadAssetToTemp(url, timeoutSeconds, CHECKSUM_SIGNATURE_MAX_BYTES);
+  try {
+    return readFileSync(path);
+  } finally {
+    rmSync(dirname(path), { recursive: true, force: true });
+  }
 }
 
 export function verifyChecksumsSignature(checksumsText: string, signature: Buffer): void {

--- a/src/self-update/upgrade.ts
+++ b/src/self-update/upgrade.ts
@@ -6,11 +6,13 @@
  * so the command handler can render the right human output.
  */
 
+import { dirname } from "node:path";
 import { CrewError } from "../core/errors.ts";
 import { CREW_VERSION } from "../core/version.ts";
+import { rmrf } from "../util/fs.ts";
 import { writeVersionCheck } from "./check.ts";
 import { checksumAssetUrl, downloadChecksums, verifyAssetChecksum } from "./checksum.ts";
-import { assetNameForArch, downloadAssetToTemp, installBinary } from "./download.ts";
+import { downloadAssetToTemp, installBinary, releaseAssetName } from "./download.ts";
 import { fetchRelease, releasesByTagUrl, releasesLatestUrl } from "./github.ts";
 import {
   checksumSignatureAssetUrl,
@@ -42,7 +44,7 @@ export interface SelfUpdateOptions {
 }
 
 export function runSelfUpdate(options: SelfUpdateOptions): SelfUpdateResult {
-  assertMacOS();
+  assertSupportedPlatform();
   const url = options.tag ? releasesByTagUrl(options.tag) : releasesLatestUrl();
   const release = fetchRelease(url, RELEASE_FETCH_TIMEOUT_SECONDS);
 
@@ -54,7 +56,7 @@ export function runSelfUpdate(options: SelfUpdateOptions): SelfUpdateResult {
     return { currentVersion, latestTag: release.tag, replaced: false };
   }
 
-  const assetName = assetNameForArch();
+  const assetName = releaseAssetName();
   const downloadUrl = release.assets[assetName];
   if (!downloadUrl) {
     throw new CrewError(
@@ -72,7 +74,12 @@ export function runSelfUpdate(options: SelfUpdateOptions): SelfUpdateResult {
     verifyChecksumsSignature(checksumsText, signature);
   }
   const tempPath = downloadAssetToTemp(downloadUrl, DOWNLOAD_TIMEOUT_SECONDS);
-  verifyAssetChecksum(tempPath, assetName, checksumsText);
+  try {
+    verifyAssetChecksum(tempPath, assetName, checksumsText);
+  } catch (err) {
+    rmrf(dirname(tempPath));
+    throw err;
+  }
   installBinary(tempPath, resolveDest(options.execPath));
   writeVersionCheck(release.tag, options.home);
   return { currentVersion, latestTag: release.tag, replaced: true };
@@ -100,7 +107,7 @@ export function runSelfUpdateCheck(
   home: string,
   tag?: string,
 ): { readonly currentVersion: string; readonly latestTag: string } {
-  assertMacOS();
+  assertSupportedPlatform();
   const url = tag ? releasesByTagUrl(tag) : releasesLatestUrl();
   const release = fetchRelease(url, RELEASE_FETCH_TIMEOUT_SECONDS);
   writeVersionCheck(release.tag, home);
@@ -112,11 +119,11 @@ function sameTag(a: string, b: string): boolean {
   return norm(a) === norm(b);
 }
 
-function assertMacOS(): void {
-  if (process.platform !== "darwin") {
+function assertSupportedPlatform(): void {
+  if (process.platform !== "darwin" && process.platform !== "linux") {
     throw new CrewError(
       "self_update_unavailable",
-      "Homecrew ships macOS binaries only. use your package manager or build from source on other platforms.",
+      "Homecrew ships binaries for macOS and Linux only. use your package manager or build from source on other platforms.",
       { platform: process.platform },
     );
   }

--- a/tests/autoupdate/commands.test.ts
+++ b/tests/autoupdate/commands.test.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { bundlePath } from "../../src/autoupdate/bundle.ts";
 import { resetLaunchctlRunner, setLaunchctlRunner } from "../../src/autoupdate/launchd.ts";
+import { resetAutoupdatePlatform, setAutoupdatePlatform } from "../../src/autoupdate/scheduler.ts";
 import { runCli } from "../../src/cli/main.ts";
 import { readConfig } from "../../src/config/load.ts";
 import { paths } from "../../src/core/paths.ts";
@@ -15,6 +16,7 @@ const savedLaunchAgentsDir = process.env["CREW_LAUNCH_AGENTS_DIR"];
 
 beforeEach(() => {
   process.env["CREW_LAUNCH_AGENTS_DIR"] = makeCrewHome();
+  setAutoupdatePlatform("darwin");
 });
 
 afterEach(() => {
@@ -23,6 +25,7 @@ afterEach(() => {
   } else {
     process.env["CREW_LAUNCH_AGENTS_DIR"] = savedLaunchAgentsDir;
   }
+  resetAutoupdatePlatform();
   resetLaunchctlRunner();
 });
 
@@ -122,73 +125,6 @@ describe("autoupdate commands", () => {
       streams: captureStreams().streams,
     });
     expect(readConfig(crewHome).autoupdate.interval_seconds).toBe(30);
-  });
-
-  test("status shows `Autoupdate is on` after enabling", () => {
-    const crewHome = makeCrewHome();
-    setLaunchctlRunner(() => true);
-    runCli(["autoupdate", "enable", "--interval", "30m"], {
-      home: crewHome,
-      streams: captureStreams().streams,
-    });
-    const c = captureStreams();
-    runCli(["autoupdate", "status"], { home: crewHome, streams: c.streams });
-    expect(c.stdout()).toContain("Autoupdate is on");
-    expect(c.stdout()).toContain("every 30 minutes");
-    expect(c.stdout()).toContain("not yet");
-  });
-
-  test("status when enabled but agent isn't loaded shows a warning hint", () => {
-    const crewHome = makeCrewHome();
-    setLaunchctlRunner(() => true);
-    runCli(["autoupdate", "enable"], { home: crewHome, streams: captureStreams().streams });
-    // Flip the runner to say "not loaded" for the status check.
-    setLaunchctlRunner((args) => args[0] !== "list");
-    const c = captureStreams();
-    runCli(["autoupdate", "status"], { home: crewHome, streams: c.streams });
-    expect(c.stdout()).toContain("background agent isn't loaded");
-    expect(c.stdout()).toContain("crew autoupdate disable");
-  });
-
-  test("status with --interval 1d reports `every day`", () => {
-    const crewHome = makeCrewHome();
-    setLaunchctlRunner(() => true);
-    runCli(["autoupdate", "enable", "--interval", "1d"], {
-      home: crewHome,
-      streams: captureStreams().streams,
-    });
-    const c = captureStreams();
-    runCli(["autoupdate", "status"], { home: crewHome, streams: c.streams });
-    expect(c.stdout()).toContain("every day");
-  });
-
-  test("status with --interval 2d reports `every 2 days`", () => {
-    const crewHome = makeCrewHome();
-    setLaunchctlRunner(() => true);
-    runCli(["autoupdate", "enable", "--interval", "2d"], {
-      home: crewHome,
-      streams: captureStreams().streams,
-    });
-    const c = captureStreams();
-    runCli(["autoupdate", "status"], { home: crewHome, streams: c.streams });
-    expect(c.stdout()).toContain("every 2 days");
-  });
-
-  test("status with a recent log line shows time-ago", () => {
-    const crewHome = makeCrewHome();
-    setLaunchctlRunner(() => true);
-    runCli(["autoupdate", "enable"], { home: crewHome, streams: captureStreams().streams });
-    // Inject a log line so readAutoupdateLogTail has something to surface.
-    const fs = require("node:fs") as typeof import("node:fs");
-    const { paths } =
-      require("../../src/core/paths.ts") as typeof import("../../src/core/paths.ts");
-    fs.mkdirSync(paths(crewHome).logsDir, { recursive: true });
-    const nowIso = new Date().toISOString();
-    fs.writeFileSync(paths(crewHome).autoupdateLog, `${nowIso} ran\n`);
-    const c = captureStreams();
-    runCli(["autoupdate", "status"], { home: crewHome, streams: c.streams });
-    expect(c.stdout()).toContain("Autoupdate is on");
-    expect(c.stdout()).toContain("last ran");
   });
 
   test("unknown autoupdate subcommand is a usage error pointing at help", () => {

--- a/tests/autoupdate/launchd.test.ts
+++ b/tests/autoupdate/launchd.test.ts
@@ -3,9 +3,9 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import {
   isAutoupdateLoaded,
   plistXml,
-  readAutoupdateLogTail,
   resetLaunchctlRunner,
 } from "../../src/autoupdate/launchd.ts";
+import { readAutoupdateLogTail } from "../../src/autoupdate/log.ts";
 import { parseDuration } from "../../src/commands/autoupdate.ts";
 import { CrewError } from "../../src/core/errors.ts";
 import { paths } from "../../src/core/paths.ts";
@@ -44,6 +44,7 @@ describe("parseDuration", () => {
   });
   test("rejects garbage", () => {
     expect(() => parseDuration("")).toThrow(CrewError);
+    expect(() => parseDuration("0s")).toThrow(CrewError);
     expect(() => parseDuration("5x")).toThrow(CrewError);
     expect(() => parseDuration("abc")).toThrow(CrewError);
   });

--- a/tests/autoupdate/status.test.ts
+++ b/tests/autoupdate/status.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Autoupdate status rendering and JSON contract tests (§10.2, C-AUTO).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { resetLaunchctlRunner, setLaunchctlRunner } from "../../src/autoupdate/launchd.ts";
+import { resetAutoupdatePlatform, setAutoupdatePlatform } from "../../src/autoupdate/scheduler.ts";
+import { runCli } from "../../src/cli/main.ts";
+import { paths } from "../../src/core/paths.ts";
+import { captureStreams, makeCrewHome } from "../helpers/env.ts";
+
+const savedLaunchAgentsDir = process.env["CREW_LAUNCH_AGENTS_DIR"];
+
+beforeEach(() => {
+  process.env["CREW_LAUNCH_AGENTS_DIR"] = makeCrewHome();
+  setAutoupdatePlatform("darwin");
+});
+
+afterEach(() => {
+  if (savedLaunchAgentsDir === undefined) delete process.env["CREW_LAUNCH_AGENTS_DIR"];
+  else process.env["CREW_LAUNCH_AGENTS_DIR"] = savedLaunchAgentsDir;
+  resetAutoupdatePlatform();
+  resetLaunchctlRunner();
+});
+
+describe("autoupdate status", () => {
+  test("shows loaded scheduler status after enabling", () => {
+    const home = makeCrewHome();
+    setLaunchctlRunner(() => true);
+    runCli(["autoupdate", "enable", "--interval", "30m"], {
+      home,
+      streams: captureStreams().streams,
+    });
+    const c = captureStreams();
+    runCli(["autoupdate", "status"], { home, streams: c.streams });
+    expect(c.stdout()).toContain("Autoupdate is on");
+    expect(c.stdout()).toContain("every 30 minutes");
+    expect(c.stdout()).toContain("not yet");
+  });
+
+  test("status --json reports scheduler_loaded with deprecated alias", () => {
+    const home = makeCrewHome();
+    setLaunchctlRunner(() => true);
+    runCli(["autoupdate", "enable"], { home, streams: captureStreams().streams });
+    const c = captureStreams();
+    runCli(["autoupdate", "status", "--json"], { home, streams: c.streams });
+    const parsed = JSON.parse(c.stdout()) as {
+      readonly agent_loaded: boolean;
+      readonly scheduler_loaded: boolean;
+    };
+    expect(parsed.scheduler_loaded).toBe(true);
+    expect(parsed.agent_loaded).toBe(true);
+  });
+
+  test("warns when enabled but scheduler isn't loaded", () => {
+    const home = makeCrewHome();
+    setLaunchctlRunner(() => true);
+    runCli(["autoupdate", "enable"], { home, streams: captureStreams().streams });
+    setLaunchctlRunner((args) => args[0] !== "list");
+    const c = captureStreams();
+    runCli(["autoupdate", "status"], { home, streams: c.streams });
+    expect(c.stdout()).toContain("background updater isn't loaded");
+    expect(c.stdout()).toContain("crew autoupdate disable");
+  });
+
+  test("formats day intervals and recent log lines", () => {
+    const home = makeCrewHome();
+    setLaunchctlRunner(() => true);
+    runCli(["autoupdate", "enable", "--interval", "2d"], {
+      home,
+      streams: captureStreams().streams,
+    });
+    const p = paths(home);
+    mkdirSync(p.logsDir, { recursive: true });
+    writeFileSync(p.autoupdateLog, `${new Date().toISOString()} ran\n`);
+    const c = captureStreams();
+    runCli(["autoupdate", "status"], { home, streams: c.streams });
+    expect(c.stdout()).toContain("every 2 days");
+    expect(c.stdout()).toContain("last ran");
+  });
+
+  test("formats singular day interval", () => {
+    const home = makeCrewHome();
+    setLaunchctlRunner(() => true);
+    runCli(["autoupdate", "enable", "--interval", "1d"], {
+      home,
+      streams: captureStreams().streams,
+    });
+    const c = captureStreams();
+    runCli(["autoupdate", "status"], { home, streams: c.streams });
+    expect(c.stdout()).toContain("every day");
+  });
+});

--- a/tests/autoupdate/systemd-failure.test.ts
+++ b/tests/autoupdate/systemd-failure.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Focused systemd failure rendering coverage (§10.2, C-AUTO).
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { resetAutoupdatePlatform, setAutoupdatePlatform } from "../../src/autoupdate/scheduler.ts";
+import { resetSystemctlRunner, setSystemctlRunner } from "../../src/autoupdate/systemd.ts";
+import { runCli } from "../../src/cli/main.ts";
+import { captureStreams, makeCrewHome } from "../helpers/env.ts";
+
+afterEach(() => {
+  resetAutoupdatePlatform();
+  resetSystemctlRunner();
+});
+
+describe("systemd failure rendering", () => {
+  test("empty systemctl stderr omits the stderr detail suffix", () => {
+    setAutoupdatePlatform("linux");
+    setSystemctlRunner((args) => ({
+      ok: args[0] !== "enable",
+      stderr: "",
+    }));
+    const c = captureStreams();
+    const code = runCli(["autoupdate", "enable"], {
+      home: makeCrewHome(),
+      streams: c.streams,
+    });
+    expect(code).toBe(8);
+    expect(c.stderr()).toContain("systemctl --user couldn't enable the autoupdate timer");
+    expect(c.stderr()).not.toContain("systemctl stderr:");
+  });
+
+  test("long systemctl stderr is bounded", () => {
+    setAutoupdatePlatform("linux");
+    setSystemctlRunner((args) => ({
+      ok: args[0] !== "enable",
+      stderr: "x".repeat(650),
+    }));
+    const c = captureStreams();
+    const code = runCli(["autoupdate", "enable"], {
+      home: makeCrewHome(),
+      streams: c.streams,
+    });
+    expect(code).toBe(8);
+    expect(c.stderr()).toContain(`${"x".repeat(600)}...`);
+    expect(c.stderr()).not.toContain("x".repeat(601));
+  });
+});

--- a/tests/autoupdate/systemd-runner.test.ts
+++ b/tests/autoupdate/systemd-runner.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Default systemctl runner coverage (§10.2, C-AUTO).
+ *
+ * The main systemd command tests use the runner seam; this file covers the
+ * production runner's process-boundary behavior.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  enableAutoupdate,
+  isAutoupdateLoaded,
+  resetSystemctlRunner,
+} from "../../src/autoupdate/systemd.ts";
+import { makeCrewHome } from "../helpers/env.ts";
+
+const original = Bun.spawnSync;
+const savedSystemdDir = process.env["CREW_SYSTEMD_USER_DIR"];
+type SpawnSync = typeof Bun.spawnSync;
+
+function setSpawnSync(next: SpawnSync): void {
+  (Bun as unknown as { spawnSync: SpawnSync }).spawnSync = next;
+}
+
+afterEach(() => {
+  setSpawnSync(original);
+  if (savedSystemdDir === undefined) delete process.env["CREW_SYSTEMD_USER_DIR"];
+  else process.env["CREW_SYSTEMD_USER_DIR"] = savedSystemdDir;
+  resetSystemctlRunner();
+});
+
+describe("systemd runner defaults", () => {
+  test("default runner returns true for zero exit", () => {
+    setSpawnSync(() => ({ exitCode: 0, stderr: new Uint8Array() }) as ReturnType<SpawnSync>);
+    expect(isAutoupdateLoaded()).toBe(true);
+  });
+
+  test("default runner catches missing systemctl", () => {
+    setSpawnSync(() => {
+      throw new Error("ENOENT");
+    });
+    expect(isAutoupdateLoaded()).toBe(false);
+  });
+
+  test("default runner preserves stderr on nonzero exit", () => {
+    process.env["CREW_SYSTEMD_USER_DIR"] = makeCrewHome();
+    setSpawnSync(
+      () =>
+        ({
+          exitCode: 1,
+          stderr: new TextEncoder().encode("no user bus"),
+        }) as ReturnType<SpawnSync>,
+    );
+    expect(() =>
+      enableAutoupdate({ crewBinaryPath: "/tmp/crew", intervalSeconds: 60, home: makeCrewHome() }),
+    ).toThrow(/no user bus/);
+  });
+});

--- a/tests/autoupdate/systemd-unit.test.ts
+++ b/tests/autoupdate/systemd-unit.test.ts
@@ -1,0 +1,39 @@
+/**
+ * systemd unit rendering tests (§10.2, C-AUTO).
+ *
+ * Keeps the unit-text assertions separate from command flow tests.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { serviceUnit, timerUnit } from "../../src/autoupdate/systemd.ts";
+import { CrewError } from "../../src/core/errors.ts";
+
+describe("systemd unit rendering", () => {
+  test("C-AUTO-01/02 service invokes crew update with pinned env", () => {
+    const unit = serviceUnit("/tmp/crew bin", "/tmp/crew.log", "/tmp/crew home");
+    expect(unit).toContain("Description=Homecrew Skill Autoupdate");
+    expect(unit).toContain('Environment="CREW_HOME=/tmp/crew home"');
+    expect(unit).toContain("Environment=CREW_AUTOUPDATE_LOG=1");
+    expect(unit).toContain('ExecStart="/tmp/crew bin" update --quiet');
+    expect(unit).toContain("StandardOutput=append:/tmp/crew.log");
+  });
+
+  test("systemd unit values escape specifiers and reject newlines", () => {
+    const unit = serviceUnit("/tmp/100%/crew", "/tmp/crew%.log", "/tmp/crew%home");
+    expect(unit).toContain('Environment="CREW_HOME=/tmp/crew%%home"');
+    expect(unit).toContain('ExecStart="/tmp/100%%/crew" update --quiet');
+    expect(unit).toContain('StandardOutput="append:/tmp/crew%%.log"');
+    expect(() => serviceUnit("/tmp/crew\nbad", "/tmp/crew.log", "/tmp/crew")).toThrow(CrewError);
+    expect(() => serviceUnit("/tmp/crew\rbad", "/tmp/crew.log", "/tmp/crew")).toThrow(
+      /cannot contain newlines/,
+    );
+  });
+
+  test("C-AUTO-02 timer carries the configured interval", () => {
+    const unit = timerUnit(1800);
+    expect(unit).toContain("OnBootSec=1800s");
+    expect(unit).toContain("OnUnitActiveSec=1800s");
+    expect(unit).toContain("Unit=sh.crew.autoupdate.service");
+    expect(unit).toContain("WantedBy=timers.target");
+  });
+});

--- a/tests/autoupdate/systemd.test.ts
+++ b/tests/autoupdate/systemd.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Linux systemd autoupdate coverage (§10.2, C-AUTO).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { resetAutoupdatePlatform, setAutoupdatePlatform } from "../../src/autoupdate/scheduler.ts";
+import { resetSystemctlRunner, setSystemctlRunner } from "../../src/autoupdate/systemd.ts";
+import { runCli } from "../../src/cli/main.ts";
+import { readConfig, writeConfig } from "../../src/config/load.ts";
+import { paths } from "../../src/core/paths.ts";
+import { captureStreams, makeCrewHome } from "../helpers/env.ts";
+
+const ok = { ok: true, stderr: "" };
+const failed = (stderr: string = "systemctl failed") => ({ ok: false, stderr });
+
+const savedSystemdDir = process.env["CREW_SYSTEMD_USER_DIR"];
+
+beforeEach(() => {
+  process.env["CREW_SYSTEMD_USER_DIR"] = makeCrewHome();
+  setAutoupdatePlatform("linux");
+});
+
+afterEach(() => {
+  if (savedSystemdDir === undefined) delete process.env["CREW_SYSTEMD_USER_DIR"];
+  else process.env["CREW_SYSTEMD_USER_DIR"] = savedSystemdDir;
+  resetAutoupdatePlatform();
+  resetSystemctlRunner();
+});
+
+describe("systemd autoupdate commands", () => {
+  test("C-AUTO-01/03 enable writes units and enables timer", () => {
+    const home = makeCrewHome();
+    const calls: string[][] = [];
+    setSystemctlRunner((args) => {
+      calls.push([...args]);
+      return ok;
+    });
+    const code = runCli(["autoupdate", "enable", "--interval", "30m"], {
+      home,
+      streams: captureStreams().streams,
+    });
+    expect(code).toBe(0);
+    expect(existsSync(paths(home).autoupdateSystemdService)).toBe(true);
+    expect(existsSync(paths(home).autoupdateSystemdTimer)).toBe(true);
+    expect(readConfig(home).autoupdate.interval_seconds).toBe(1800);
+    expect(calls).toContainEqual(["daemon-reload"]);
+    expect(calls).toContainEqual(["enable", "--now", "sh.crew.autoupdate.timer"]);
+  });
+
+  test("C-AUTO-04 disable removes units and reloads", () => {
+    const home = makeCrewHome();
+    const calls: string[][] = [];
+    setSystemctlRunner((args) => {
+      calls.push([...args]);
+      return ok;
+    });
+    runCli(["autoupdate", "enable"], { home, streams: captureStreams().streams });
+    calls.length = 0;
+    const code = runCli(["autoupdate", "disable"], {
+      home,
+      streams: captureStreams().streams,
+    });
+    expect(code).toBe(0);
+    expect(existsSync(paths(home).autoupdateSystemdService)).toBe(false);
+    expect(existsSync(paths(home).autoupdateSystemdTimer)).toBe(false);
+    expect(calls).toContainEqual(["disable", "--now", "sh.crew.autoupdate.timer"]);
+    expect(calls).toContainEqual(["daemon-reload"]);
+    expect(readConfig(home).autoupdate.enabled).toBe(false);
+  });
+
+  test("disable without units is a no-op", () => {
+    const home = makeCrewHome();
+    setSystemctlRunner(() => {
+      throw new Error("should not call systemctl");
+    });
+    const code = runCli(["autoupdate", "disable"], {
+      home,
+      streams: captureStreams().streams,
+    });
+    expect(code).toBe(0);
+  });
+
+  test("disable reports post-removal daemon-reload failure", () => {
+    const home = makeCrewHome();
+    setSystemctlRunner(() => ok);
+    runCli(["autoupdate", "enable"], { home, streams: captureStreams().streams });
+    setSystemctlRunner((args) => (args[0] === "daemon-reload" ? failed("reload failed") : ok));
+    const c = captureStreams();
+    const code = runCli(["autoupdate", "disable"], {
+      home,
+      streams: c.streams,
+    });
+    expect(code).toBe(8);
+    expect(c.stderr()).toContain("reload failed");
+    expect(readConfig(home).autoupdate.enabled).toBe(true);
+    expect(existsSync(paths(home).autoupdateSystemdService)).toBe(false);
+    expect(existsSync(paths(home).autoupdateSystemdTimer)).toBe(false);
+  });
+
+  test("failed disable leaves units for a retry", () => {
+    const home = makeCrewHome();
+    const calls: string[][] = [];
+    setSystemctlRunner(() => ok);
+    runCli(["autoupdate", "enable"], { home, streams: captureStreams().streams });
+    setSystemctlRunner((args) => {
+      calls.push([...args]);
+      return args[0] === "disable" && calls.length === 1 ? failed("unit busy") : ok;
+    });
+    const c = captureStreams();
+    const code = runCli(["autoupdate", "disable"], { home, streams: c.streams });
+    expect(code).toBe(8);
+    expect(c.stderr()).toContain("unit busy");
+    expect(readConfig(home).autoupdate.enabled).toBe(true);
+    expect(existsSync(paths(home).autoupdateSystemdService)).toBe(true);
+    const retry = runCli(["autoupdate", "disable"], { home, streams: captureStreams().streams });
+    expect(retry).toBe(0);
+    expect(calls.filter((a) => a[0] === "disable")).toHaveLength(2);
+    expect(existsSync(paths(home).autoupdateSystemdService)).toBe(false);
+    expect(existsSync(paths(home).autoupdateSystemdTimer)).toBe(false);
+  });
+
+  test("C-AUTO-06 enable reports autoupdate_failure when systemctl fails", () => {
+    const home = makeCrewHome();
+    setSystemctlRunner((args) => (args[0] === "enable" ? failed("permission denied") : ok));
+    const c = captureStreams();
+    const code = runCli(["autoupdate", "enable"], {
+      home,
+      streams: c.streams,
+    });
+    expect(code).toBe(8);
+    expect(c.stderr()).toContain("systemctl --user couldn't enable the autoupdate timer");
+    expect(c.stderr()).toContain("permission denied");
+    expect(readConfig(home).autoupdate.enabled).toBe(false);
+    expect(existsSync(paths(home).autoupdateSystemdService)).toBe(false);
+    expect(existsSync(paths(home).autoupdateSystemdTimer)).toBe(false);
+  });
+
+  test("failed daemon-reload also removes written unit files", () => {
+    const home = makeCrewHome();
+    setSystemctlRunner((args) => (args[0] === "daemon-reload" ? failed("no user bus") : ok));
+    const c = captureStreams();
+    const code = runCli(["autoupdate", "enable"], {
+      home,
+      streams: c.streams,
+    });
+    expect(code).toBe(8);
+    expect(c.stderr()).toContain("no user bus");
+    expect(readConfig(home).autoupdate.enabled).toBe(false);
+    expect(existsSync(paths(home).autoupdateSystemdService)).toBe(false);
+    expect(existsSync(paths(home).autoupdateSystemdTimer)).toBe(false);
+  });
+
+  test("status uses systemctl is-active", () => {
+    const home = makeCrewHome();
+    setSystemctlRunner((args) => (args[0] === "is-active" ? failed() : ok));
+    runCli(["autoupdate", "enable"], { home, streams: captureStreams().streams });
+    const c = captureStreams();
+    runCli(["autoupdate", "status"], { home, streams: c.streams });
+    expect(c.stdout()).toContain("background updater isn't loaded");
+  });
+
+  test("systemd units contain effective CREW_HOME", () => {
+    const home = makeCrewHome();
+    setSystemctlRunner(() => ok);
+    runCli(["autoupdate", "enable"], { home, streams: captureStreams().streams });
+    const service = readFileSync(paths(home).autoupdateSystemdService, "utf8");
+    expect(service).toContain(`Environment=CREW_HOME=${home}`);
+  });
+});
+
+describe("systemd platform dispatch", () => {
+  test("unsupported scheduler platform fails cleanly", () => {
+    setAutoupdatePlatform("freebsd" as NodeJS.Platform);
+    const c = captureStreams();
+    const code = runCli(["autoupdate", "enable"], {
+      home: makeCrewHome(),
+      streams: c.streams,
+    });
+    expect(code).toBe(8);
+    expect(c.stderr()).toContain("autoupdate is not supported on freebsd");
+  });
+
+  test("unsupported scheduler status reports not loaded", () => {
+    setAutoupdatePlatform("freebsd" as NodeJS.Platform);
+    const home = makeCrewHome();
+    const config = readConfig(home);
+    writeConfig({ ...config, autoupdate: { enabled: true, interval_seconds: 14400 } }, home);
+    const c = captureStreams();
+    const code = runCli(["autoupdate", "status"], {
+      home,
+      streams: c.streams,
+    });
+    expect(code).toBe(0);
+    expect(c.stdout()).toContain("background updater isn't loaded");
+  });
+});

--- a/tests/helpers/env.ts
+++ b/tests/helpers/env.ts
@@ -31,7 +31,9 @@ export function captureStreams(): { streams: OutputStreams; stdout(): string; st
 
 /** Make a fresh crew home directory. */
 export function makeCrewHome(): string {
-  return mkdtempSync(join(tmpdir(), "crew-home-"));
+  const home = mkdtempSync(join(tmpdir(), "crew-home-"));
+  activeCrewHome = home;
+  return home;
 }
 
 type AdapterMut = {
@@ -48,6 +50,7 @@ type AdapterMut = {
  * on first call.
  */
 const ADAPTER_ORIGINALS = new Map<string, AdapterMut>();
+let activeCrewHome = tmpdir();
 
 /**
  * Force every adapter NOT in the `keep` set to be undetected and point
@@ -78,8 +81,7 @@ export function neutralizeAdaptersExcept(keep: readonly string[]): void {
       });
     }
     if (keepSet.has(a.name)) continue;
-    (a as AdapterMut).userPath = () =>
-      join(process.env["CREW_HOME"] ?? tmpdir(), "inert-adapters", a.name);
+    (a as AdapterMut).userPath = () => join(activeCrewHome, "inert-adapters", a.name);
     (a as AdapterMut).projectPath = (cwd: string) => join(cwd, ".inert-adapters", a.name);
     (a as AdapterMut).detect = () => false;
   }

--- a/tests/misc/gaps.test.ts
+++ b/tests/misc/gaps.test.ts
@@ -18,6 +18,7 @@ import { geminiCliAdapter } from "../../src/agents/gemini-cli.ts";
 import { ALL_AGENTS, agentByName } from "../../src/agents/registry.ts";
 import { uninstallSkillFromAgents } from "../../src/agents/uninstall.ts";
 import { resetLaunchctlRunner, setLaunchctlRunner } from "../../src/autoupdate/launchd.ts";
+import { resetAutoupdatePlatform, setAutoupdatePlatform } from "../../src/autoupdate/scheduler.ts";
 import { runCli } from "../../src/cli/main.ts";
 import { parseDuration } from "../../src/commands/autoupdate.ts";
 import { CrewError } from "../../src/core/errors.ts";
@@ -379,24 +380,28 @@ describe("doctor warnings — orphan store", () => {
       require("../../src/config/load.ts") as typeof import("../../src/config/load.ts");
     const cfg = readConfig(home);
     writeConfig({ ...cfg, autoupdate: { enabled: true, interval_seconds: 60 } }, home);
+    setAutoupdatePlatform("darwin");
     setLaunchctlRunner(() => false); // not loaded
     try {
       const c = captureStreams();
       runCli(["doctor"], { home, streams: c.streams });
-      expect(c.stdout()).toContain("background agent isn't loaded");
+      expect(c.stdout()).toContain("background updater isn't loaded");
     } finally {
+      resetAutoupdatePlatform();
       resetLaunchctlRunner();
     }
   });
 
   test("doctor flags autoupdate unexpectedly loaded", () => {
     const home = makeCrewHome();
+    setAutoupdatePlatform("darwin");
     setLaunchctlRunner(() => true); // loaded
     try {
       const c = captureStreams();
       runCli(["doctor"], { home, streams: c.streams });
       expect(c.stdout()).toContain("still loaded");
     } finally {
+      resetAutoupdatePlatform();
       resetLaunchctlRunner();
     }
   });

--- a/tests/misc/install-script-checksum.test.ts
+++ b/tests/misc/install-script-checksum.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Installer checksum-tool fallback tests.
+ *
+ * These run the public Bash installer with an isolated fake PATH so Linux
+ * fallback behavior cannot be masked by host `shasum` or `sha256sum`.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const INSTALL_SCRIPT = "site/public/install.sh";
+
+describe("public installer checksum tools", () => {
+  test("uses sha256sum when shasum is unavailable", () => {
+    const env = installEnv("sha256sum");
+    const proc = runInstaller(env);
+    expect(proc.exitCode).toBe(0);
+    expect(readFileSync(env.checksumLog, "utf8")).toContain("sha256sum");
+  });
+
+  test("fails when neither checksum tool exists", () => {
+    const env = installEnv("none");
+    const proc = runInstaller(env);
+    expect(proc.exitCode).toBe(1);
+    expect(new TextDecoder().decode(proc.stderr)).toContain("shasum` or `sha256sum");
+    expect(readFileSync(env.curlLog, "utf8")).toBe("");
+  });
+
+  test("fails closed when signature verification fails", () => {
+    const env = installEnv("sha256sum", { opensslFails: true });
+    const proc = runInstaller(env);
+    expect(proc.exitCode).toBe(1);
+    expect(new TextDecoder().decode(proc.stderr)).toContain("signature verification failed");
+    expect(existsSync(join(env.prefix, "crew"))).toBe(false);
+  });
+
+  test("fails closed when the binary checksum mismatches", () => {
+    const env = installEnv("sha256sum", { actualSha: "def456" });
+    const proc = runInstaller(env);
+    expect(proc.exitCode).toBe(1);
+    expect(new TextDecoder().decode(proc.stderr)).toContain("checksum mismatch");
+    expect(existsSync(join(env.prefix, "crew"))).toBe(false);
+  });
+});
+
+type ChecksumTool = "sha256sum" | "none";
+
+type InstallEnv = {
+  readonly checksumLog: string;
+  readonly curlLog: string;
+  readonly env: NodeJS.ProcessEnv;
+  readonly prefix: string;
+};
+
+type InstallOptions = {
+  readonly actualSha?: string;
+  readonly opensslFails?: boolean;
+};
+
+function installEnv(tool: ChecksumTool, options: InstallOptions = {}): InstallEnv {
+  const root = mkdtempSync(join(tmpdir(), "crew-install-checksum-"));
+  const bin = join(root, "bin");
+  const prefix = join(root, "prefix");
+  writeFakeTool(bin, "uname", '#!/bin/sh\n[ "$1" = -s ] && echo Linux || echo x86_64\n');
+  writeFakeTool(bin, "curl", curlTool());
+  writeFakeTool(bin, "openssl", '#!/bin/sh\n[ "$FAKE_OPENSSL_FAIL" = 1 ] && exit 1\nexit 0\n');
+  writeCoreTools(bin);
+  if (tool === "sha256sum") writeChecksumTool(bin);
+  return {
+    checksumLog: join(root, "checksum.log"),
+    curlLog: join(root, "curl.log"),
+    prefix,
+    env: {
+      ...process.env,
+      CREW_INSTALL_PREFIX: prefix,
+      CREW_VERSION: "v9.9.9",
+      FAKE_ACTUAL_SHA: options.actualSha ?? "abc123",
+      FAKE_ASSET: "crew-linux-x64",
+      FAKE_BINARY_SHA: "abc123",
+      FAKE_CHECKSUM_LOG: join(root, "checksum.log"),
+      FAKE_CURL_LOG: join(root, "curl.log"),
+      FAKE_OPENSSL_FAIL: options.opensslFails ? "1" : "0",
+      FAKE_ROOT: root,
+      HOME: root,
+      PATH: bin,
+    },
+  };
+}
+
+function writeCoreTools(dir: string): void {
+  for (const name of ["cat", "chmod", "mkdir", "mv", "rm"]) {
+    writeFakeTool(dir, name, `#!/bin/sh\n/bin/${name} "$@"\n`);
+  }
+  writeFakeTool(
+    dir,
+    "mktemp",
+    '#!/bin/sh\n/bin/mkdir -p "$FAKE_ROOT/tmp"\nprintf \'%s\\n\' "$FAKE_ROOT/tmp"\n',
+  );
+  writeFakeTool(
+    dir,
+    "awk",
+    '#!/bin/sh\nif [ "$1" = "-v" ]; then printf \'%s\\n\' "$FAKE_BINARY_SHA"; exit 0; fi\nread first rest\nprintf \'%s\\n\' "$first"\n',
+  );
+}
+
+function writeChecksumTool(dir: string): void {
+  writeFakeTool(
+    dir,
+    "sha256sum",
+    '#!/bin/sh\nprintf \'sha256sum\\n\' >> "$FAKE_CHECKSUM_LOG"\nprintf \'%s  %s\\n\' "$FAKE_ACTUAL_SHA" "$1"\n',
+  );
+}
+
+function curlTool(): string {
+  return `#!/bin/sh
+out=""
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) out="$2"; shift 2 ;;
+    -*) shift ;;
+    *) url="$1"; shift ;;
+  esac
+done
+printf '%s\\n' "$url" >> "$FAKE_CURL_LOG"
+case "$url" in
+  */SHA256SUMS) printf '%s  %s\\n' "$FAKE_BINARY_SHA" "$FAKE_ASSET" > "$out" ;;
+  */SHA256SUMS.sig) printf 'sig' > "$out" ;;
+  *) printf '%s\\n' '#!/bin/sh' 'exit 0' > "$out" ;;
+esac
+`;
+}
+
+function writeFakeTool(dir: string, name: string, body: string): void {
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, name);
+  writeFileSync(path, body);
+  chmodSync(path, 0o755);
+}
+
+function runInstaller(input: InstallEnv): ReturnType<typeof Bun.spawnSync> {
+  writeFileSync(input.checksumLog, "");
+  writeFileSync(input.curlLog, "");
+  return Bun.spawnSync({
+    cmd: ["/bin/bash", INSTALL_SCRIPT],
+    env: input.env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}

--- a/tests/misc/install-script.test.ts
+++ b/tests/misc/install-script.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Installer script smoke tests.
+ *
+ * The public install path is a site artifact rather than TypeScript runtime,
+ * so these tests pin the advertised shell and syntax-check the Bash script.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const INSTALL_SCRIPT = "site/public/install.sh";
+const INSTALL_COMMAND = "curl -fsSL https://crew.logic.inc/install.sh | bash";
+
+describe("public installer", () => {
+  test("advertised command uses the Bash shell the installer requires", () => {
+    const readme = readFileSync("README.md", "utf8");
+    const site = readFileSync("site/components/sections/Install.tsx", "utf8");
+    const script = readFileSync(INSTALL_SCRIPT, "utf8");
+    expect(readme).toContain(INSTALL_COMMAND);
+    expect(site).toContain(INSTALL_COMMAND);
+    expect(script).toContain(INSTALL_COMMAND);
+    expect(readme).not.toContain("install.sh | sh");
+    expect(site).not.toContain("install.sh | sh");
+    expect(script).not.toContain("install.sh | sh");
+  });
+
+  test("installer parses under Bash", () => {
+    const proc = Bun.spawnSync({
+      cmd: ["bash", "-n", INSTALL_SCRIPT],
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(proc.exitCode).toBe(0);
+  });
+
+  test.each([
+    ["Darwin", "arm64", "crew-macos-arm64"],
+    ["Linux", "x86_64", "crew-linux-x64"],
+    ["Linux", "aarch64", "crew-linux-arm64"],
+  ])("installer downloads %s/%s asset", (os, arch, asset) => {
+    const env = installEnv(os, arch, asset);
+    const proc = runInstaller(env);
+    expect(proc.exitCode).toBe(0);
+    expect(existsSync(join(env.prefix, "crew"))).toBe(true);
+    expect(readFileSync(env.curlLog, "utf8")).toContain(
+      `https://github.com/with-logic/crew/releases/download/v9.9.9/${asset}`,
+    );
+  });
+
+  test("installer rejects unsupported platforms before downloading", () => {
+    const env = installEnv("FreeBSD", "x86_64", "unused");
+    const proc = runInstaller(env);
+    expect(proc.exitCode).toBe(1);
+    expect(new TextDecoder().decode(proc.stderr)).toContain("unsupported platform: FreeBSD/x86_64");
+    expect(readFileSync(env.curlLog, "utf8")).toBe("");
+  });
+});
+
+type InstallEnv = {
+  readonly curlLog: string;
+  readonly env: NodeJS.ProcessEnv;
+  readonly prefix: string;
+};
+
+function installEnv(os: string, arch: string, asset: string): InstallEnv {
+  const root = mkdtempSync(join(tmpdir(), "crew-install-script-"));
+  const bin = join(root, "bin");
+  const prefix = join(root, "prefix");
+  mkdirSync(bin);
+  writeFakeTool(
+    bin,
+    "uname",
+    `#!/bin/sh
+case "$1" in
+  -s) printf '%s\\n' "$FAKE_OS" ;;
+  -m) printf '%s\\n' "$FAKE_ARCH" ;;
+  *) exit 1 ;;
+esac
+`,
+  );
+  writeFakeTool(bin, "openssl", "#!/bin/sh\nexit 0\n");
+  writeFakeTool(bin, "shasum", '#!/bin/sh\nprintf \'%s  %s\\n\' "$FAKE_BINARY_SHA" "$3"\n');
+  writeFakeTool(
+    bin,
+    "curl",
+    `#!/bin/sh
+out=""
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) out="$2"; shift 2 ;;
+    -w) shift 2 ;;
+    -*) shift ;;
+    *) url="$1"; shift ;;
+  esac
+done
+printf '%s\\n' "$url" >> "$FAKE_CURL_LOG"
+case "$url" in
+  */latest) printf 'https://github.com/with-logic/crew/releases/tag/v9.9.9' ;;
+  */SHA256SUMS) printf '%s  %s\\n' "$FAKE_BINARY_SHA" "$FAKE_ASSET" > "$out" ;;
+  */SHA256SUMS.sig) printf 'sig' > "$out" ;;
+  *) printf '%s\\n' '#!/usr/bin/env sh' 'case "$1" in' '  version) echo "crew v9.9.9" ;;' '  update) exit 0 ;;' '  *) exit 0 ;;' 'esac' > "$out" ;;
+esac
+`,
+  );
+  return {
+    curlLog: join(root, "curl.log"),
+    prefix,
+    env: {
+      ...process.env,
+      CREW_INSTALL_PREFIX: prefix,
+      CREW_VERSION: "v9.9.9",
+      FAKE_ARCH: arch,
+      FAKE_ASSET: asset,
+      FAKE_BINARY_SHA: "abc123",
+      FAKE_CURL_LOG: join(root, "curl.log"),
+      FAKE_OS: os,
+      HOME: root,
+      PATH: `${bin}:/usr/bin:/bin`,
+    },
+  };
+}
+
+function writeFakeTool(dir: string, name: string, body: string): void {
+  const path = join(dir, name);
+  writeFileSync(path, body);
+  chmodSync(path, 0o755);
+}
+
+function runInstaller(input: InstallEnv): ReturnType<typeof Bun.spawnSync> {
+  writeFileSync(input.curlLog, "");
+  return Bun.spawnSync({
+    cmd: ["/bin/bash", INSTALL_SCRIPT],
+    env: input.env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}

--- a/tests/misc/run-cli-home.test.ts
+++ b/tests/misc/run-cli-home.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Regression tests for `runCli({ home })` path threading.
+ *
+ * Programmatic callers should be able to pass a home override without
+ * mutating global process env or depending on ambient CREW_HOME.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { runCli } from "../../src/cli/main.ts";
+import { captureStreams, makeCrewHome } from "../helpers/env.ts";
+import { makeSkill, makeTempDir, skillFrontmatter } from "../helpers/fixtures.ts";
+
+describe("runCli home path threading", () => {
+  test("explicit home overrides ambient CREW_HOME for adapter paths", () => {
+    const prev = process.env["CREW_HOME"];
+    const polluted = makeTempDir("crew-polluted-home-");
+    const home = makeCrewHome();
+    const src = makeTempDir("crew-env-home-src-");
+    makeSkill(src, "env-demo", skillFrontmatter({ name: "env-demo" }));
+    mkdirSync(join(polluted, "inert-adapters", "claude-code", "env-demo"), {
+      recursive: true,
+    });
+    try {
+      process.env["CREW_HOME"] = polluted;
+      const code = runCli(["install", join(src, "env-demo")], {
+        home,
+        streams: captureStreams().streams,
+      });
+      expect(code).toBe(0);
+      expect(process.env["CREW_HOME"]).toBe(polluted);
+      expect(existsSync(join(home, "inert-adapters", "claude-code", "env-demo"))).toBe(true);
+      expect(existsSync(join(polluted, "inert-adapters", "claude-code", "env-demo"))).toBe(true);
+    } finally {
+      if (prev === undefined) {
+        delete process.env["CREW_HOME"];
+      } else {
+        process.env["CREW_HOME"] = prev;
+      }
+    }
+  });
+
+  test("explicit home does not create CREW_HOME when it was absent", () => {
+    const prev = process.env["CREW_HOME"];
+    try {
+      delete process.env["CREW_HOME"];
+      const code = runCli(["version"], {
+        home: makeCrewHome(),
+        streams: captureStreams().streams,
+      });
+      expect(code).toBe(0);
+      expect(process.env["CREW_HOME"]).toBeUndefined();
+    } finally {
+      if (prev !== undefined) {
+        process.env["CREW_HOME"] = prev;
+      }
+    }
+  });
+});

--- a/tests/misc/update-edges.test.ts
+++ b/tests/misc/update-edges.test.ts
@@ -20,6 +20,7 @@ import { join } from "node:path";
 import { claudeCodeAdapter } from "../../src/agents/claude-code.ts";
 import { codexAdapter } from "../../src/agents/codex.ts";
 import { geminiCliAdapter } from "../../src/agents/gemini-cli.ts";
+import { COMMAND_HANDLERS, type CommandHandler } from "../../src/cli/dispatch.ts";
 import { runCli } from "../../src/cli/main.ts";
 import { readConfig, writeConfig } from "../../src/config/load.ts";
 import { readState } from "../../src/state/load.ts";
@@ -128,5 +129,21 @@ describe("update edge cases", () => {
     expect(code).toBe(0);
     expect(c.stdout()).toBe("");
     expect(c.stderr()).toMatch(/^crew-autoupdate \S+ exit=0\n$/);
+  });
+
+  test("autoupdate log mode records unexpected update crashes", () => {
+    const savedEnv = process.env["CREW_AUTOUPDATE_LOG"];
+    const savedHandler = COMMAND_HANDLERS["update"] as CommandHandler;
+    process.env["CREW_AUTOUPDATE_LOG"] = "1";
+    COMMAND_HANDLERS["update"] = () => {
+      throw new Error("boom");
+    };
+    const c = captureStreams();
+    const code = runCli(["update", "--quiet"], { home: makeCrewHome(), streams: c.streams });
+    COMMAND_HANDLERS["update"] = savedHandler;
+    if (savedEnv === undefined) delete process.env["CREW_AUTOUPDATE_LOG"];
+    else process.env["CREW_AUTOUPDATE_LOG"] = savedEnv;
+    expect(code).toBe(4);
+    expect(c.stderr()).toMatch(/crew-autoupdate \S+ exit=4\n$/);
   });
 });

--- a/tests/self-update/command.test.ts
+++ b/tests/self-update/command.test.ts
@@ -30,9 +30,7 @@ import {
 import { captureStreams, makeCrewHome } from "../helpers/env.ts";
 import { currentAssetName, downloaderForBinary, releaseAssets } from "./helpers.ts";
 
-// Force darwin for the happy-path tests — `runSelfUpdate`'s platform
-// guard rejects non-macOS hosts. Without this override every test in
-// this file would fail on a Linux CI runner.
+// Force darwin for deterministic asset names in the happy-path tests.
 const originalPlatform = process.platform;
 // Also clear the notice-suppression env vars so that on a CI runner
 // (where `CI` is set) the post-command update notice still fires —

--- a/tests/self-update/defaults.test.ts
+++ b/tests/self-update/defaults.test.ts
@@ -99,12 +99,14 @@ describe("defaultDownloader (download.ts)", () => {
       const cmd = (args as unknown as { cmd: string[] }).cmd;
       const outIdx = cmd.indexOf("-o");
       const outPath = cmd[outIdx + 1]!;
-      require("node:fs").writeFileSync(outPath, "downloaded-bytes");
+      const sizeIdx = cmd.indexOf("--max-filesize");
+      expect(cmd[sizeIdx + 1]).toBe("9");
+      require("node:fs").writeFileSync(outPath, "bytes");
       return result(0);
     });
-    const p = downloadAssetToTemp("https://example.com/asset", 5);
+    const p = downloadAssetToTemp("https://example.com/asset", 5, 9);
     expect(existsSync(p)).toBe(true);
-    expect(readFileSync(p, "utf8")).toBe("downloaded-bytes");
+    expect(readFileSync(p, "utf8")).toBe("bytes");
     void home;
   });
 

--- a/tests/self-update/download.test.ts
+++ b/tests/self-update/download.test.ts
@@ -10,11 +10,11 @@
 
 import { afterEach, describe, expect, test } from "bun:test";
 import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import {
-  assetNameForArch,
   downloadAssetToTemp,
   installBinary,
+  releaseAssetName,
   resetAssetDownloader,
   resetXattrClearer,
   setAssetDownloader,
@@ -27,17 +27,24 @@ afterEach(() => {
   resetXattrClearer();
 });
 
-describe("assetNameForArch", () => {
+describe("releaseAssetName", () => {
   test("arm64 → crew-macos-arm64", () => {
-    expect(assetNameForArch("arm64")).toBe("crew-macos-arm64");
+    expect(releaseAssetName("arm64", "darwin")).toBe("crew-macos-arm64");
   });
 
   test("x64 → crew-macos-x64", () => {
-    expect(assetNameForArch("x64")).toBe("crew-macos-x64");
+    expect(releaseAssetName("x64", "darwin")).toBe("crew-macos-x64");
+  });
+
+  test("linux assets include platform in the name", () => {
+    expect(releaseAssetName("arm64", "linux")).toBe("crew-linux-arm64");
+    expect(releaseAssetName("x64", "linux")).toBe("crew-linux-x64");
   });
 
   test("throws self_update_unavailable for unknown arches", () => {
-    expect(() => assetNameForArch("riscv64")).toThrow(/no release asset for this CPU \(riscv64\)/);
+    expect(() => releaseAssetName("riscv64" as NodeJS.Architecture, "linux")).toThrow(
+      /no release asset for this platform \(linux\/riscv64\)/,
+    );
   });
 });
 
@@ -52,10 +59,25 @@ describe("downloadAssetToTemp", () => {
   });
 
   test("wraps downloader failures as self_update_unavailable", () => {
-    setAssetDownloader(() => {
+    let tempPath = "";
+    setAssetDownloader((_url, destPath) => {
+      tempPath = destPath;
       throw new Error("network down");
     });
     expect(() => downloadAssetToTemp("https://example.com/crew", 5)).toThrow(/network down/);
+    expect(existsSync(dirname(tempPath))).toBe(false);
+  });
+
+  test("rejects downloads larger than the requested byte cap", () => {
+    let tempPath = "";
+    setAssetDownloader((_url, destPath) => {
+      tempPath = destPath;
+      writeFileSync(destPath, "too-large");
+    });
+    expect(() => downloadAssetToTemp("https://example.com/crew", 5, 3)).toThrow(
+      /exceeded the 3 byte limit/,
+    );
+    expect(existsSync(dirname(tempPath))).toBe(false);
   });
 });
 

--- a/tests/self-update/helpers.ts
+++ b/tests/self-update/helpers.ts
@@ -4,14 +4,14 @@
 
 import { createHash } from "node:crypto";
 import { writeFileSync } from "node:fs";
-import { type AssetDownloader, assetNameForArch } from "../../src/self-update/download.ts";
+import { type AssetDownloader, releaseAssetName } from "../../src/self-update/download.ts";
 
 export const ASSET_URL = "https://example.com/asset";
 export const CHECKSUMS_URL = "https://example.com/SHA256SUMS";
 export const CHECKSUMS_SIGNATURE_URL = "https://example.com/SHA256SUMS.sig";
 
 export function currentAssetName(): string {
-  return assetNameForArch();
+  return releaseAssetName();
 }
 
 export function sha256Hex(bytes: string): string {

--- a/tests/self-update/upgrade.test.ts
+++ b/tests/self-update/upgrade.test.ts
@@ -9,7 +9,7 @@
 
 import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { paths } from "../../src/core/paths.ts";
 import { CREW_VERSION } from "../../src/core/version.ts";
 import { readVersionCheck } from "../../src/self-update/check.ts";
@@ -35,11 +35,9 @@ import {
   releaseAssets,
 } from "./helpers.ts";
 
-// Force `process.platform === "darwin"` for the duration of this file.
-// `runSelfUpdate`'s platform guard rejects non-macOS hosts (§10.3), so
-// every happy-path test here would fail on a Linux CI runner without
-// this override. The dedicated "platform guard" test below still
-// flips it back to "linux" for that one case.
+// Force `process.platform === "darwin"` for deterministic asset names.
+// The dedicated "platform guard" test below flips to an unsupported
+// platform for that one case.
 const originalPlatform = process.platform;
 beforeAll(() => {
   Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
@@ -49,6 +47,7 @@ afterAll(() => {
 });
 
 afterEach(() => {
+  Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
   resetReleaseFetcher();
   resetAssetDownloader();
   resetXattrClearer();
@@ -77,6 +76,25 @@ describe("runSelfUpdate", () => {
     const record = readVersionCheck(home);
     expect(record?.latest_tag).toBe("v99.99.99");
     expect(existsSync(paths(home).versionCheckFile)).toBe(true);
+  });
+
+  test("downloads the Linux release asset on Linux hosts", () => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    const home = makeCrewHome();
+    const dest = join(home, "crew-bin");
+    writeFileSync(dest, "OLD");
+
+    setReleaseFetcher(() => ({
+      tag: "v99.99.99",
+      assets: releaseAssets(),
+    }));
+    setAssetDownloader(downloaderForBinary("LINUX"));
+    setReleaseSignatureVerifier(() => true);
+    setXattrClearer(() => {});
+
+    const result = runSelfUpdate({ home, force: false, execPath: dest });
+    expect(result.replaced).toBe(true);
+    expect(readFileSync(dest, "utf8")).toBe("LINUX");
   });
 
   test("no-op when already on latest, but still refreshes version-check", () => {
@@ -189,7 +207,9 @@ describe("runSelfUpdate", () => {
     writeFileSync(dest, "OLD");
 
     setReleaseFetcher(() => ({ tag: "v99.99.99", assets: releaseAssets() }));
+    let assetPath = "";
     setAssetDownloader((url, destPath) => {
+      if (url.endsWith("/asset")) assetPath = destPath;
       const body =
         url === CHECKSUMS_URL || url === CHECKSUMS_SIGNATURE_URL
           ? checksumTextFor("EXPECTED")
@@ -202,6 +222,7 @@ describe("runSelfUpdate", () => {
       /checksum mismatch/,
     );
     expect(readFileSync(dest, "utf8")).toBe("OLD");
+    expect(existsSync(dirname(assetPath))).toBe(false);
   });
 
   test("accepts an explicit tag", () => {
@@ -246,11 +267,11 @@ describe("runSelfUpdateCheck", () => {
 });
 
 describe("platform guard", () => {
-  test("non-darwin raises self_update_unavailable before touching the network", () => {
+  test("unsupported platforms raise self_update_unavailable before touching the network", () => {
     // Inside this file, `beforeAll` has stamped platform = "darwin".
-    // Flip to linux for this test alone and restore to darwin after,
+    // Flip to freebsd for this test alone and restore to darwin after,
     // keeping the file-level invariant intact for any later tests.
-    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    Object.defineProperty(process, "platform", { value: "freebsd", configurable: true });
     let fetcherCalled = false;
     setReleaseFetcher(() => {
       fetcherCalled = true;
@@ -258,7 +279,7 @@ describe("platform guard", () => {
     });
     try {
       expect(() => runSelfUpdateCheck(makeCrewHome())).toThrow(
-        /Homecrew ships macOS binaries only/,
+        /Homecrew ships binaries for macOS and Linux only/,
       );
       expect(fetcherCalled).toBe(false);
     } finally {


### PR DESCRIPTION
## Summary

Homecrew can now run as a first-class Linux install: release assets, the public installer, self-update, and autoupdate all understand Linux arm64/x64 alongside macOS. Linux autoupdate uses a systemd user timer behind the same platform-neutral scheduler contract that launchd uses on macOS, so status, doctor, logging, and error handling stay consistent across platforms.

The public surface has been brought along with the behavior: the PRD, README, install script, release workflows, and website now describe Linux support and the new platform scheduler model. The site also includes the presentation refresh and grid background work already on this branch.

## Design Notes

| Area | What changed |
|---|---|
| Linux autoupdate | Adds a systemd user backend, shared scheduler dispatch, shared autoupdate log parsing, and platform-neutral `autoupdate_failure` handling. |
| Release/install | Builds and publishes Linux binaries, teaches the installer to select Linux assets, and supports `sha256sum` when `shasum` is unavailable. |
| Self-update | Selects Linux assets, verifies signed checksums before swapping binaries, caps downloaded asset sizes, and cleans failed temp downloads. |
| Status/doctor | Reports scheduler state instead of macOS-only agent state, while keeping `agent_loaded` as a deprecated JSON alias for compatibility. |
| Site/docs | Updates user-facing Linux copy and refreshes the site visual system, including the interactive grid background. |

## Test Plan

- `bun run check`
- 985 tests passed, 0 failed
- 100% line/function coverage

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)

Closes #79
