### PR TITLE
[LOG-5228] Release v0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.10.1] — 2026-07-03
+
+### Changed
+- Hardened GitHub Actions workflows with least-privilege default tokens, and Claude's mention handling no longer checks out PR-head code from privileged comment/review events, closing outstanding CodeQL alerts around workflow permissions and untrusted checkout.
+- Dependabot-authored PRs can now go through the same automated Claude review as other PRs.
+- Routine dependency maintenance: `js-yaml` (4→5), `@biomejs/biome` (2.4.15→2.5.1), `actions/checkout` (6→7), and `@types/node` in the site package.
+
+### Fixed
+- Preserved empty YAML document handling after the `js-yaml` upgrade, so empty config/frontmatter parses continue to normalize to `null`.
+
 ## [0.10.0] — 2026-06-15
 
 ### Added

--- a/PRD.md
+++ b/PRD.md
@@ -2,7 +2,7 @@
 
 **A package manager for Agent Skills.**
 
-Version: 0.10.0
+Version: 0.10.1
 Status: Specification, ready for implementation
 Platform: macOS (Apple Silicon and Intel), Linux (x86_64 and ARM64)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crew",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "A package manager for Agent Skills",
   "author": "Logic App, Inc.",
   "license": "MIT",

--- a/site/public/latest-version.json
+++ b/site/public/latest-version.json
@@ -1,29 +1,29 @@
 {
-  "tag_name": "v0.10.0",
+  "tag_name": "v0.10.1",
   "assets": [
     {
       "name": "crew-macos-arm64",
-      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.10.0/crew-macos-arm64"
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.10.1/crew-macos-arm64"
     },
     {
       "name": "crew-macos-x64",
-      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.10.0/crew-macos-x64"
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.10.1/crew-macos-x64"
     },
     {
       "name": "crew-linux-arm64",
-      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.10.0/crew-linux-arm64"
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.10.1/crew-linux-arm64"
     },
     {
       "name": "crew-linux-x64",
-      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.10.0/crew-linux-x64"
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.10.1/crew-linux-x64"
     },
     {
       "name": "SHA256SUMS",
-      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.10.0/SHA256SUMS"
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.10.1/SHA256SUMS"
     },
     {
       "name": "SHA256SUMS.sig",
-      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.10.0/SHA256SUMS.sig"
+      "browser_download_url": "https://github.com/with-logic/crew/releases/download/v0.10.1/SHA256SUMS.sig"
     }
   ]
 }

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -5,5 +5,5 @@
  * without touching anything else. The value written to the `installed_by`
  * marker field and printed by `crew version` is derived from here.
  */
-export const CREW_VERSION = "0.10.0";
+export const CREW_VERSION = "0.10.1";
 export const CREW_INSTALLED_BY = `crew/${CREW_VERSION}`;

--- a/src/yaml/parse.ts
+++ b/src/yaml/parse.ts
@@ -11,7 +11,7 @@
  *   - one import site to update if we ever want to swap the library.
  */
 
-import { dump, load, YAMLException } from "js-yaml";
+import { dump, load } from "js-yaml";
 
 /** The value kinds we accept. */
 export type YamlValue = string | number | boolean | null | YamlValue[] | YamlMap;
@@ -22,18 +22,8 @@ export function parseYaml(source: string): YamlValue {
   // `load` already rejects multi-document input (use `loadAll` for that) and
   // uses the DEFAULT_SCHEMA, which is safe (no !!js/function,
   // no !!js/regexp, no !!js/undefined).
-  let value: unknown;
-  try {
-    value = load(source);
-  } catch (err) {
-    if (
-      err instanceof YAMLException &&
-      err.reason === "expected a document, but the input is empty"
-    ) {
-      return null;
-    }
-    throw err;
-  }
+  if (source.trim() === "") return null;
+  const value = load(source);
   return value as YamlValue;
 }
 


### PR DESCRIPTION
This is a maintenance release following v0.10.0’s Linux support launch. It ships security hardening, dependency hygiene, and a compatibility fix for the js-yaml upgrade.

## Changed
- **CI hardening:** GitHub Actions workflows now run with least-privilege default tokens, and Claude’s mention-handling workflow no longer checks out PR-head code from privileged comment/review events. This closes the open CodeQL alerts for missing workflow permissions and untrusted checkout in a privileged context.
- Dependabot PRs can now be reviewed by the same automated Claude review used on other PRs.
- Bumped `js-yaml` (4→5), `@biomejs/biome` (2.4.15→2.5.1) in both the CLI and site packages, `actions/checkout` (6→7), and `@types/node` in the site package.

## Fixed
- Preserved empty YAML document handling after the `js-yaml` upgrade, so empty config/frontmatter parses continue to normalize to `null`.