### PR TITLE
[LOG-5092] Release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.10.0] — 2026-06-15
+
+### Added
+- Linux is now a supported platform. Homecrew ships Linux x64 and ARM64 release assets, installs through the hosted installer, performs signed self-updates, and runs background autoupdates through systemd user timers.
+
+### Changed
+- The website now presents Homecrew as a macOS and Linux tool and uses the refreshed visual system from the public site update.
+
 ## [0.9.0] — 2026-05-26
 
 ### Added
@@ -134,4 +142,3 @@
 All notable changes to crew are documented in this file. The format
 is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and crew adheres to [Semantic Versioning](https://semver.org/).
-

--- a/PRD.md
+++ b/PRD.md
@@ -2,7 +2,7 @@
 
 **A package manager for Agent Skills.**
 
-Version: 0.9.0
+Version: 0.10.0
 Status: Specification, ready for implementation
 Platform: macOS (Apple Silicon and Intel), Linux (x86_64 and ARM64)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crew",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "A package manager for Agent Skills",
   "author": "Logic App, Inc.",
   "license": "MIT",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -191,20 +191,21 @@ fi
 
 # Claude reports logical failures (auth, budget, refusal) as a
 # top-level `{ "is_error": true, "result": "..." }` envelope and still
-# exits 0. Surface the `result` text instead of letting the downstream
-# jq fail with a cryptic parse error.
-if [ "$(echo "$response" | jq -r 'if type == "object" then (.is_error // false) else false end')" = "true" ]; then
+# exits 0. Some Claude CLI versions wrap the result envelope in an
+# event array, so normalize to the final envelope before inspecting it.
+envelope="$(echo "$response" | jq -c 'if type == "array" then .[-1] else . end')"
+if [ "$(echo "$envelope" | jq -r 'if type == "object" then (.is_error // false) else false end')" = "true" ]; then
   echo "error: claude reported an error:" >&2
-  echo "  $(echo "$response" | jq -r '.result // "(no result field)"')" >&2
+  echo "  $(echo "$envelope" | jq -r '.result // "(no result field)"')" >&2
   exit 1
 fi
 
 # With `--json-schema` and `--output-format json`, claude returns a
-# single result envelope and parks the schema-conforming object at
-# top-level `.structured_output`. (Earlier versions of this script
-# walked a stream-json event log — that shape never matched under
-# --output-format json and produced a cryptic jq error.)
-inner="$(echo "$response" | jq -c '.structured_output')"
+# result envelope and parks the schema-conforming object at top-level
+# `.structured_output`. (Earlier versions of this script walked a
+# stream-json event log — that shape never matched under --output-format
+# json and produced a cryptic jq error.)
+inner="$(echo "$envelope" | jq -c '.structured_output')"
 if [ -z "$inner" ] || [ "$inner" = "null" ]; then
   echo "error: claude response missing structured output" >&2
   echo "--- raw response ---" >&2

--- a/site/public/latest-version.json
+++ b/site/public/latest-version.json
@@ -1,29 +1,29 @@
 {
-  "tag_name": "v0.9.0",
+  "tag_name": "v0.10.0",
   "assets": [
     {
       "name": "crew-macos-arm64",
-      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.9.0/crew-macos-arm64"
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.10.0/crew-macos-arm64"
     },
     {
       "name": "crew-macos-x64",
-      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.9.0/crew-macos-x64"
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.10.0/crew-macos-x64"
     },
     {
       "name": "crew-linux-arm64",
-      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.9.0/crew-linux-arm64"
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.10.0/crew-linux-arm64"
     },
     {
       "name": "crew-linux-x64",
-      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.9.0/crew-linux-x64"
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.10.0/crew-linux-x64"
     },
     {
       "name": "SHA256SUMS",
-      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.9.0/SHA256SUMS"
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.10.0/SHA256SUMS"
     },
     {
       "name": "SHA256SUMS.sig",
-      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.9.0/SHA256SUMS.sig"
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.10.0/SHA256SUMS.sig"
     }
   ]
 }

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -5,5 +5,5 @@
  * without touching anything else. The value written to the `installed_by`
  * marker field and printed by `crew version` is derived from here.
  */
-export const CREW_VERSION = "0.9.0";
+export const CREW_VERSION = "0.10.0";
 export const CREW_INSTALLED_BY = `crew/${CREW_VERSION}`;


### PR DESCRIPTION
## Summary

Release v0.10.0 publishes the Linux support work merged since v0.9.0. Homecrew now has Linux x64 and ARM64 release assets, Linux installer/self-update support, and systemd user timers for background autoupdates.

## Changed

- Add Linux as a supported Homecrew platform alongside macOS.
- Point the hosted latest-version metadata at the v0.10.0 release assets for macOS, Linux, and signed checksums.
- Bump package, implementation, and PRD versions to 0.10.0.
- Add the v0.10.0 changelog entry.
- Fix `scripts/release.sh` to handle Claude CLI JSON output when the result envelope is wrapped in an event array.

## Verification

- `bun run known-taps build && bun run known-taps check`
- `bun run check` (985 tests, 100% line/function coverage)
- `bash -n scripts/release.sh`
- Sampled the release helper jq parser against both direct-object and array-wrapped Claude responses.
