### PR TITLE
[LOG-5295] ci: stop [skip ci] suppressing required checks on dependabot lockfile regen

### DIFF
--- a/.github/workflows/dependabot-bun-lock.yml
+++ b/.github/workflows/dependabot-bun-lock.yml
@@ -45,6 +45,6 @@ jobs:
           if git diff --cached --quiet; then
             echo "Lockfiles already up to date."
           else
-            git commit -m "chore: regenerate bun.lock for dependabot bump [skip ci]"
+            git commit -m "chore: regenerate bun.lock for dependabot bump"
             git push
           fi


### PR DESCRIPTION
Dependabot only manages \`package.json\`, so a companion workflow regenerates \`bun.lock\`. That regen commit carried \`[skip ci]\`, which suppresses **all** workflows for the commit — including the branch-protection required checks (\`check\`, \`site-check\`). So the required checks never re-ran against the fixed lockfile and Dependabot PRs sat BLOCKED even once the lockfile was correct.

Fix: drop \`[skip ci]\` from the regen commit message so CI runs on the regenerated head and the required checks report green there.

No loop risk: commits pushed with \`GITHUB_TOKEN\` do not trigger new workflow runs, and the job is already gated on \`github.actor == 'dependabot[bot]'\`.