### PR TITLE
[LOG-5260] Regenerate bun.lock automatically on dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-bun-lock.yml
+++ b/.github/workflows/dependabot-bun-lock.yml
@@ -1,0 +1,51 @@
+name: Dependabot — regenerate bun.lock
+
+# Dependabot only manages package.json; it has no knowledge of bun.lock.
+# This workflow runs on every dependabot PR, regenerates any stale lockfiles,
+# and commits them back so that `bun install --frozen-lockfile` passes in CI.
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  update-lockfile:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Check out the PR head branch (not the merge ref) so we can push back.
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Regenerate root bun.lock
+        run: bun install
+
+      - name: Regenerate site/bun.lock
+        run: bun install
+        working-directory: site
+
+      - name: Commit lockfiles if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add bun.lock site/bun.lock
+          if git diff --cached --quiet; then
+            echo "Lockfiles already up to date."
+          else
+            git commit -m "chore: regenerate bun.lock for dependabot bump [skip ci]"
+            git push
+          fi

--- a/.github/workflows/dependabot-bun-lock.yml
+++ b/.github/workflows/dependabot-bun-lock.yml
@@ -12,14 +12,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: write
-
 jobs:
   update-lockfile:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
## Problem

Dependabot bumps `package.json` but has no knowledge of `bun.lock`. Every npm dependabot PR was failing `bun install --frozen-lockfile` in CI with:

```
error: lockfile had changes, but lockfile is frozen
```

We hit this on PRs #94 and #95 (Biome 2.5.1 → 2.5.2) and had to manually regenerate and push lockfiles to unblock them.

## Fix

New workflow `.github/workflows/dependabot-bun-lock.yml` that:
- Triggers only on PRs where `github.actor == 'dependabot[bot]'`
- Checks out the PR head branch (not the merge ref) so it can push back
- Runs `bun install` at root and in `site/`
- Commits any lockfile changes with `[skip ci]` to avoid triggering a second workflow run
- No-ops if the lockfiles are already current

## Notes

- Needs `contents: write` permission to push back to the dependabot branch — scoped to this job only, and dependabot branches are throwaway
- `[skip ci]` on the lockfile commit prevents an infinite loop (the commit itself isn't a PR open/reopen event, but belt-and-suspenders)
- Works for both root and site lockfiles regardless of which `package.json` dependabot touched

## Test plan
- [ ] Merge this, then let the next dependabot PR arrive — lockfile commit should appear automatically and CI should go green without manual intervention