### PR TITLE
[LOG-5275] ci: switch dependabot ecosystem from npm to bun

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,17 +2,20 @@
 #
 # Weekly cadence keeps PRs manageable on a small repo. Three ecosystems:
 #
-#   1. npm at the repo root — the crew CLI's deps (typescript, biome,
-#      bun types, etc.). Bun reads npm packages via the same registry.
-#   2. npm in `site/` — the Next.js landing site.
+#   1. bun at the repo root — the crew CLI's deps (typescript, biome,
+#      bun types, etc.). Native bun ecosystem support (GA Feb 2025)
+#      keeps bun.lock in sync alongside package.json automatically.
+#   2. bun in `site/` — the Next.js landing site (also uses bun.lock).
 #   3. github-actions — the workflows under `.github/workflows/`.
 #
-# Security advisories on any of these come in via Dependabot security
-# updates (enabled separately on the repo) regardless of this schedule.
+# Note: Dependabot security updates are not yet supported for the bun
+# ecosystem (version-updates only). Security advisories for npm packages
+# in the bun registry will not generate automatic security PRs until
+# that support ships.
 
 version: 2
 updates:
-  - package-ecosystem: "npm"
+  - package-ecosystem: "bun"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -20,7 +23,7 @@ updates:
     commit-message:
       prefix: "deps"
 
-  - package-ecosystem: "npm"
+  - package-ecosystem: "bun"
     directory: "/site"
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,10 @@
 #   2. bun in `site/` — the Next.js landing site (also uses bun.lock).
 #   3. github-actions — the workflows under `.github/workflows/`.
 #
-# Note: Dependabot security updates are not yet supported for the bun
-# ecosystem (version-updates only). Security advisories for npm packages
-# in the bun registry will not generate automatic security PRs until
-# that support ships.
+# Note: Dependabot does not yet generate security-update PRs for the bun
+# ecosystem (version-updates only). Repo-level security alerts still
+# surface advisories on the dashboard; only the automatic security-update
+# PRs won't fire until bun security-update support ships.
 
 version: 2
 updates:


### PR DESCRIPTION
## Problem

`.github/dependabot.yml` declared `package-ecosystem: "npm"` for both the root and `/site`. Dependabot was bumping `package.json` but never touching `bun.lock` — it didn't know the repo uses Bun. This caused `bun install --frozen-lockfile` to fail in CI on every dependabot PR. We hit this on #94 and #95 and had to manually push lockfile updates.

## Fix

Switch `package-ecosystem` from `"npm"` to `"bun"` for both entries. Native Dependabot Bun support has been GA since Feb 13, 2025 — it regenerates `bun.lock` alongside `package.json` automatically, treating the lockfile as a first-class artifact.

This fixes the root cause. A previous PR (#96) added a CI workflow to regenerate the lockfile on the fly; that approach treated the symptom and has been closed in favour of this.

## Known gap

The `bun` ecosystem currently supports **version-updates only**. Dependabot security-update PRs for bun packages are not yet generated automatically (that support is on the Dependabot roadmap). For now, security advisories that previously surfaced via the `npm` ecosystem will not auto-PR. This is noted in a comment in `dependabot.yml` so the next person to read the file understands the tradeoff.

## Verification

The next dependabot version-update PR should include changes to both `package.json` and `bun.lock`, and `bun install --frozen-lockfile` in CI should pass without any manual intervention.