### PR TITLE
[LOG-5116] ci: allow Dependabot Claude reviews

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -53,6 +53,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_bots: dependabot[bot]
           prompt: ${{ steps.read-prompt.outputs.prompt }}
           path_to_bun_executable: ~/.bun/bin/bun
           track_progress: 'true'


### PR DESCRIPTION
## Summary

Allow Dependabot PRs to run the Claude PR review workflow by adding `dependabot[bot]` to the Claude action's `allowed_bots` input.

This keeps the permission narrow instead of allowing all bot actors.

## Verification

- `bun run lint`
